### PR TITLE
feat(recipes): add typed recipe query helpers

### DIFF
--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -1,1 +1,39 @@
 export { RecipesPage } from "./components/RecipesPage";
+export {
+  createRecipe,
+  deleteRecipe,
+  getRecipeDetail,
+  listRecipes,
+  RecipeDataAccessError,
+  type RecipeDataAccessErrorCode,
+} from "./queries/recipeApi";
+export {
+  isRecipeMutationAuthError,
+  RecipeMutationAuthError,
+  requireRecipeMutationAuth,
+  type RecipeMutationAuthErrorCode,
+} from "./queries/recipeAuth";
+export { recipeMutationKeys, recipeQueryKeys } from "./queries/recipeKeys";
+export {
+  createRecipeMutationOptions,
+  deleteRecipeMutationOptions,
+} from "./queries/recipeMutationOptions";
+export {
+  preloadRecipeDetail,
+  preloadRecipeList,
+  recipeDetailQueryOptions,
+  recipeListQueryOptions,
+} from "./queries/recipeQueryOptions";
+export type {
+  CreateRecipeEquipmentInput,
+  CreateRecipeIngredientInput,
+  CreateRecipeInput,
+  CreateRecipeStepInput,
+  DeleteRecipeInput,
+  DeleteRecipeResult,
+  RecipeDetail,
+  RecipeEquipment,
+  RecipeIngredient,
+  RecipeListItem,
+  RecipeStep,
+} from "./types/recipes";

