### PR TITLE
style(recipes): polish detail reading layout

### DIFF
--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -34,14 +34,16 @@ type RecipeDetailCollectionSectionProps =
 export function RecipeDetailCollectionSection(
   props: RecipeDetailCollectionSectionProps,
 ): JSX.Element {
+  const isMethod = props.kind === "steps";
+
   return (
-    <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-6 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)]">
+    <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:p-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-            {props.kind === "steps" ? "Cooking flow" : "Recipe details"}
+            {isMethod ? "Cooking flow" : "Recipe details"}
           </p>
-          <h2 className="mt-2 font-display text-3xl tracking-[-0.03em] text-foreground">
+          <h2 className="mt-2 font-display text-2xl tracking-[-0.03em] text-foreground sm:text-3xl">
             {props.title}
           </h2>
         </div>
@@ -49,7 +51,7 @@ export function RecipeDetailCollectionSection(
           {getCountText(props.kind, props.items.length)}
         </p>
       </div>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
         {props.description}
       </p>
 
@@ -60,28 +62,33 @@ export function RecipeDetailCollectionSection(
       ) : null}
 
       {props.kind === "ingredients" && props.items.length > 0 ? (
-        <ul className="mt-5 space-y-3">
+        <ul className="mt-5 grid gap-3">
           {props.items.map((ingredient) => (
             <li
               key={ingredient.id}
-              className="rounded-[1.4rem] border border-border/60 bg-background/80 px-4 py-4"
+              className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4"
             >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <p className="text-sm font-medium text-foreground">
-                    {formatIngredientText(ingredient)}
-                  </p>
+              <div className="flex items-start gap-3">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-xs font-semibold text-muted-foreground">
+                  {ingredient.position}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <p className="text-sm font-medium leading-6 text-foreground sm:text-[0.95rem]">
+                      {formatIngredientText(ingredient)}
+                    </p>
+                    {ingredient.isOptional ? (
+                      <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                        Optional
+                      </span>
+                    ) : null}
+                  </div>
                   {ingredient.notes !== null ? (
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">
                       {ingredient.notes}
                     </p>
                   ) : null}
                 </div>
-                {ingredient.isOptional ? (
-                  <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
-                    Optional
-                  </span>
-                ) : null}
               </div>
             </li>
           ))}
@@ -89,28 +96,33 @@ export function RecipeDetailCollectionSection(
       ) : null}
 
       {props.kind === "equipment" && props.items.length > 0 ? (
-        <ul className="mt-5 space-y-3">
+        <ul className="mt-5 grid gap-3">
           {props.items.map((equipment) => (
             <li
               key={equipment.id}
-              className="rounded-[1.4rem] border border-border/60 bg-background/80 px-4 py-4"
+              className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4"
             >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <p className="text-sm font-medium text-foreground">
-                    {equipment.name}
-                  </p>
+              <div className="flex items-start gap-3">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-xs font-semibold text-muted-foreground">
+                  {equipment.position}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <p className="text-sm font-medium leading-6 text-foreground sm:text-[0.95rem]">
+                      {equipment.name}
+                    </p>
+                    {equipment.isOptional ? (
+                      <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                        Optional
+                      </span>
+                    ) : null}
+                  </div>
                   {equipment.details !== null ? (
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">
                       {equipment.details}
                     </p>
                   ) : null}
                 </div>
-                {equipment.isOptional ? (
-                  <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
-                    Optional
-                  </span>
-                ) : null}
               </div>
             </li>
           ))}
@@ -122,19 +134,19 @@ export function RecipeDetailCollectionSection(
           {props.items.map((step) => (
             <li
               key={step.id}
-              className="rounded-[1.4rem] border border-border/60 bg-background/80 px-4 py-4"
+              className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4 sm:px-5"
             >
-              <div className="flex items-start gap-4">
-                <div className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-sm font-semibold text-foreground">
+              <div className="flex items-start gap-3 sm:gap-4">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-[1rem] border border-border/70 bg-card text-sm font-semibold text-foreground shadow-[0_12px_24px_-20px_rgba(69,52,35,0.5)] sm:size-11">
                   {step.position}
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-medium leading-6 text-foreground">
+                    <p className="text-sm font-medium leading-6 text-foreground sm:text-[0.98rem]">
                       {step.instruction}
                     </p>
                     {step.timerSeconds !== null ? (
-                      <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                      <span className="rounded-full border border-amber-300/70 bg-amber-50/85 px-2.5 py-1 text-xs font-medium text-amber-950">
                         {formatStepTimer(step.timerSeconds)}
                       </span>
                     ) : null}

--- a/src/features/recipes/components/RecipeDetailHero.tsx
+++ b/src/features/recipes/components/RecipeDetailHero.tsx
@@ -30,8 +30,13 @@ export function RecipeDetailHero({
 
   return (
     <>
-      <div>
-        <Button asChild variant="ghost" size="lg" className="rounded-full px-4">
+      <div className="sticky top-3 z-10 -mx-2 px-2 sm:static sm:mx-0 sm:px-0">
+        <Button
+          asChild
+          variant="ghost"
+          size="lg"
+          className="rounded-full border border-border/70 bg-background/90 px-4 shadow-[0_16px_42px_-36px_rgba(69,52,35,0.6)] backdrop-blur sm:bg-transparent sm:shadow-none"
+        >
           <Link to="/recipes">
             <ArrowLeft />
             Back to recipe shelf
@@ -39,32 +44,60 @@ export function RecipeDetailHero({
         </Button>
       </div>
 
-      <section className="rounded-[2rem] border border-border/70 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-          Recipe Detail
-        </p>
-        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-          {recipe.title}
-        </h1>
-        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-          {summary}
-        </p>
-        {description !== "" && description !== summary ? (
-          <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
-            {description}
-          </p>
-        ) : null}
-        <div className="mt-6 flex flex-wrap gap-2">
-          {metadata.map((item) => (
-            <span
-              key={item}
-              className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground"
-            >
-              {item}
-            </span>
-          ))}
+      <section className="overflow-hidden rounded-[2rem] border border-border/70 bg-[radial-gradient(circle_at_top_left,rgba(217,170,93,0.16),transparent_28%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-5 py-6 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8 sm:py-8">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(16rem,0.9fr)] lg:items-start">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+              Recipe Detail
+            </p>
+            <h1 className="mt-3 font-display text-4xl leading-[0.95] tracking-[-0.05em] text-foreground sm:text-5xl lg:text-6xl">
+              {recipe.title}
+            </h1>
+            <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+              {summary}
+            </p>
+            {description !== "" && description !== summary ? (
+              <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
+                {description}
+              </p>
+            ) : null}
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-border/70 bg-background/80 p-4 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.55)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+              Cook at a glance
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+              {metadata.map((item, index) => (
+                <div
+                  key={item}
+                  className="rounded-[1.25rem] border border-border/70 bg-card/90 px-3 py-3"
+                >
+                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                    {getMetadataLabel(index)}
+                  </p>
+                  <p className="mt-2 text-sm font-medium leading-6 text-foreground">
+                    {item}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </aside>
         </div>
       </section>
     </>
   );
+}
+
+function getMetadataLabel(index: number): string {
+  switch (index) {
+    case 0:
+      return "Time";
+    case 1:
+      return "Yield";
+    case 2:
+      return "Scaling";
+    default:
+      return "Detail";
+  }
 }

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -20,18 +20,20 @@ export function RecipeDetailPageSections({
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)] lg:items-start">
       <div className="space-y-4">
-        <RecipeDetailCollectionSection
-          description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
-          items={recipe.ingredients}
-          kind="ingredients"
-          title="Ingredients"
-        />
-        <RecipeDetailCollectionSection
-          description="Equipment is separated from ingredients so the reading flow stays calm while you cook."
-          items={recipe.equipment}
-          kind="equipment"
-          title="Equipment"
-        />
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+          <RecipeDetailCollectionSection
+            description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
+            items={recipe.ingredients}
+            kind="ingredients"
+            title="Ingredients"
+          />
+          <RecipeDetailCollectionSection
+            description="Equipment is separated from ingredients so the reading flow stays calm while you cook."
+            items={recipe.equipment}
+            kind="equipment"
+            title="Equipment"
+          />
+        </div>
         <RecipeDetailCollectionSection
           description="Each step is presented in order, with any saved timer notes staying attached to the right instruction."
           items={recipe.steps}

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@tanstack/react-router";
 
-
 import { Button } from "@/components/ui/button";
 import type { AuthSessionState } from "@/features/auth";
 
@@ -21,7 +20,7 @@ export function RecipeOwnerActionsPanel({
   const state = getOwnerActionState(isSessionLoading, recipe, sessionState);
 
   return (
-    <aside className="rounded-[1.75rem] border border-border/70 bg-background/85 p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
+    <aside className="rounded-[1.75rem] border border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
       <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
         Owner Actions
       </p>
@@ -32,7 +31,12 @@ export function RecipeOwnerActionsPanel({
         {state.description}
       </p>
       {state.ctaLabel !== null ? (
-        <Button asChild className="mt-5 w-full" size="lg" variant={state.ctaVariant}>
+        <Button
+          asChild
+          className="mt-5 w-full rounded-xl"
+          size="lg"
+          variant={state.ctaVariant}
+        >
           <Link to={state.ctaTo}>{state.ctaLabel}</Link>
         </Button>
       ) : null}


### PR DESCRIPTION
## Summary
- strengthen the recipe detail hero with a more useful at-a-glance layout for cooking context
- improve ingredient, equipment, and step presentation for easier scanning on phones and laptops
- keep owner actions visually separate while making the overall detail surface feel calmer and more intentional

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No auth or permission behavior change
- Presentation-only polish on the existing public detail view

Closes #16