### PR TITLE
feat(auth): add supabase account flows

### DIFF
--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -1,13 +1,47 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, LockKeyhole, NotebookPen, Soup } from "lucide-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
+import {
+  signInMutationOptions,
+  signOutMutationOptions,
+  signUpMutationOptions,
+} from "../queries/authMutationOptions";
 import { sessionQueryOptions } from "../queries/sessionQueries";
+import { authCredentialsSchema } from "../schemas/authSchemas";
+import { createEmptyAuthFormValues } from "../utils/authFormValues";
+
+import { AuthenticatedAccountPanel } from "./AuthenticatedAccountPanel";
+import { AuthFormCard } from "./AuthFormCard";
 
 import type { AuthSessionState } from "../queries/sessionQueries";
 import type { JSX } from "react";
+
+type AuthFeedback = {
+  description: string;
+  tone: "error" | "success";
+  title: string;
+};
+
+type AuthActionResult = {
+  message: string;
+};
+
+type CredentialMutation = {
+  mutate: (
+    values: {
+      email: string;
+      password: string;
+    },
+    options: {
+      onError: (error: Error) => void;
+      onSuccess: (result: AuthActionResult) => void;
+    },
+  ) => void;
+};
 
 function getHeadlineText(
   kind: "authenticated" | "guest" | "loading" | "unconfigured",
@@ -44,7 +78,14 @@ function getHeadlineText(
 }
 
 export function AccountPage(): JSX.Element {
+  const queryClient = useQueryClient();
   const sessionQuery = useQuery(sessionQueryOptions);
+  const signInMutation = useMutation(signInMutationOptions(queryClient));
+  const signUpMutation = useMutation(signUpMutationOptions(queryClient));
+  const signOutMutation = useMutation(signOutMutationOptions(queryClient));
+  const [feedback, setFeedback] = useState<AuthFeedback | null>(null);
+  const [signInValues, setSignInValues] = useState(createEmptyAuthFormValues);
+  const [signUpValues, setSignUpValues] = useState(createEmptyAuthFormValues);
 
   const kind = sessionQuery.isLoading
     ? "loading"
@@ -54,6 +95,8 @@ export function AccountPage(): JSX.Element {
     sessionQuery.isLoading,
     sessionQuery.data,
   );
+  const isGuest = sessionQuery.data?.kind === "guest" || sessionQuery.data === undefined;
+  const isConfigured = sessionQuery.data?.kind !== "unconfigured";
 
   return (
     <main className="mx-auto flex max-w-5xl flex-col gap-6 py-4 sm:py-6">
@@ -91,6 +134,21 @@ export function AccountPage(): JSX.Element {
         </div>
       </section>
 
+      {feedback !== null ? (
+        <section
+          className={
+            feedback.tone === "success"
+              ? "rounded-[1.5rem] border border-emerald-300/70 bg-emerald-50/80 px-5 py-4 text-emerald-950"
+              : "rounded-[1.5rem] border border-destructive/20 bg-destructive/5 px-5 py-4 text-foreground"
+          }
+        >
+          <p className="text-sm font-semibold">{feedback.title}</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {feedback.description}
+          </p>
+        </section>
+      ) : null}
+
       <section className="grid gap-4 lg:grid-cols-3">
         <article className="rounded-[1.75rem] border border-border/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.6)]">
           <div className="mb-4 flex size-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
@@ -116,15 +174,128 @@ export function AccountPage(): JSX.Element {
             <NotebookPen className="size-5" />
           </div>
           <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
-            What comes next
+            Ownership guard behavior
           </h2>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            This route is intentionally light today. Its main job is to give the
-            shell a clear account destination so sign-in, sign-up, sign-out, and
-            ownership prompts can slot into an established place.
+            Public recipe routes stay open. Creating or deleting recipes still
+            requires an authenticated session, and existing UI prompts point
+            guests back here when ownership tools are needed.
           </p>
         </article>
       </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {sessionQuery.data?.kind === "authenticated" ? (
+          <AuthenticatedAccountPanel
+            isPending={signOutMutation.isPending}
+            onSignOut={() => {
+              setFeedback(null);
+              signOutMutation.mutate(undefined, {
+                onError: (error) => {
+                  setFeedback({
+                    description: error.message,
+                    title: "Sign-out failed",
+                    tone: "error",
+                  });
+                },
+                onSuccess: (result) => {
+                  setFeedback({
+                    description: result.message,
+                    title: "Signed out",
+                    tone: "success",
+                  });
+                },
+              });
+            }}
+            sessionState={sessionQuery.data}
+          />
+        ) : (
+          <>
+            <AuthFormCard
+              description="Use your existing Supabase account to unlock recipe ownership actions while public browsing stays open."
+              email={signInValues.email}
+              isPending={signInMutation.isPending}
+              onEmailChange={(event) => {
+                setSignInValues((current) => ({
+                  ...current,
+                  email: event.target.value,
+                }));
+              }}
+              onPasswordChange={(event) => {
+                setSignInValues((current) => ({
+                  ...current,
+                  password: event.target.value,
+                }));
+              }}
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitCredentials(signInValues, signInMutation, {
+                  setFeedback,
+                  setValues: setSignInValues,
+                  successTitle: "Signed in",
+                });
+              }}
+              password={signInValues.password}
+              submitLabel="Sign in"
+              title="Sign in"
+            />
+            <AuthFormCard
+              description="Create a first-pass account so future recipe authoring and ownership flows have an authenticated foundation."
+              email={signUpValues.email}
+              isPending={signUpMutation.isPending}
+              onEmailChange={(event) => {
+                setSignUpValues((current) => ({
+                  ...current,
+                  email: event.target.value,
+                }));
+              }}
+              onPasswordChange={(event) => {
+                setSignUpValues((current) => ({
+                  ...current,
+                  password: event.target.value,
+                }));
+              }}
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitCredentials(signUpValues, signUpMutation, {
+                  setFeedback,
+                  setValues: setSignUpValues,
+                  successTitle: "Account ready",
+                });
+              }}
+              password={signUpValues.password}
+              submitLabel="Create account"
+              title="Sign up"
+            />
+          </>
+        )}
+      </section>
+
+      {!isConfigured ? (
+        <section className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)]">
+          <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
+            Supabase auth is not configured here yet
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Add the public Supabase URL and anon key to enable sign-in, sign-up,
+            and sign-out in this environment. Public recipe browsing can stay
+            available either way.
+          </p>
+        </section>
+      ) : null}
+
+      {isGuest ? (
+        <section className="rounded-[1.75rem] border border-amber-300/70 bg-amber-50/80 px-5 py-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)]">
+          <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-amber-950">
+            Guests can browse, but ownership still requires sign-in
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-amber-950/85">
+            The recipe shelf and detail pages stay public, while future create,
+            edit, and delete actions will keep redirecting or prompting guests
+            here before they continue.
+          </p>
+        </section>
+      ) : null}
     </main>
   );
 }