--- a/src/features/recipes/queries/recipeAdapters.ts
+++ b/src/features/recipes/queries/recipeAdapters.ts
@@ -1,0 +1,182 @@
+import type { Database } from "@/types/supabase";
+
+import type {
+  CreateRecipeEquipmentInput,
+  CreateRecipeIngredientInput,
+  CreateRecipeInput,
+  CreateRecipeStepInput,
+  RecipeDetail,
+  RecipeEquipment,
+  RecipeIngredient,
+  RecipeListItem,
+  RecipeStep,
+} from "../types/recipes";
+
+type RecipeRow = Database["public"]["Tables"]["recipes"]["Row"];
+type RecipeInsert = Database["public"]["Tables"]["recipes"]["Insert"];
+type RecipeIngredientInsert =
+  Database["public"]["Tables"]["recipe_ingredients"]["Insert"];
+type RecipeIngredientRow = Database["public"]["Tables"]["recipe_ingredients"]["Row"];
+type RecipeEquipmentInsert =
+  Database["public"]["Tables"]["recipe_equipment"]["Insert"];
+type RecipeEquipmentRow = Database["public"]["Tables"]["recipe_equipment"]["Row"];
+type RecipeStepInsert = Database["public"]["Tables"]["recipe_steps"]["Insert"];
+type RecipeStepRow = Database["public"]["Tables"]["recipe_steps"]["Row"];
+
+export type RecipeListRecord = RecipeRow;
+
+export type RecipeDetailRecord = RecipeRow & {
+  recipe_equipment: RecipeEquipmentRow[] | null;
+  recipe_ingredients: RecipeIngredientRow[] | null;
+  recipe_steps: RecipeStepRow[] | null;
+};
+
+export function buildRecipeInsert(input: CreateRecipeInput): RecipeInsert {
+  return {
+    cook_minutes: input.cookMinutes ?? null,
+    cover_image_path: normalizeOptionalText(input.coverImagePath),
+    description: normalizeRecipeBodyText(input.description),
+    is_scalable: input.isScalable ?? true,
+    prep_minutes: input.prepMinutes ?? null,
+    summary: normalizeRecipeBodyText(input.summary),
+    title: input.title.trim(),
+    yield_quantity: input.yieldQuantity ?? null,
+    yield_unit: normalizeOptionalText(input.yieldUnit),
+  };
+}
+
+export function buildRecipeEquipmentInsertRows(
+  recipeId: string,
+  equipment: CreateRecipeEquipmentInput[] | undefined,
+): RecipeEquipmentInsert[] {
+  return (equipment ?? []).map((item, index) => ({
+    details: normalizeOptionalText(item.details),
+    is_optional: item.isOptional ?? false,
+    name: item.name.trim(),
+    position: index + 1,
+    recipe_id: recipeId,
+  }));
+}
+
+export function buildRecipeIngredientInsertRows(
+  recipeId: string,
+  ingredients: CreateRecipeIngredientInput[] | undefined,
+): RecipeIngredientInsert[] {
+  return (ingredients ?? []).map((ingredient, index) => ({
+    amount: ingredient.amount ?? null,
+    is_optional: ingredient.isOptional ?? false,
+    item: ingredient.item.trim(),
+    notes: normalizeOptionalText(ingredient.notes),
+    position: index + 1,
+    preparation: normalizeOptionalText(ingredient.preparation),
+    recipe_id: recipeId,
+    unit: normalizeOptionalText(ingredient.unit),
+  }));
+}
+
+export function buildRecipeStepInsertRows(
+  recipeId: string,
+  steps: CreateRecipeStepInput[] | undefined,
+): RecipeStepInsert[] {
+  return (steps ?? []).map((step, index) => ({
+    instruction: step.instruction.trim(),
+    notes: normalizeOptionalText(step.notes),
+    position: index + 1,
+    recipe_id: recipeId,
+    timer_seconds: step.timerSeconds ?? null,
+  }));
+}
+
+export function mapRecipeDetailRecord(record: RecipeDetailRecord): RecipeDetail {
+  return {
+    ...mapRecipeListRecord(record),
+    equipment: sortByPosition(record.recipe_equipment ?? []).map(
+      mapRecipeEquipmentRow,
+    ),
+    ingredients: sortByPosition(record.recipe_ingredients ?? []).map(
+      mapRecipeIngredientRow,
+    ),
+    steps: sortByPosition(record.recipe_steps ?? []).map(mapRecipeStepRow),
+  };
+}
+
+export function mapRecipeListRecord(record: RecipeListRecord): RecipeListItem {
+  return {
+    cookMinutes: record.cook_minutes,
+    coverImagePath: record.cover_image_path,
+    createdAt: record.created_at,
+    description: record.description,
+    id: record.id,
+    isScalable: record.is_scalable,
+    ownerId: record.owner_id,
+    prepMinutes: record.prep_minutes,
+    summary: record.summary,
+    title: record.title,
+    totalMinutes: getTotalMinutes(record.prep_minutes, record.cook_minutes),
+    updatedAt: record.updated_at,
+    yieldQuantity: record.yield_quantity,
+    yieldUnit: record.yield_unit,
+  };
+}
+
+function getTotalMinutes(
+  prepMinutes: number | null,
+  cookMinutes: number | null,
+): number | null {
+  if (prepMinutes === null && cookMinutes === null) {
+    return null;
+  }
+
+  return (prepMinutes ?? 0) + (cookMinutes ?? 0);
+}
+
+function mapRecipeEquipmentRow(row: RecipeEquipmentRow): RecipeEquipment {
+  return {
+    details: row.details,
+    id: row.id,
+    isOptional: row.is_optional,
+    name: row.name,
+    position: row.position,
+  };
+}
+
+function mapRecipeIngredientRow(row: RecipeIngredientRow): RecipeIngredient {
+  return {
+    amount: row.amount,
+    id: row.id,
+    isOptional: row.is_optional,
+    item: row.item,
+    notes: row.notes,
+    position: row.position,
+    preparation: row.preparation,
+    unit: row.unit,
+  };
+}
+
+function mapRecipeStepRow(row: RecipeStepRow): RecipeStep {
+  return {
+    id: row.id,
+    instruction: row.instruction,
+    notes: row.notes,
+    position: row.position,
+    timerSeconds: row.timer_seconds,
+  };
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const normalizedValue = value.trim();
+
+  return normalizedValue === "" ? null : normalizedValue;
+}
+
+function normalizeRecipeBodyText(value: string | null | undefined): string {
+  return normalizeOptionalText(value) ?? "";
+}
+
+function sortByPosition<T extends { position: number }>(items: T[]): T[] {
+  return [...items].sort((left, right) => left.position - right.position);
+}

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -1,0 +1,253 @@
+import { supabase } from "@/lib/supabase";
+
+import {
+  buildRecipeEquipmentInsertRows,
+  buildRecipeIngredientInsertRows,
+  buildRecipeInsert,
+  buildRecipeStepInsertRows,
+  mapRecipeDetailRecord,
+  mapRecipeListRecord,
+  type RecipeDetailRecord,
+  type RecipeListRecord,
+} from "./recipeAdapters";
+import { requireRecipeMutationAuth } from "./recipeAuth";
+
+import type {
+  CreateRecipeInput,
+  DeleteRecipeInput,
+  DeleteRecipeResult,
+  RecipeDetail,
+  RecipeListItem,
+} from "../types/recipes";
+
+type RecipeApiClient = NonNullable<typeof supabase>;
+
+type CreatedRecipeRecord = {
+  id: string;
+};
+
+export type RecipeDataAccessErrorCode = "not-found" | "supabase-unconfigured";
+
+export class RecipeDataAccessError extends Error {
+  readonly code: RecipeDataAccessErrorCode;
+
+  constructor(
+    code: RecipeDataAccessErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.code = code;
+    this.name = "RecipeDataAccessError";
+  }
+}
+
+const recipeListSelect = `
+  id,
+  owner_id,
+  title,
+  summary,
+  description,
+  yield_quantity,
+  yield_unit,
+  is_scalable,
+  prep_minutes,
+  cook_minutes,
+  cover_image_path,
+  created_at,
+  updated_at
+`;
+
+const recipeDetailSelect = `
+  id,
+  owner_id,
+  title,
+  summary,
+  description,
+  yield_quantity,
+  yield_unit,
+  is_scalable,
+  prep_minutes,
+  cook_minutes,
+  cover_image_path,
+  created_at,
+  updated_at,
+  recipe_ingredients (
+    id,
+    position,
+    item,
+    amount,
+    unit,
+    preparation,
+    notes,
+    is_optional
+  ),
+  recipe_equipment (
+    id,
+    position,
+    name,
+    details,
+    is_optional
+  ),
+  recipe_steps (
+    id,
+    position,
+    instruction,
+    notes,
+    timer_seconds
+  )
+`;
+
+export async function createRecipe(
+  input: CreateRecipeInput,
+  client: RecipeApiClient | null = supabase,
+): Promise<RecipeDetail> {
+  const recipeClient = await requireRecipeMutationAuth(client);
+  let createdRecipeId: string | null = null;
+
+  try {
+    const { data, error } = await recipeClient
+      .from("recipes")
+      .insert(buildRecipeInsert(input))
+      .select("id")
+      .single()
+      .overrideTypes<CreatedRecipeRecord, { merge: false }>();
+
+    if (error !== null) {
+      throw error;
+    }
+
+    createdRecipeId = data.id;
+
+    await insertRecipeRelations(recipeClient, createdRecipeId, input);
+
+    return getRecipeDetail(createdRecipeId, recipeClient);
+  } catch (error) {
+    if (createdRecipeId !== null) {
+      await recipeClient.from("recipes").delete().eq("id", createdRecipeId);
+    }
+
+    throw error;
+  }
+}
+
+export async function deleteRecipe(
+  input: DeleteRecipeInput,
+  client: RecipeApiClient | null = supabase,
+): Promise<DeleteRecipeResult> {
+  const recipeClient = await requireRecipeMutationAuth(client);
+  const recipeId = input.recipeId.trim();
+  const { data, error } = await recipeClient
+    .from("recipes")
+    .delete()
+    .eq("id", recipeId)
+    .select("id")
+    .maybeSingle()
+    .overrideTypes<CreatedRecipeRecord, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data === null) {
+    throw new RecipeDataAccessError(
+      "not-found",
+      `Recipe ${recipeId} was not found or could not be deleted.`,
+    );
+  }
+
+  return {
+    recipeId: data.id,
+  };
+}
+
+export async function getRecipeDetail(
+  recipeId: string,
+  client: RecipeApiClient | null = supabase,
+): Promise<RecipeDetail> {
+  const recipeClient = getRecipeApiClient(client);
+  const { data, error } = await recipeClient
+    .from("recipes")
+    .select(recipeDetailSelect)
+    .eq("id", recipeId)
+    .maybeSingle()
+    .overrideTypes<RecipeDetailRecord, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data === null) {
+    throw new RecipeDataAccessError(
+      "not-found",
+      `Recipe ${recipeId} was not found.`,
+    );
+  }
+
+  return mapRecipeDetailRecord(data);
+}
+
+export async function listRecipes(
+  client: RecipeApiClient | null = supabase,
+): Promise<RecipeListItem[]> {
+  const recipeClient = getRecipeApiClient(client);
+  const { data, error } = await recipeClient
+    .from("recipes")
+    .select(recipeListSelect)
+    .order("created_at", { ascending: false })
+    .overrideTypes<RecipeListRecord[], { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return (data ?? []).map(mapRecipeListRecord);
+}
+
+function getRecipeApiClient(client: RecipeApiClient | null): RecipeApiClient {
+  if (client === null) {
+    throw new RecipeDataAccessError(
+      "supabase-unconfigured",
+      "Supabase is not configured for recipe data access.",
+    );
+  }
+
+  return client;
+}
+
+async function insertRecipeRelations(
+  client: RecipeApiClient,
+  recipeId: string,
+  input: CreateRecipeInput,
+): Promise<void> {
+  const ingredientRows = buildRecipeIngredientInsertRows(
+    recipeId,
+    input.ingredients,
+  );
+  const equipmentRows = buildRecipeEquipmentInsertRows(recipeId, input.equipment);
+  const stepRows = buildRecipeStepInsertRows(recipeId, input.steps);
+
+  if (ingredientRows.length > 0) {
+    const { error } = await client.from("recipe_ingredients").insert(ingredientRows);
+
+    if (error !== null) {
+      throw error;
+    }
+  }
+
+  if (equipmentRows.length > 0) {
+    const { error } = await client.from("recipe_equipment").insert(equipmentRows);
+
+    if (error !== null) {
+      throw error;
+    }
+  }
+
+  if (stepRows.length > 0) {
+    const { error } = await client.from("recipe_steps").insert(stepRows);
+
+    if (error !== null) {
+      throw error;
+    }
+  }
+}

--- a/src/features/recipes/queries/recipeAuth.ts
+++ b/src/features/recipes/queries/recipeAuth.ts
@@ -1,0 +1,69 @@
+export type RecipeMutationAuthErrorCode =
+  | "authentication-required"
+  | "session-expired"
+  | "supabase-unconfigured";
+
+export class RecipeMutationAuthError extends Error {
+  readonly code: RecipeMutationAuthErrorCode;
+
+  constructor(
+    code: RecipeMutationAuthErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.code = code;
+    this.name = "RecipeMutationAuthError";
+  }
+}
+
+export type RecipeAuthCapableClient = {
+  auth: {
+    getUser: () => Promise<{
+      data: {
+        user: {
+          id: string;
+        } | null;
+      };
+      error: {
+        message: string;
+      } | null;
+    }>;
+  };
+};
+
+export function isRecipeMutationAuthError(
+  error: unknown,
+): error is RecipeMutationAuthError {
+  return error instanceof RecipeMutationAuthError;
+}
+
+export async function requireRecipeMutationAuth<
+  TClient extends RecipeAuthCapableClient,
+>(client: TClient | null): Promise<TClient> {
+  if (client === null) {
+    throw new RecipeMutationAuthError(
+      "supabase-unconfigured",
+      "Supabase is not configured for recipe ownership actions.",
+    );
+  }
+
+  const { data, error } = await client.auth.getUser();
+
+  if (error !== null) {
+    throw new RecipeMutationAuthError(
+      "session-expired",
+      "Your session has expired. Sign in again to manage recipes.",
+      { cause: error },
+    );
+  }
+
+  if (data.user === null) {
+    throw new RecipeMutationAuthError(
+      "authentication-required",
+      "You need to sign in before creating or deleting recipes.",
+    );
+  }
+
+  return client;
+}

--- a/src/features/recipes/queries/recipeData.test.ts
+++ b/src/features/recipes/queries/recipeData.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildRecipeIngredientInsertRows,
+  buildRecipeStepInsertRows,
+  mapRecipeDetailRecord,
+} from "./recipeAdapters";
+import {
+  requireRecipeMutationAuth,
+} from "./recipeAuth";
+
+describe("mapRecipeDetailRecord", () => {
+  it("sorts nested relations and computes total minutes", () => {
+    const recipe = mapRecipeDetailRecord({
+      cook_minutes: 18,
+      cover_image_path: null,
+      created_at: "2026-03-26T10:00:00.000Z",
+      description: "Bring everything together.",
+      id: "recipe-1",
+      is_scalable: true,
+      owner_id: "owner-1",
+      prep_minutes: 12,
+      recipe_equipment: [
+        {
+          created_at: "2026-03-26T10:00:00.000Z",
+          details: null,
+          id: "equipment-2",
+          is_optional: false,
+          name: "Mixing bowl",
+          position: 2,
+          recipe_id: "recipe-1",
+          updated_at: "2026-03-26T10:00:00.000Z",
+        },
+        {
+          created_at: "2026-03-26T10:00:00.000Z",
+          details: "for finishing",
+          id: "equipment-1",
+          is_optional: true,
+          name: "Microplane",
+          position: 1,
+          recipe_id: "recipe-1",
+          updated_at: "2026-03-26T10:00:00.000Z",
+        },
+      ],
+      recipe_ingredients: [
+        {
+          amount: 2,
+          created_at: "2026-03-26T10:00:00.000Z",
+          id: "ingredient-2",
+          is_optional: true,
+          item: "Lemon zest",
+          notes: null,
+          position: 2,
+          preparation: null,
+          recipe_id: "recipe-1",
+          unit: "teaspoons",
+          updated_at: "2026-03-26T10:00:00.000Z",
+        },
+        {
+          amount: 500,
+          created_at: "2026-03-26T10:00:00.000Z",
+          id: "ingredient-1",
+          is_optional: false,
+          item: "Pasta",
+          notes: null,
+          position: 1,
+          preparation: null,
+          recipe_id: "recipe-1",
+          unit: "grams",
+          updated_at: "2026-03-26T10:00:00.000Z",
+        },
+      ],
+      recipe_steps: [
+        {
+          created_at: "2026-03-26T10:00:00.000Z",
+          id: "step-2",
+          instruction: "Finish with lemon zest.",
+          notes: null,
+          position: 2,
+          recipe_id: "recipe-1",
+          timer_seconds: null,
+          updated_at: "2026-03-26T10:00:00.000Z",
+        },
+        {
+          created_at: "2026-03-26T10:00:00.000Z",
+          id: "step-1",
+          instruction: "Boil the pasta.",
+          notes: "Salt the water well.",
+          position: 1,
+          recipe_id: "recipe-1",
+          timer_seconds: 600,
+          updated_at: "2026-03-26T10:00:00.000Z",
+        },
+      ],
+      summary: "Fast weeknight dinner",
+      title: "Lemon Pasta",
+      updated_at: "2026-03-26T10:15:00.000Z",
+      yield_quantity: 4,
+      yield_unit: "servings",
+    });
+
+    expect(recipe.totalMinutes).toBe(30);
+    expect(recipe.ingredients.map((item) => item.position)).toEqual([1, 2]);
+    expect(recipe.equipment.map((item) => item.position)).toEqual([1, 2]);
+    expect(recipe.steps.map((item) => item.position)).toEqual([1, 2]);
+  });
+});
+
+describe("recipe insert builders", () => {
+  it("normalizes blank optional fields and derives stable positions", () => {
+    const ingredients = buildRecipeIngredientInsertRows("recipe-1", [
+      {
+        amount: null,
+        isOptional: true,
+        item: " Lemon zest ",
+        notes: " ",
+        preparation: " finely grated ",
+        unit: " ",
+      },
+    ]);
+    const steps = buildRecipeStepInsertRows("recipe-1", [
+      {
+        instruction: " Toast the spices ",
+        notes: " ",
+        timerSeconds: 90,
+      },
+    ]);
+
+    expect(ingredients).toEqual([
+      {
+        amount: null,
+        is_optional: true,
+        item: "Lemon zest",
+        notes: null,
+        position: 1,
+        preparation: "finely grated",
+        recipe_id: "recipe-1",
+        unit: null,
+      },
+    ]);
+    expect(steps).toEqual([
+      {
+        instruction: "Toast the spices",
+        notes: null,
+        position: 1,
+        recipe_id: "recipe-1",
+        timer_seconds: 90,
+      },
+    ]);
+  });
+});
+
+describe("requireRecipeMutationAuth", () => {
+  it("returns the client when a signed-in user is available", async () => {
+    const getUser = vi.fn().mockResolvedValue({
+      data: {
+        user: {
+          id: "owner-1",
+        },
+      },
+      error: null,
+    });
+    const client = {
+      auth: {
+        getUser,
+      },
+    };
+
+    const authenticatedClient = await requireRecipeMutationAuth(client);
+
+    expect(authenticatedClient).toBe(client);
+    expect(getUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clean auth error when no user is present", async () => {
+    const client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: null,
+          },
+          error: null,
+        }),
+      },
+    };
+
+    await expect(requireRecipeMutationAuth(client)).rejects.toMatchObject({
+      code: "authentication-required",
+      name: "RecipeMutationAuthError",
+    });
+  });
+
+  it("maps Supabase auth failures to a session-expired error", async () => {
+    const client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: null,
+          },
+          error: {
+            message: "JWT expired",
+          },
+        }),
+      },
+    };
+
+    await expect(requireRecipeMutationAuth(client)).rejects.toEqual(
+      expect.objectContaining({
+        code: "session-expired",
+      }),
+    );
+  });
+});

