### PR TITLE
feat(recipes): expand recipe detail reading view

### DIFF
--- a/src/features/auth/queries/sessionQueries.ts
+++ b/src/features/auth/queries/sessionQueries.ts
@@ -5,7 +5,7 @@ import { supabase } from "@/lib/supabase";
 import type { QueryClient } from "@tanstack/react-query";
 
 export type AuthSessionState =
-  | { kind: "authenticated"; email: string | null }
+  | { kind: "authenticated"; email: string | null; userId: string }
   | { kind: "guest" }
   | { kind: "unconfigured" };
 
@@ -23,6 +23,7 @@ async function getAuthSessionState(): Promise<AuthSessionState> {
   return {
     kind: "authenticated",
     email: data.session.user.email ?? null,
+    userId: data.session.user.id,
   };
 }
 

--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -1,0 +1,180 @@
+import {
+  formatIngredientText,
+  formatStepTimer,
+  getRecipeCountLabel,
+} from "../utils/recipePresentation";
+
+import type {
+  RecipeEquipment,
+  RecipeIngredient,
+  RecipeStep,
+} from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipeDetailCollectionSectionProps =
+  | {
+      description: string;
+      items: RecipeIngredient[];
+      kind: "ingredients";
+      title: string;
+    }
+  | {
+      description: string;
+      items: RecipeEquipment[];
+      kind: "equipment";
+      title: string;
+    }
+  | {
+      description: string;
+      items: RecipeStep[];
+      kind: "steps";
+      title: string;
+    };
+
+export function RecipeDetailCollectionSection(
+  props: RecipeDetailCollectionSectionProps,
+): JSX.Element {
+  return (
+    <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-6 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)]">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            {props.kind === "steps" ? "Cooking flow" : "Recipe details"}
+          </p>
+          <h2 className="mt-2 font-display text-3xl tracking-[-0.03em] text-foreground">
+            {props.title}
+          </h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {getCountText(props.kind, props.items.length)}
+        </p>
+      </div>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+        {props.description}
+      </p>
+
+      {props.items.length === 0 ? (
+        <div className="mt-5 rounded-[1.4rem] border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm leading-6 text-muted-foreground">
+          {getEmptyText(props.kind)}
+        </div>
+      ) : null}
+
+      {props.kind === "ingredients" && props.items.length > 0 ? (
+        <ul className="mt-5 space-y-3">
+          {props.items.map((ingredient) => (
+            <li
+              key={ingredient.id}
+              className="rounded-[1.4rem] border border-border/60 bg-background/80 px-4 py-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {formatIngredientText(ingredient)}
+                  </p>
+                  {ingredient.notes !== null ? (
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      {ingredient.notes}
+                    </p>
+                  ) : null}
+                </div>
+                {ingredient.isOptional ? (
+                  <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    Optional
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {props.kind === "equipment" && props.items.length > 0 ? (
+        <ul className="mt-5 space-y-3">
+          {props.items.map((equipment) => (
+            <li
+              key={equipment.id}
+              className="rounded-[1.4rem] border border-border/60 bg-background/80 px-4 py-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {equipment.name}
+                  </p>
+                  {equipment.details !== null ? (
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      {equipment.details}
+                    </p>
+                  ) : null}
+                </div>
+                {equipment.isOptional ? (
+                  <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    Optional
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {props.kind === "steps" && props.items.length > 0 ? (
+        <ol className="mt-5 space-y-4">
+          {props.items.map((step) => (
+            <li
+              key={step.id}
+              className="rounded-[1.4rem] border border-border/60 bg-background/80 px-4 py-4"
+            >
+              <div className="flex items-start gap-4">
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-sm font-semibold text-foreground">
+                  {step.position}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium leading-6 text-foreground">
+                      {step.instruction}
+                    </p>
+                    {step.timerSeconds !== null ? (
+                      <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                        {formatStepTimer(step.timerSeconds)}
+                      </span>
+                    ) : null}
+                  </div>
+                  {step.notes !== null ? (
+                    <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                      {step.notes}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </section>
+  );
+}
+
+function getCountText(
+  kind: RecipeDetailCollectionSectionProps["kind"],
+  count: number,
+): string {
+  switch (kind) {
+    case "ingredients":
+      return getRecipeCountLabel(count, "ingredient");
+    case "equipment":
+      return getRecipeCountLabel(count, "piece", "pieces");
+    case "steps":
+      return getRecipeCountLabel(count, "step");
+  }
+}
+
+function getEmptyText(kind: RecipeDetailCollectionSectionProps["kind"]): string {
+  switch (kind) {
+    case "ingredients":
+      return "No ingredients were listed for this recipe yet.";
+    case "equipment":
+      return "No equipment notes were captured for this recipe yet.";
+    case "steps":
+      return "No cooking steps were captured for this recipe yet.";
+  }
+}

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -3,17 +3,19 @@ import { Link } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { sessionQueryOptions } from "@/features/auth";
 
 import { recipeDetailQueryOptions } from "../queries/recipeQueryOptions";
 import {
   formatRecipeTime,
   formatRecipeYield,
-  getRecipeCountLabel,
   getRecipeScalingLabel,
   getRecipeSummary,
 } from "../utils/recipePresentation";
 
+import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
 import { RecipeDetailPageLoading } from "./RecipeDetailPageLoading";
+import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
 
 import type { JSX } from "react";
 
@@ -25,6 +27,7 @@ export function RecipeDetailPage({
   recipeId,
 }: RecipeDetailPageProps): JSX.Element {
   const recipeDetailQuery = useQuery(recipeDetailQueryOptions(recipeId));
+  const sessionQuery = useQuery(sessionQueryOptions);
 
   if (recipeDetailQuery.data === undefined) {
     return <RecipeDetailPageLoading />;
@@ -37,20 +40,6 @@ export function RecipeDetailPage({
     formatRecipeTime(recipe),
     formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit),
     getRecipeScalingLabel(recipe.isScalable),
-  ];
-  const recipeSections = [
-    {
-      description: "Ordered ingredients are ready for the fuller read.",
-      title: getRecipeCountLabel(recipe.ingredients.length, "ingredient"),
-    },
-    {
-      description: "Equipment stays separate so prep remains predictable.",
-      title: getRecipeCountLabel(recipe.equipment.length, "tool", "tools"),
-    },
-    {
-      description: "Steps are already captured in cooking order.",
-      title: getRecipeCountLabel(recipe.steps.length, "step"),
-    },
   ];
 
   return (
@@ -91,24 +80,36 @@ export function RecipeDetailPage({
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
-        {recipeSections.map((section) => (
-          <article
-            key={section.title}
-            className="rounded-[1.75rem] border border-border/70 bg-background/85 p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-              Recipe structure
-            </p>
-            <p className="mt-3 font-display text-2xl tracking-[-0.03em] text-foreground">
-              {section.title}
-            </p>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              {section.description}
-            </p>
-          </article>
-        ))}
-      </section>
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)] lg:items-start">
+        <div className="space-y-4">
+          <RecipeDetailCollectionSection
+            description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
+            items={recipe.ingredients}
+            kind="ingredients"
+            title="Ingredients"
+          />
+          <RecipeDetailCollectionSection
+            description="Equipment is separated from ingredients so the reading flow stays calm while you cook."
+            items={recipe.equipment}
+            kind="equipment"
+            title="Equipment"
+          />
+          <RecipeDetailCollectionSection
+            description="Each step is presented in order, with any saved timer notes staying attached to the right instruction."
+            items={recipe.steps}
+            kind="steps"
+            title="Method"
+          />
+        </div>
+
+        <div className="lg:sticky lg:top-24">
+          <RecipeOwnerActionsPanel
+            isSessionLoading={sessionQuery.isLoading}
+            recipe={recipe}
+            sessionState={sessionQuery.data}
+          />
+        </div>
+      </div>
     </main>
   );
 }

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -1,0 +1,106 @@
+import { Link } from "@tanstack/react-router";
+
+
+import { Button } from "@/components/ui/button";
+import type { AuthSessionState } from "@/features/auth";
+
+import type { RecipeDetail } from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipeOwnerActionsPanelProps = {
+  isSessionLoading: boolean;
+  recipe: RecipeDetail;
+  sessionState: AuthSessionState | undefined;
+};
+
+export function RecipeOwnerActionsPanel({
+  isSessionLoading,
+  recipe,
+  sessionState,
+}: RecipeOwnerActionsPanelProps): JSX.Element {
+  const state = getOwnerActionState(isSessionLoading, recipe, sessionState);
+
+  return (
+    <aside className="rounded-[1.75rem] border border-border/70 bg-background/85 p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+        Owner Actions
+      </p>
+      <h2 className="mt-3 font-display text-2xl tracking-[-0.03em] text-foreground">
+        {state.title}
+      </h2>
+      <p className="mt-3 text-sm leading-6 text-muted-foreground">
+        {state.description}
+      </p>
+      {state.ctaLabel !== null ? (
+        <Button asChild className="mt-5 w-full" size="lg" variant={state.ctaVariant}>
+          <Link to={state.ctaTo}>{state.ctaLabel}</Link>
+        </Button>
+      ) : null}
+    </aside>
+  );
+}
+
+function getOwnerActionState(
+  isSessionLoading: boolean,
+  recipe: RecipeDetail,
+  sessionState: AuthSessionState | undefined,
+): {
+  ctaLabel: string | null;
+  ctaTo: "/account" | "/recipes";
+  ctaVariant: "default" | "outline";
+  description: string;
+  title: string;
+} {
+  if (isSessionLoading) {
+    return {
+      ctaLabel: null,
+      ctaTo: "/recipes",
+      ctaVariant: "outline",
+      description:
+        "Ownership tools stay separate from the public reading view, and the app is checking whether this recipe belongs to you.",
+      title: "Checking kitchen access",
+    };
+  }
+
+  if (sessionState === undefined || sessionState.kind === "guest") {
+    return {
+      ctaLabel: "Go to account",
+      ctaTo: "/account",
+      ctaVariant: "default",
+      description:
+        "Anyone can read this recipe. Sign in from the account area before future create, edit, or delete actions become available.",
+      title: "Sign in for ownership tools",
+    };
+  }
+
+  if (sessionState.kind === "unconfigured") {
+    return {
+      ctaLabel: "Review account setup",
+      ctaTo: "/account",
+      ctaVariant: "outline",
+      description:
+        "Public reading is still available, but ownership controls cannot light up until Supabase auth is configured for this environment.",
+      title: "Auth setup still needed",
+    };
+  }
+
+  if (sessionState.userId === recipe.ownerId) {
+    return {
+      ctaLabel: "Visit account",
+      ctaTo: "/account",
+      ctaVariant: "outline",
+      description:
+        "This recipe belongs to you. Owner-only controls are intentionally separated here so edit and delete flows can land without disturbing the cooking view.",
+      title: "You own this recipe",
+    };
+  }
+
+  return {
+    ctaLabel: null,
+    ctaTo: "/recipes",
+    ctaVariant: "outline",
+    description:
+      "This recipe belongs to another cook. Public reading stays open, while any ownership actions remain private to the signed-in owner.",
+    title: "Public view only",
+  };
+}

--- a/src/features/recipes/utils/recipePresentation.test.ts
+++ b/src/features/recipes/utils/recipePresentation.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import { RecipeDataAccessError } from "../queries/recipeApi";
 
 import {
+  formatIngredientText,
   formatRecipeTime,
   formatRecipeYield,
+  formatStepTimer,
   getRecipeLoadErrorCopy,
   getRecipeSummary,
 } from "./recipePresentation";
@@ -57,6 +59,46 @@ describe("formatRecipeYield", () => {
     expect(formatRecipeYield(null, "loaves")).toBe("loaves");
     expect(formatRecipeYield(2, null)).toBe("2 servings");
     expect(formatRecipeYield(null, null)).toBe("Yield not set");
+  });
+});
+
+describe("formatIngredientText", () => {
+  it("combines amount, unit, item, and preparation in reading order", () => {
+    expect(
+      formatIngredientText({
+        amount: 2,
+        item: "lemons",
+        preparation: "thinly sliced",
+        unit: null,
+      }),
+    ).toBe("2 lemons, thinly sliced");
+    expect(
+      formatIngredientText({
+        amount: 1.5,
+        item: "flour",
+        preparation: null,
+        unit: "cups",
+      }),
+    ).toBe("1.5 cups flour");
+  });
+
+  it("falls back to the ingredient item when no amount metadata exists", () => {
+    expect(
+      formatIngredientText({
+        amount: null,
+        item: "olive oil",
+        preparation: null,
+        unit: null,
+      }),
+    ).toBe("olive oil");
+  });
+});
+
+describe("formatStepTimer", () => {
+  it("formats short, exact-minute, and mixed timers", () => {
+    expect(formatStepTimer(45)).toBe("45 sec timer");
+    expect(formatStepTimer(600)).toBe("10 min timer");
+    expect(formatStepTimer(125)).toBe("2 min 5 sec timer");
   });
 });
 

--- a/src/features/recipes/utils/recipePresentation.ts
+++ b/src/features/recipes/utils/recipePresentation.ts
@@ -46,6 +46,42 @@ export function formatRecipeYield(
   return `${yieldQuantity} ${yieldUnit}`;
 }
 
+export function formatIngredientText(ingredient: {
+  amount: number | null;
+  item: string;
+  preparation: string | null;
+  unit: string | null;
+}): string {
+  const amountText = ingredient.amount === null ? null : `${ingredient.amount}`;
+  const unitText = ingredient.unit;
+  const lead = [amountText, unitText].filter(Boolean).join(" ").trim();
+  const itemText =
+    ingredient.preparation === null
+      ? ingredient.item
+      : `${ingredient.item}, ${ingredient.preparation}`;
+
+  if (lead === "") {
+    return itemText;
+  }
+
+  return `${lead} ${itemText}`;
+}
+
+export function formatStepTimer(timerSeconds: number): string {
+  if (timerSeconds < 60) {
+    return `${timerSeconds} sec timer`;
+  }
+
+  const wholeMinutes = Math.floor(timerSeconds / 60);
+  const remainingSeconds = timerSeconds % 60;
+
+  if (remainingSeconds === 0) {
+    return `${wholeMinutes} min timer`;
+  }
+
+  return `${wholeMinutes} min ${remainingSeconds} sec timer`;
+}
+
 export function getRecipeCountLabel(
   count: number,
   singular: string,


### PR DESCRIPTION
## Summary
- turn the recipe detail page into a full reading surface with ordered ingredients, equipment, and method sections
- add a separate owner-actions panel that reacts to guest, owner, non-owner, and unconfigured auth states without blocking public reads
- extend session state with the authenticated user id and add presentation helper coverage for ingredient and timer labels

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- Public recipe reading remains open
- Owner-only affordances are clearly separated from public content, and no privileged browser secrets were added

Closes #14