@@ -149,4 +320,49 @@ function getCurrentStateText(
     case "unconfigured":
       return "unconfigured";
   }
+}
+
+function submitCredentials(
+  values: {
+    email: string;
+    password: string;
+  },
+  mutation: CredentialMutation,
+  options: {
+    setFeedback: (feedback: AuthFeedback) => void;
+    setValues: (value: {
+      email: string;
+      password: string;
+    }) => void;
+    successTitle: string;
+  },
+): void {
+  const parsed = authCredentialsSchema.safeParse(values);
+
+  if (!parsed.success) {
+    options.setFeedback({
+      description: parsed.error.issues[0]?.message ?? "Review the form values and try again.",
+      title: "Form validation needed",
+      tone: "error",
+    });
+    return;
+  }
+
+  mutation.mutate(parsed.data, {
+    onError: (error) => {
+      options.setFeedback({
+        description: error.message,
+        title: "Auth request failed",
+        tone: "error",
+      });
+    },
+    onSuccess: (result) => {
+      options.setFeedback({
+        description: result.message,
+        title: options.successTitle,
+        tone: "success",
+      });
+      options.setValues(createEmptyAuthFormValues());
+    },
+  });
 }

--- a/src/features/auth/components/AuthFormCard.tsx
+++ b/src/features/auth/components/AuthFormCard.tsx
@@ -1,0 +1,82 @@
+import type { ChangeEvent, FormEvent, JSX } from "react";
+
+type AuthFormCardProps = {
+  description: string;
+  email: string;
+  isPending: boolean;
+  onEmailChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  password: string;
+  submitLabel: string;
+  title: string;
+};
+
+const inputClassName =
+  "h-11 w-full rounded-[1rem] border border-border/70 bg-background/90 px-4 text-sm text-foreground outline-none transition focus:border-primary/50 focus:ring-3 focus:ring-primary/15";
+
+export function AuthFormCard({
+  description,
+  email,
+  isPending,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+  password,
+  submitLabel,
+  title,
+}: AuthFormCardProps): JSX.Element {
+  return (
+    <article className="rounded-[1.75rem] border border-border/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.55)]">
+      <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
+        {title}
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        {description}
+      </p>
+
+      <form className="mt-5 space-y-4" onSubmit={onSubmit}>
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-foreground" htmlFor={`${title}-email`}>
+            Email
+          </label>
+          <input
+            autoComplete="email"
+            className={inputClassName}
+            id={`${title}-email`}
+            name="email"
+            onChange={onEmailChange}
+            type="email"
+            value={email}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor={`${title}-password`}
+          >
+            Password
+          </label>
+          <input
+            autoComplete={submitLabel === "Create account" ? "new-password" : "current-password"}
+            className={inputClassName}
+            id={`${title}-password`}
+            name="password"
+            onChange={onPasswordChange}
+            type="password"
+            value={password}
+          />
+        </div>
+
+        <button
+          className="inline-flex h-11 w-full items-center justify-center rounded-[1rem] bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isPending}
+          type="submit"
+        >
+          {isPending ? "Working..." : submitLabel}
+        </button>
+      </form>
+    </article>
+  );
+}