--- a/src/features/recipes/queries/recipeKeys.ts
+++ b/src/features/recipes/queries/recipeKeys.ts
@@ -1,0 +1,12 @@
+export const recipeQueryKeys = {
+  all: ["recipes"] as const,
+  detail: (recipeId: string) => [...recipeQueryKeys.details(), recipeId] as const,
+  details: () => [...recipeQueryKeys.all, "detail"] as const,
+  list: () => [...recipeQueryKeys.lists(), "public"] as const,
+  lists: () => [...recipeQueryKeys.all, "list"] as const,
+};
+
+export const recipeMutationKeys = {
+  create: () => [...recipeQueryKeys.all, "create"] as const,
+  delete: () => [...recipeQueryKeys.all, "delete"] as const,
+};

--- a/src/features/recipes/queries/recipeMutationOptions.ts
+++ b/src/features/recipes/queries/recipeMutationOptions.ts
@@ -1,0 +1,45 @@
+import { mutationOptions } from "@tanstack/react-query";
+
+import { createRecipe, deleteRecipe } from "./recipeApi";
+import { recipeMutationKeys, recipeQueryKeys } from "./recipeKeys";
+
+import type {
+  CreateRecipeInput,
+  DeleteRecipeInput,
+  DeleteRecipeResult,
+  RecipeDetail,
+} from "../types/recipes";
+import type { QueryClient } from "@tanstack/react-query";
+
+type CreateRecipeMutationOptions = ReturnType<
+  typeof mutationOptions<RecipeDetail, Error, CreateRecipeInput>
+>;
+type DeleteRecipeMutationOptions = ReturnType<
+  typeof mutationOptions<DeleteRecipeResult, Error, DeleteRecipeInput>
+>;
+
+export function createRecipeMutationOptions(
+  queryClient: QueryClient,
+): CreateRecipeMutationOptions {
+  return mutationOptions<RecipeDetail, Error, CreateRecipeInput>({
+    mutationFn: (input): Promise<RecipeDetail> => createRecipe(input),
+    mutationKey: recipeMutationKeys.create(),
+    onSuccess: async (recipe): Promise<void> => {
+      queryClient.setQueryData(recipeQueryKeys.detail(recipe.id), recipe);
+      await queryClient.invalidateQueries({ queryKey: recipeQueryKeys.lists() });
+    },
+  });
+}
+
+export function deleteRecipeMutationOptions(
+  queryClient: QueryClient,
+): DeleteRecipeMutationOptions {
+  return mutationOptions<DeleteRecipeResult, Error, DeleteRecipeInput>({
+    mutationFn: (input): Promise<DeleteRecipeResult> => deleteRecipe(input),
+    mutationKey: recipeMutationKeys.delete(),
+    onSuccess: async ({ recipeId }): Promise<void> => {
+      queryClient.removeQueries({ queryKey: recipeQueryKeys.detail(recipeId) });
+      await queryClient.invalidateQueries({ queryKey: recipeQueryKeys.lists() });
+    },
+  });
+}

