### PR TITLE
refactor(recipes): extract page composition sections

### DIFF
--- a/src/features/recipes/components/RecipeDetailHero.tsx
+++ b/src/features/recipes/components/RecipeDetailHero.tsx
@@ -1,0 +1,70 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import {
+  formatRecipeTime,
+  formatRecipeYield,
+  getRecipeScalingLabel,
+  getRecipeSummary,
+} from "../utils/recipePresentation";
+
+import type { RecipeDetail } from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipeDetailHeroProps = {
+  recipe: RecipeDetail;
+};
+
+export function RecipeDetailHero({
+  recipe,
+}: RecipeDetailHeroProps): JSX.Element {
+  const summary = getRecipeSummary(recipe.summary, recipe.description);
+  const description = recipe.description.trim();
+  const metadata = [
+    formatRecipeTime(recipe),
+    formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit),
+    getRecipeScalingLabel(recipe.isScalable),
+  ];
+
+  return (
+    <>
+      <div>
+        <Button asChild variant="ghost" size="lg" className="rounded-full px-4">
+          <Link to="/recipes">
+            <ArrowLeft />
+            Back to recipe shelf
+          </Link>
+        </Button>
+      </div>
+
+      <section className="rounded-[2rem] border border-border/70 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+          Recipe Detail
+        </p>
+        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+          {recipe.title}
+        </h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+          {summary}
+        </p>
+        {description !== "" && description !== summary ? (
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+        <div className="mt-6 flex flex-wrap gap-2">
+          {metadata.map((item) => (
+            <span
+              key={item}
+              className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -1,21 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
 
 import { recipeDetailQueryOptions } from "../queries/recipeQueryOptions";
-import {
-  formatRecipeTime,
-  formatRecipeYield,
-  getRecipeScalingLabel,
-  getRecipeSummary,
-} from "../utils/recipePresentation";
 
-import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
+import { RecipeDetailHero } from "./RecipeDetailHero";
 import { RecipeDetailPageLoading } from "./RecipeDetailPageLoading";
-import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
+import { RecipeDetailPageSections } from "./RecipeDetailPageSections";
 
 import type { JSX } from "react";
 
@@ -34,82 +25,15 @@ export function RecipeDetailPage({
   }
 
   const recipe = recipeDetailQuery.data;
-  const summary = getRecipeSummary(recipe.summary, recipe.description);
-  const description = recipe.description.trim();
-  const metadata = [
-    formatRecipeTime(recipe),
-    formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit),
-    getRecipeScalingLabel(recipe.isScalable),
-  ];
 
   return (
     <main className="mx-auto flex max-w-5xl flex-col gap-6 py-6">
-      <div>
-        <Button asChild variant="ghost" size="lg" className="rounded-full px-4">
-          <Link to="/recipes">
-            <ArrowLeft />
-            Back to recipe shelf
-          </Link>
-        </Button>
-      </div>
-
-      <section className="rounded-[2rem] border border-border/70 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-          Recipe Detail
-        </p>
-        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-          {recipe.title}
-        </h1>
-        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-          {summary}
-        </p>
-        {description !== "" && description !== summary ? (
-          <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
-            {description}
-          </p>
-        ) : null}
-        <div className="mt-6 flex flex-wrap gap-2">
-          {metadata.map((item) => (
-            <span
-              key={item}
-              className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground"
-            >
-              {item}
-            </span>
-          ))}
-        </div>
-      </section>
-
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)] lg:items-start">
-        <div className="space-y-4">
-          <RecipeDetailCollectionSection
-            description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
-            items={recipe.ingredients}
-            kind="ingredients"
-            title="Ingredients"
-          />
-          <RecipeDetailCollectionSection
-            description="Equipment is separated from ingredients so the reading flow stays calm while you cook."
-            items={recipe.equipment}
-            kind="equipment"
-            title="Equipment"
-          />
-          <RecipeDetailCollectionSection
-            description="Each step is presented in order, with any saved timer notes staying attached to the right instruction."
-            items={recipe.steps}
-            kind="steps"
-            title="Method"
-          />
-        </div>
-
-        <div className="lg:sticky lg:top-24">
-          <RecipeOwnerActionsPanel
-            isSessionLoading={sessionQuery.isLoading}
-            recipe={recipe}
-            sessionState={sessionQuery.data}
-          />
-        </div>
-      </div>
+      <RecipeDetailHero recipe={recipe} />
+      <RecipeDetailPageSections
+        isSessionLoading={sessionQuery.isLoading}
+        recipe={recipe}
+        sessionState={sessionQuery.data}
+      />
     </main>
   );
 }

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -1,0 +1,52 @@
+import type { AuthSessionState } from "@/features/auth";
+
+import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
+import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
+
+import type { RecipeDetail } from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipeDetailPageSectionsProps = {
+  isSessionLoading: boolean;
+  recipe: RecipeDetail;
+  sessionState: AuthSessionState | undefined;
+};
+
+export function RecipeDetailPageSections({
+  isSessionLoading,
+  recipe,
+  sessionState,
+}: RecipeDetailPageSectionsProps): JSX.Element {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)] lg:items-start">
+      <div className="space-y-4">
+        <RecipeDetailCollectionSection
+          description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
+          items={recipe.ingredients}
+          kind="ingredients"
+          title="Ingredients"
+        />
+        <RecipeDetailCollectionSection
+          description="Equipment is separated from ingredients so the reading flow stays calm while you cook."
+          items={recipe.equipment}
+          kind="equipment"
+          title="Equipment"
+        />
+        <RecipeDetailCollectionSection
+          description="Each step is presented in order, with any saved timer notes staying attached to the right instruction."
+          items={recipe.steps}
+          kind="steps"
+          title="Method"
+        />
+      </div>
+
+      <div className="lg:sticky lg:top-24">
+        <RecipeOwnerActionsPanel
+          isSessionLoading={isSessionLoading}
+          recipe={recipe}
+          sessionState={sessionState}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/recipes/components/RecipesPage.tsx
+++ b/src/features/recipes/components/RecipesPage.tsx
@@ -2,8 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { recipeListQueryOptions } from "../queries/recipeQueryOptions";
 
-import { RecipePreviewCard } from "./RecipePreviewCard";
-import { RecipesEmptyState } from "./RecipesEmptyState";
+import { RecipesPageContent } from "./RecipesPageContent";
 import { RecipesPageHeader } from "./RecipesPageHeader";
 import { RecipesPageLoading } from "./RecipesPageLoading";
 
@@ -21,15 +20,7 @@ export function RecipesPage(): JSX.Element {
   return (
     <main className="mx-auto flex max-w-6xl flex-col gap-6 py-6">
       <RecipesPageHeader recipeCount={recipes.length} />
-      {recipes.length === 0 ? (
-        <RecipesEmptyState />
-      ) : (
-        <section className="grid gap-4">
-          {recipes.map((recipe) => (
-            <RecipePreviewCard key={recipe.id} recipe={recipe} />
-          ))}
-        </section>
-      )}
+      <RecipesPageContent recipes={recipes} />
     </main>
   );
 }

--- a/src/features/recipes/components/RecipesPageContent.tsx
+++ b/src/features/recipes/components/RecipesPageContent.tsx
@@ -1,0 +1,25 @@
+import { RecipePreviewCard } from "./RecipePreviewCard";
+import { RecipesEmptyState } from "./RecipesEmptyState";
+
+import type { RecipeListItem } from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipesPageContentProps = {
+  recipes: RecipeListItem[];
+};
+
+export function RecipesPageContent({
+  recipes,
+}: RecipesPageContentProps): JSX.Element {
+  if (recipes.length === 0) {
+    return <RecipesEmptyState />;
+  }
+
+  return (
+    <section className="grid gap-4">
+      {recipes.map((recipe) => (
+        <RecipePreviewCard key={recipe.id} recipe={recipe} />
+      ))}
+    </section>
+  );
+}

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -1,7 +1,10 @@
 export { RecipeDetailPage } from "./components/RecipeDetailPage";
+export { RecipeDetailHero } from "./components/RecipeDetailHero";
 export { RecipeDetailPageErrorState } from "./components/RecipeDetailPageErrorState";
 export { RecipeDetailPageLoading } from "./components/RecipeDetailPageLoading";
+export { RecipeDetailPageSections } from "./components/RecipeDetailPageSections";
 export { RecipesPage } from "./components/RecipesPage";
+export { RecipesPageContent } from "./components/RecipesPageContent";
 export { RecipesPageErrorState } from "./components/RecipesPageErrorState";
 export { RecipesPageLoading } from "./components/RecipesPageLoading";
 export {


### PR DESCRIPTION
## Summary
- extract the recipe detail hero and page section layout into feature-owned components
- extract list-page content rendering into its own recipe feature component so page modules stay focused on query orchestration
- keep route behavior unchanged while giving follow-on recipe work cleaner component landing spots

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No auth or permission behavior change
- Refactor only; public and owner-only surfaces behave the same as before

Closes #15