--- a/src/features/auth/components/AuthenticatedAccountPanel.tsx
+++ b/src/features/auth/components/AuthenticatedAccountPanel.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@/components/ui/button";
+
+import type { AuthSessionState } from "../queries/sessionQueries";
+import type { JSX } from "react";
+
+type AuthenticatedAccountPanelProps = {
+  isPending: boolean;
+  onSignOut: () => void;
+  sessionState: Extract<AuthSessionState, { kind: "authenticated" }>;
+};
+
+export function AuthenticatedAccountPanel({
+  isPending,
+  onSignOut,
+  sessionState,
+}: AuthenticatedAccountPanelProps): JSX.Element {
+  return (
+    <article className="rounded-[1.75rem] border border-emerald-300/70 bg-emerald-50/80 p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.55)]">
+      <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
+        You are signed in
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        {sessionState.email === null
+          ? "This session is ready for recipe ownership actions."
+          : `Signed in as ${sessionState.email}. Recipe create and delete flows can now rely on your authenticated session.`}
+      </p>
+      <Button className="mt-5 w-full rounded-[1rem]" disabled={isPending} onClick={onSignOut} size="lg">
+        {isPending ? "Signing out..." : "Sign out"}
+      </Button>
+    </article>
+  );
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,6 +1,16 @@
 export { AccountPage } from "./components/AccountPage";
+export { AuthenticatedAccountPanel } from "./components/AuthenticatedAccountPanel";
+export { AuthFormCard } from "./components/AuthFormCard";
+export {
+  signInMutationOptions,
+  signOutMutationOptions,
+  signUpMutationOptions,
+} from "./queries/authMutationOptions";
 export {
   preloadSessionState,
+  sessionQueryKey,
   sessionQueryOptions,
   type AuthSessionState,
 } from "./queries/sessionQueries";
+export { authCredentialsSchema, type AuthCredentialsInput } from "./schemas/authSchemas";
+export { createEmptyAuthFormValues, type AuthFormValues } from "./utils/authFormValues";

--- a/src/features/auth/queries/authApi.ts
+++ b/src/features/auth/queries/authApi.ts
@@ -1,0 +1,71 @@
+import { supabase } from "@/lib/supabase";
+
+import type { AuthCredentialsInput } from "../schemas/authSchemas";
+
+type AuthActionResult = {
+  message: string;
+};
+
+function getAuthClient(): NonNullable<typeof supabase> {
+  if (supabase === null) {
+    throw new Error("Supabase auth is not configured for this environment.");
+  }
+
+  return supabase;
+}
+
+export async function signInWithPassword(
+  input: AuthCredentialsInput,
+): Promise<AuthActionResult> {
+  const authClient = getAuthClient();
+  const { error } = await authClient.auth.signInWithPassword({
+    email: input.email.trim(),
+    password: input.password,
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return {
+    message: "You are signed in and ready for recipe ownership actions.",
+  };
+}
+
+export async function signUpWithPassword(
+  input: AuthCredentialsInput,
+): Promise<AuthActionResult> {
+  const authClient = getAuthClient();
+  const { data, error } = await authClient.auth.signUp({
+    email: input.email.trim(),
+    password: input.password,
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data.session === null) {
+    return {
+      message:
+        "Account created. Check your email for a confirmation link before signing in.",
+    };
+  }
+
+  return {
+    message: "Account created and signed in.",
+  };
+}
+
+export async function signOut(): Promise<AuthActionResult> {
+  const authClient = getAuthClient();
+  const { error } = await authClient.auth.signOut();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return {
+    message: "You have been signed out.",
+  };
+}

--- a/src/features/auth/queries/authMutationOptions.ts
+++ b/src/features/auth/queries/authMutationOptions.ts
@@ -1,0 +1,57 @@
+import { mutationOptions } from "@tanstack/react-query";
+
+import { signInWithPassword, signOut, signUpWithPassword } from "./authApi";
+import { sessionQueryKey } from "./sessionQueries";
+
+import type { AuthCredentialsInput } from "../schemas/authSchemas";
+import type { QueryClient } from "@tanstack/react-query";
+
+type AuthActionResult = {
+  message: string;
+};
+
+type SignInMutationOptions = ReturnType<
+  typeof mutationOptions<AuthActionResult, Error, AuthCredentialsInput>
+>;
+type SignUpMutationOptions = ReturnType<
+  typeof mutationOptions<AuthActionResult, Error, AuthCredentialsInput>
+>;
+type SignOutMutationOptions = ReturnType<
+  typeof mutationOptions<AuthActionResult, Error, void>
+>;
+
+export function signInMutationOptions(
+  queryClient: QueryClient,
+): SignInMutationOptions {
+  return mutationOptions<AuthActionResult, Error, AuthCredentialsInput>({
+    mutationFn: signInWithPassword,
+    mutationKey: ["auth", "sign-in"],
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: sessionQueryKey });
+    },
+  });
+}
+
+export function signUpMutationOptions(
+  queryClient: QueryClient,
+): SignUpMutationOptions {
+  return mutationOptions<AuthActionResult, Error, AuthCredentialsInput>({
+    mutationFn: signUpWithPassword,
+    mutationKey: ["auth", "sign-up"],
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: sessionQueryKey });
+    },
+  });
+}
+
+export function signOutMutationOptions(
+  queryClient: QueryClient,
+): SignOutMutationOptions {
+  return mutationOptions<AuthActionResult, Error, void>({
+    mutationFn: signOut,
+    mutationKey: ["auth", "sign-out"],
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: sessionQueryKey });
+    },
+  });
+}