--- a/src/features/recipes/queries/recipeQueryOptions.ts
+++ b/src/features/recipes/queries/recipeQueryOptions.ts
@@ -1,0 +1,55 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getRecipeDetail, listRecipes } from "./recipeApi";
+import { recipeQueryKeys } from "./recipeKeys";
+
+import type { RecipeDetail, RecipeListItem } from "../types/recipes";
+import type { QueryClient } from "@tanstack/react-query";
+
+type RecipeDetailQueryOptions = ReturnType<
+  typeof queryOptions<
+    RecipeDetail,
+    Error,
+    RecipeDetail,
+    ReturnType<typeof recipeQueryKeys.detail>
+  >
+>;
+type RecipeListQueryOptions = ReturnType<
+  typeof queryOptions<
+    RecipeListItem[],
+    Error,
+    RecipeListItem[],
+    ReturnType<typeof recipeQueryKeys.list>
+  >
+>;
+
+export function recipeDetailQueryOptions(
+  recipeId: string,
+): RecipeDetailQueryOptions {
+  return queryOptions({
+    queryFn: (): Promise<RecipeDetail> => getRecipeDetail(recipeId),
+    queryKey: recipeQueryKeys.detail(recipeId),
+    staleTime: 30_000,
+  });
+}
+
+export function recipeListQueryOptions(): RecipeListQueryOptions {
+  return queryOptions({
+    queryFn: (): Promise<RecipeListItem[]> => listRecipes(),
+    queryKey: recipeQueryKeys.list(),
+    staleTime: 30_000,
+  });
+}
+
+export async function preloadRecipeDetail(
+  queryClient: QueryClient,
+  recipeId: string,
+): Promise<void> {
+  await queryClient.ensureQueryData(recipeDetailQueryOptions(recipeId));
+}
+
+export async function preloadRecipeList(
+  queryClient: QueryClient,
+): Promise<void> {
+  await queryClient.ensureQueryData(recipeListQueryOptions());
+}