--- a/src/features/auth/queries/sessionQueries.ts
+++ b/src/features/auth/queries/sessionQueries.ts
@@ -9,6 +9,8 @@ export type AuthSessionState =
   | { kind: "guest" }
   | { kind: "unconfigured" };
 
+export const sessionQueryKey = ["auth", "session"] as const;
+
 async function getAuthSessionState(): Promise<AuthSessionState> {
   if (supabase === null) {
     return { kind: "unconfigured" };
@@ -28,7 +30,7 @@ async function getAuthSessionState(): Promise<AuthSessionState> {
 }
 
 export const sessionQueryOptions = queryOptions({
-  queryKey: ["auth", "session"],
+  queryKey: sessionQueryKey,
   queryFn: getAuthSessionState,
   staleTime: 30_000,
 });

--- a/src/features/auth/schemas/authSchemas.test.ts
+++ b/src/features/auth/schemas/authSchemas.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { authCredentialsSchema } from "./authSchemas";
+
+describe("authCredentialsSchema", () => {
+  it("accepts trimmed email and password values", () => {
+    expect(
+      authCredentialsSchema.parse({
+        email: "  cook@example.com ",
+        password: "kitchen123",
+      }),
+    ).toEqual({
+      email: "cook@example.com",
+      password: "kitchen123",
+    });
+  });
+
+  it("rejects invalid email addresses", () => {
+    const result = authCredentialsSchema.safeParse({
+      email: "not-an-email",
+      password: "kitchen123",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues[0]?.message).toBe("Enter a valid email address.");
+  });
+
+  it("rejects short passwords", () => {
+    const result = authCredentialsSchema.safeParse({
+      email: "cook@example.com",
+      password: "short",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues[0]?.message).toBe(
+      "Password must be at least 8 characters long.",
+    );
+  });
+});

--- a/src/features/auth/schemas/authSchemas.ts
+++ b/src/features/auth/schemas/authSchemas.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const authCredentialsSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, "Enter a valid email address.")
+    .email("Enter a valid email address."),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters long."),
+});
+
+export type AuthCredentialsInput = z.infer<typeof authCredentialsSchema>;

--- a/src/features/auth/utils/authFormValues.ts
+++ b/src/features/auth/utils/authFormValues.ts
@@ -1,0 +1,11 @@
+export type AuthFormValues = {
+  email: string;
+  password: string;
+};
+
+export function createEmptyAuthFormValues(): AuthFormValues {
+  return {
+    email: "",
+    password: "",
+  };
+}


### PR DESCRIPTION
## Summary
- add first-pass sign-in, sign-up, and sign-out flows to the account page using feature-owned auth queries and schemas
- invalidate shared session state after auth actions so the shell and recipe ownership prompts reflect the current user immediately
- keep public recipe browsing open while surfacing clear guest and unconfigured auth guidance for ownership actions

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No secrets added to the browser app
- Ownership enforcement still relies on existing backend auth and RLS rules; this adds the browser-side entry flow only

Closes #22