--- a/src/features/recipes/types/recipes.ts
+++ b/src/features/recipes/types/recipes.ts
@@ -1,0 +1,93 @@
+export type RecipeListItem = {
+  cookMinutes: number | null;
+  coverImagePath: string | null;
+  createdAt: string;
+  description: string;
+  id: string;
+  isScalable: boolean;
+  ownerId: string;
+  prepMinutes: number | null;
+  summary: string;
+  title: string;
+  totalMinutes: number | null;
+  updatedAt: string;
+  yieldQuantity: number | null;
+  yieldUnit: string | null;
+};
+
+export type RecipeIngredient = {
+  amount: number | null;
+  id: string;
+  isOptional: boolean;
+  item: string;
+  notes: string | null;
+  position: number;
+  preparation: string | null;
+  unit: string | null;
+};
+
+export type RecipeEquipment = {
+  details: string | null;
+  id: string;
+  isOptional: boolean;
+  name: string;
+  position: number;
+};
+
+export type RecipeStep = {
+  id: string;
+  instruction: string;
+  notes: string | null;
+  position: number;
+  timerSeconds: number | null;
+};
+
+export type RecipeDetail = RecipeListItem & {
+  equipment: RecipeEquipment[];
+  ingredients: RecipeIngredient[];
+  steps: RecipeStep[];
+};
+
+export type CreateRecipeIngredientInput = {
+  amount?: number | null;
+  isOptional?: boolean;
+  item: string;
+  notes?: string | null;
+  preparation?: string | null;
+  unit?: string | null;
+};
+
+export type CreateRecipeEquipmentInput = {
+  details?: string | null;
+  isOptional?: boolean;
+  name: string;
+};
+
+export type CreateRecipeStepInput = {
+  instruction: string;
+  notes?: string | null;
+  timerSeconds?: number | null;
+};
+
+export type CreateRecipeInput = {
+  cookMinutes?: number | null;
+  coverImagePath?: string | null;
+  description?: string | null;
+  equipment?: CreateRecipeEquipmentInput[];
+  ingredients?: CreateRecipeIngredientInput[];
+  isScalable?: boolean;
+  prepMinutes?: number | null;
+  steps?: CreateRecipeStepInput[];
+  summary?: string | null;
+  title: string;
+  yieldQuantity?: number | null;
+  yieldUnit?: string | null;
+};
+
+export type DeleteRecipeInput = {
+  recipeId: string;
+};
+
+export type DeleteRecipeResult = {
+  recipeId: string;
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,6 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/types/supabase";
 
 const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
@@ -6,4 +8,6 @@ const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 const hasSupabaseConfig =
   url !== undefined && url !== "" && anonKey !== undefined && anonKey !== "";
 
-export const supabase = hasSupabaseConfig ? createClient(url, anonKey) : null;
+export const supabase: SupabaseClient<Database> | null = hasSupabaseConfig
+  ? createClient<Database>(url, anonKey)
+  : null;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,196 @@
+export type Json =
+  | boolean
+  | null
+  | number
+  | string
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  public: {
+    Tables: {
+      recipe_equipment: {
+        Row: {
+          created_at: string;
+          details: string | null;
+          id: string;
+          is_optional: boolean;
+          name: string;
+          position: number;
+          recipe_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          details?: string | null;
+          id?: string;
+          is_optional?: boolean;
+          name: string;
+          position: number;
+          recipe_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          details?: string | null;
+          id?: string;
+          is_optional?: boolean;
+          name?: string;
+          position?: number;
+          recipe_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            columns: ["recipe_id"];
+            foreignKeyName: "recipe_equipment_recipe_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "recipes";
+          },
+        ];
+      };
+      recipe_ingredients: {
+        Row: {
+          amount: number | null;
+          created_at: string;
+          id: string;
+          is_optional: boolean;
+          item: string;
+          notes: string | null;
+          position: number;
+          preparation: string | null;
+          recipe_id: string;
+          unit: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          amount?: number | null;
+          created_at?: string;
+          id?: string;
+          is_optional?: boolean;
+          item: string;
+          notes?: string | null;
+          position: number;
+          preparation?: string | null;
+          recipe_id: string;
+          unit?: string | null;
+          updated_at?: string;
+        };
+        Update: {
+          amount?: number | null;
+          created_at?: string;
+          id?: string;
+          is_optional?: boolean;
+          item?: string;
+          notes?: string | null;
+          position?: number;
+          preparation?: string | null;
+          recipe_id?: string;
+          unit?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            columns: ["recipe_id"];
+            foreignKeyName: "recipe_ingredients_recipe_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "recipes";
+          },
+        ];
+      };
+      recipe_steps: {
+        Row: {
+          created_at: string;
+          id: string;
+          instruction: string;
+          notes: string | null;
+          position: number;
+          recipe_id: string;
+          timer_seconds: number | null;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          instruction: string;
+          notes?: string | null;
+          position: number;
+          recipe_id: string;
+          timer_seconds?: number | null;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          instruction?: string;
+          notes?: string | null;
+          position?: number;
+          recipe_id?: string;
+          timer_seconds?: number | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            columns: ["recipe_id"];
+            foreignKeyName: "recipe_steps_recipe_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "recipes";
+          },
+        ];
+      };
+      recipes: {
+        Row: {
+          cook_minutes: number | null;
+          cover_image_path: string | null;
+          created_at: string;
+          description: string;
+          id: string;
+          is_scalable: boolean;
+          owner_id: string;
+          prep_minutes: number | null;
+          summary: string;
+          title: string;
+          updated_at: string;
+          yield_quantity: number | null;
+          yield_unit: string | null;
+        };
+        Insert: {
+          cook_minutes?: number | null;
+          cover_image_path?: string | null;
+          created_at?: string;
+          description?: string;
+          id?: string;
+          is_scalable?: boolean;
+          owner_id?: string;
+          prep_minutes?: number | null;
+          summary?: string;
+          title: string;
+          updated_at?: string;
+          yield_quantity?: number | null;
+          yield_unit?: string | null;
+        };
+        Update: {
+          cook_minutes?: number | null;
+          cover_image_path?: string | null;
+          created_at?: string;
+          description?: string;
+          id?: string;
+          is_scalable?: boolean;
+          owner_id?: string;
+          prep_minutes?: number | null;
+          summary?: string;
+          title?: string;
+          updated_at?: string;
+          yield_quantity?: number | null;
+          yield_unit?: string | null;
+        };
+        Relationships: [];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+  };
+};


### PR DESCRIPTION
## Summary
- Closes #9 by adding typed recipe query keys, public query option builders, and auth-aware create/delete helpers.
- Centralizes recipe Supabase access in feature-owned query modules with row adapters and shared recipe types.
- Adds focused Vitest coverage for mapper normalization and auth-state handling.

## Validation
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`

## Data and Security Impact
- [x] No schema change
- [x] Auth, permission, or data exposure impact reviewed
- Browser-side mutations still use the anon client, explicitly check session state, and rely on the existing RLS policies from issue #8. No secrets or service-role access were added.