### PR TITLE
feat(recipes): add create recipe flow

### DIFF
--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -1,0 +1,135 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+import { sessionQueryOptions } from "@/features/auth";
+
+import { RecipeDataAccessError } from "../queries/recipeApi";
+import { isRecipeMutationAuthError } from "../queries/recipeAuth";
+import { createRecipeMutationOptions } from "../queries/recipeMutationOptions";
+import { recipeCreateFormSchema } from "../schemas/recipeFormSchema";
+import { createEmptyRecipeCreateFormValues } from "../utils/recipeFormValues";
+
+import { RecipeCreateAuthPrompt } from "./RecipeCreateAuthPrompt";
+import { RecipeCreateForm } from "./RecipeCreateForm";
+
+import type { JSX } from "react";
+
+type FormFeedback = {
+  description: string;
+  tone: "error";
+  title: string;
+};
+
+export function CreateRecipePage(): JSX.Element {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery(sessionQueryOptions);
+  const createRecipeMutation = useMutation(createRecipeMutationOptions(queryClient));
+  const [feedback, setFeedback] = useState<FormFeedback | null>(null);
+  const [values, setValues] = useState(createEmptyRecipeCreateFormValues);
+
+  if (sessionQuery.isLoading) {
+    return (
+      <main className="mx-auto max-w-4xl py-6">
+        <section className="rounded-[2rem] border border-border/80 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+            Recipe Authoring
+          </p>
+          <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+            Checking kitchen access
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+            The app is confirming session state before it shows owner-only
+            authoring tools.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  if (
+    sessionQuery.data === undefined ||
+    sessionQuery.data.kind === "guest" ||
+    sessionQuery.data.kind === "unconfigured"
+  ) {
+    return <RecipeCreateAuthPrompt sessionState={sessionQuery.data} />;
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl py-6">
+      <section className="rounded-[2rem] border border-border/80 bg-[radial-gradient(circle_at_top_left,rgba(95,123,73,0.16),transparent_24%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+          Recipe Authoring
+        </p>
+        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+          Build a recipe without losing the cooking flow.
+        </h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+          Capture the basics first, then stack ingredients, equipment, and
+          ordered steps in one pass. Successful saves land on the new detail
+          page immediately.
+        </p>
+      </section>
+
+      {feedback === null ? null : (
+        <section className="mt-6 rounded-[1.5rem] border border-destructive/20 bg-destructive/5 px-5 py-4 text-foreground">
+          <p className="text-sm font-semibold">{feedback.title}</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {feedback.description}
+          </p>
+        </section>
+      )}
+
+      <div className="mt-6">
+        <RecipeCreateForm
+          isPending={createRecipeMutation.isPending}
+          onSubmit={(event) => {
+            event.preventDefault();
+            setFeedback(null);
+
+            const parsedValues = recipeCreateFormSchema.safeParse(values);
+
+            if (!parsedValues.success) {
+              setFeedback({
+                description:
+                  parsedValues.error.issues[0]?.message ??
+                  "Review the form values and try again.",
+                title: "Recipe form needs attention",
+                tone: "error",
+              });
+              return;
+            }
+
+            createRecipeMutation.mutate(parsedValues.data, {
+              onError: (error) => {
+                setFeedback({
+                  description: getCreateRecipeErrorMessage(error),
+                  title: "Recipe could not be created",
+                  tone: "error",
+                });
+              },
+              onSuccess: (recipe) => {
+                void navigate({ to: "/recipes/$recipeId", params: { recipeId: recipe.id } });
+              },
+            });
+          }}
+          setValues={setValues}
+          values={values}
+        />
+      </div>
+    </main>
+  );
+}
+
+function getCreateRecipeErrorMessage(error: Error): string {
+  if (isRecipeMutationAuthError(error)) {
+    return error.message;
+  }
+
+  if (error instanceof RecipeDataAccessError) {
+    return error.message;
+  }
+
+  return "Something went wrong while saving the recipe. Please try again.";
+}

--- a/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
+++ b/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
@@ -1,0 +1,64 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import type { AuthSessionState } from "@/features/auth";
+
+import type { JSX } from "react";
+
+type RecipeCreateAuthPromptProps = {
+  sessionState: AuthSessionState | undefined;
+};
+
+export function RecipeCreateAuthPrompt({
+  sessionState,
+}: RecipeCreateAuthPromptProps): JSX.Element {
+  const copy = getAuthPromptCopy(sessionState);
+
+  return (
+    <main className="mx-auto max-w-4xl py-6">
+      <section className="rounded-[2rem] border border-border/80 bg-[radial-gradient(circle_at_top_left,rgba(217,170,93,0.18),transparent_24%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+          Recipe Authoring
+        </p>
+        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+          {copy.title}
+        </h1>
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+          {copy.description}
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Button asChild size="lg" className="rounded-full px-5">
+            <Link to="/account">{copy.ctaLabel}</Link>
+          </Button>
+          <Button asChild size="lg" variant="outline" className="rounded-full px-5">
+            <Link to="/recipes">Back to recipe shelf</Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function getAuthPromptCopy(
+  sessionState: AuthSessionState | undefined,
+): {
+  ctaLabel: string;
+  description: string;
+  title: string;
+} {
+  if (sessionState === undefined || sessionState.kind === "guest") {
+    return {
+      ctaLabel: "Sign in to continue",
+      description:
+        "Recipe creation is an owner-only flow. Public browsing stays open, but you need an authenticated account before you can add basics, ingredients, equipment, and steps.",
+      title: "Sign in before creating a recipe",
+    };
+  }
+
+  return {
+    ctaLabel: "Review account setup",
+    description:
+      "This environment can browse public recipes, but Supabase auth is not configured yet, so owner-only authoring tools cannot submit safely.",
+    title: "Auth setup is still required",
+  };
+}

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -1,0 +1,566 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+
+import {
+  createEmptyRecipeEquipmentFormValue,
+  createEmptyRecipeIngredientFormValue,
+  createEmptyRecipeStepFormValue,
+  type RecipeCreateEquipmentFormValue,
+  type RecipeCreateFormValues,
+  type RecipeCreateIngredientFormValue,
+  type RecipeCreateStepFormValue,
+} from "../utils/recipeFormValues";
+
+import type { FormEvent, JSX } from "react";
+
+const inputClassName =
+  "mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20";
+const checkboxClassName =
+  "size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20";
+
+type RecipeCreateFormProps = {
+  isPending: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  setValues: (
+    updater: (current: RecipeCreateFormValues) => RecipeCreateFormValues,
+  ) => void;
+  values: RecipeCreateFormValues;
+};
+
+export function RecipeCreateForm({
+  isPending,
+  onSubmit,
+  setValues,
+  values,
+}: RecipeCreateFormProps): JSX.Element {
+  return (
+    <form className="space-y-6" onSubmit={onSubmit}>
+      <section className="rounded-[2rem] border border-border/80 bg-card/95 px-6 py-6 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+            Basics
+          </p>
+          <h2 className="mt-3 font-display text-3xl tracking-[-0.03em] text-foreground">
+            Start with the shape of the recipe.
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            Capture the title, quick summary, yield, timing, and whether serving
+            scaling should stay available later.
+          </p>
+        </div>
+
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <label className="md:col-span-2">
+            <span className="text-sm font-medium text-foreground">Title</span>
+            <input
+              className={inputClassName}
+              name="title"
+              onChange={(event) => {
+                const title = event.target.value;
+                setValues((current) => ({ ...current, title }));
+              }}
+              placeholder="Weeknight tomato pasta"
+              value={values.title}
+            />
+          </label>
+
+          <label className="md:col-span-2">
+            <span className="text-sm font-medium text-foreground">Summary</span>
+            <textarea
+              className={`${inputClassName} min-h-24 resize-y`}
+              name="summary"
+              onChange={(event) => {
+                const summary = event.target.value;
+                setValues((current) => ({ ...current, summary }));
+              }}
+              placeholder="Fast, pantry-friendly pasta with bright tomato flavor."
+              value={values.summary}
+            />
+          </label>
+
+          <label className="md:col-span-2">
+            <span className="text-sm font-medium text-foreground">Description</span>
+            <textarea
+              className={`${inputClassName} min-h-32 resize-y`}
+              name="description"
+              onChange={(event) => {
+                const description = event.target.value;
+                setValues((current) => ({ ...current, description }));
+              }}
+              placeholder="Add any context, serving notes, or why this dish earns a spot in the rotation."
+              value={values.description}
+            />
+          </label>
+
+          <label>
+            <span className="text-sm font-medium text-foreground">Yield quantity</span>
+            <input
+              className={inputClassName}
+              inputMode="decimal"
+              name="yieldQuantity"
+              onChange={(event) => {
+                const yieldQuantity = event.target.value;
+                setValues((current) => ({ ...current, yieldQuantity }));
+              }}
+              placeholder="4"
+              value={values.yieldQuantity}
+            />
+          </label>
+
+          <label>
+            <span className="text-sm font-medium text-foreground">Yield unit</span>
+            <input
+              className={inputClassName}
+              name="yieldUnit"
+              onChange={(event) => {
+                const yieldUnit = event.target.value;
+                setValues((current) => ({ ...current, yieldUnit }));
+              }}
+              placeholder="servings"
+              value={values.yieldUnit}
+            />
+          </label>
+
+          <label>
+            <span className="text-sm font-medium text-foreground">Prep minutes</span>
+            <input
+              className={inputClassName}
+              inputMode="numeric"
+              name="prepMinutes"
+              onChange={(event) => {
+                const prepMinutes = event.target.value;
+                setValues((current) => ({ ...current, prepMinutes }));
+              }}
+              placeholder="15"
+              value={values.prepMinutes}
+            />
+          </label>
+
+          <label>
+            <span className="text-sm font-medium text-foreground">Cook minutes</span>
+            <input
+              className={inputClassName}
+              inputMode="numeric"
+              name="cookMinutes"
+              onChange={(event) => {
+                const cookMinutes = event.target.value;
+                setValues((current) => ({ ...current, cookMinutes }));
+              }}
+              placeholder="20"
+              value={values.cookMinutes}
+            />
+          </label>
+        </div>
+
+        <label className="mt-5 flex items-center gap-3 rounded-2xl border border-border/70 bg-background/75 px-4 py-3 text-sm text-foreground">
+          <input
+            checked={values.isScalable}
+            className={checkboxClassName}
+            onChange={(event) => {
+              const isScalable = event.target.checked;
+              setValues((current) => ({ ...current, isScalable }));
+            }}
+            type="checkbox"
+          />
+          Allow serving scaling for this recipe.
+        </label>
+      </section>
+
+      <RecipeCreateCollectionSection
+        addLabel="Add ingredient"
+        description="Keep ingredients in cooking order so prep and shopping stay predictable."
+        items={values.ingredients}
+        itemLabel="Ingredient"
+        onAdd={() => {
+          setValues((current) => ({
+            ...current,
+            ingredients: [
+              ...current.ingredients,
+              createEmptyRecipeIngredientFormValue(),
+            ],
+          }));
+        }}
+        onRemove={(index) => {
+          setValues((current) => ({
+            ...current,
+            ingredients: current.ingredients.filter((_, itemIndex) => itemIndex !== index),
+          }));
+        }}
+        renderItem={(ingredient, index) => (
+          <IngredientFields
+            ingredient={ingredient}
+            index={index}
+            onChange={(nextIngredient) => {
+              setValues((current) => ({
+                ...current,
+                ingredients: updateCollectionItem(
+                  current.ingredients,
+                  index,
+                  nextIngredient,
+                ),
+              }));
+            }}
+          />
+        )}
+        title="Ingredients"
+      />
+
+      <RecipeCreateCollectionSection
+        addLabel="Add equipment"
+        description="Equipment is optional, but it helps future cooks see the setup at a glance."
+        items={values.equipment}
+        itemLabel="Equipment"
+        onAdd={() => {
+          setValues((current) => ({
+            ...current,
+            equipment: [...current.equipment, createEmptyRecipeEquipmentFormValue()],
+          }));
+        }}
+        onRemove={(index) => {
+          setValues((current) => ({
+            ...current,
+            equipment: current.equipment.filter((_, itemIndex) => itemIndex !== index),
+          }));
+        }}
+        renderItem={(equipment, index) => (
+          <EquipmentFields
+            equipment={equipment}
+            index={index}
+            onChange={(nextEquipment) => {
+              setValues((current) => ({
+                ...current,
+                equipment: updateCollectionItem(
+                  current.equipment,
+                  index,
+                  nextEquipment,
+                ),
+              }));
+            }}
+          />
+        )}
+        title="Equipment"
+      />
+
+      <RecipeCreateCollectionSection
+        addLabel="Add step"
+        description="Steps stay ordered so the detail page can render a clean cooking flow immediately after creation."
+        items={values.steps}
+        itemLabel="Step"
+        onAdd={() => {
+          setValues((current) => ({
+            ...current,
+            steps: [...current.steps, createEmptyRecipeStepFormValue()],
+          }));
+        }}
+        onRemove={(index) => {
+          setValues((current) => ({
+            ...current,
+            steps: current.steps.filter((_, itemIndex) => itemIndex !== index),
+          }));
+        }}
+        renderItem={(step, index) => (
+          <StepFields
+            index={index}
+            onChange={(nextStep) => {
+              setValues((current) => ({
+                ...current,
+                steps: updateCollectionItem(current.steps, index, nextStep),
+              }));
+            }}
+            step={step}
+          />
+        )}
+        title="Steps"
+      />
+
+      <div className="flex flex-wrap items-center justify-end gap-3">
+        <Button asChild size="lg" variant="outline" className="rounded-full px-5">
+          <Link to="/recipes">Cancel</Link>
+        </Button>
+        <Button
+          className="rounded-full px-6"
+          disabled={isPending}
+          size="lg"
+          type="submit"
+        >
+          {isPending ? "Saving recipe..." : "Create recipe"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+type RecipeCreateCollectionSectionProps<TItem> = {
+  addLabel: string;
+  description: string;
+  items: TItem[];
+  itemLabel: string;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  renderItem: (item: TItem, index: number) => JSX.Element;
+  title: string;
+};
+
+function RecipeCreateCollectionSection<TItem>({
+  addLabel,
+  description,
+  items,
+  itemLabel,
+  onAdd,
+  onRemove,
+  renderItem,
+  title,
+}: RecipeCreateCollectionSectionProps<TItem>): JSX.Element {
+  return (
+    <section className="rounded-[2rem] border border-border/80 bg-background/85 px-6 py-6 shadow-[0_20px_60px_-44px_rgba(69,52,35,0.5)] sm:px-8">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-2xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            {title}
+          </p>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <Button
+          className="rounded-full px-5"
+          onClick={onAdd}
+          type="button"
+          variant="outline"
+        >
+          {addLabel}
+        </Button>
+      </div>
+
+      <div className="mt-6 space-y-4">
+        {items.map((item, index) => (
+          <article
+            key={`${title}-${index + 1}`}
+            className="rounded-[1.5rem] border border-border/70 bg-card/90 p-4 shadow-[0_16px_40px_-34px_rgba(69,52,35,0.45)]"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-semibold text-foreground">
+                {itemLabel} {index + 1}
+              </p>
+              <Button
+                disabled={items.length === 1 && (title === "Ingredients" || title === "Steps")}
+                onClick={() => {
+                  onRemove(index);
+                }}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Remove
+              </Button>
+            </div>
+            <div className="mt-4">{renderItem(item, index)}</div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+type IngredientFieldsProps = {
+  index: number;
+  ingredient: RecipeCreateIngredientFormValue;
+  onChange: (ingredient: RecipeCreateIngredientFormValue) => void;
+};
+
+function IngredientFields({
+  index,
+  ingredient,
+  onChange,
+}: IngredientFieldsProps): JSX.Element {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <label className="md:col-span-2">
+        <span className="text-sm font-medium text-foreground">Ingredient name</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...ingredient, item: event.target.value });
+          }}
+          placeholder="Olive oil"
+          value={ingredient.item}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Amount</span>
+        <input
+          className={inputClassName}
+          inputMode="decimal"
+          onChange={(event) => {
+            onChange({ ...ingredient, amount: event.target.value });
+          }}
+          placeholder="2"
+          value={ingredient.amount}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Unit</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...ingredient, unit: event.target.value });
+          }}
+          placeholder="tbsp"
+          value={ingredient.unit}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Preparation</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...ingredient, preparation: event.target.value });
+          }}
+          placeholder="minced"
+          value={ingredient.preparation}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Notes</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...ingredient, notes: event.target.value });
+          }}
+          placeholder="plus more for serving"
+          value={ingredient.notes}
+        />
+      </label>
+
+      <label className="md:col-span-2 flex items-center gap-3 rounded-2xl border border-border/70 bg-background/75 px-4 py-3 text-sm text-foreground">
+        <input
+          checked={ingredient.isOptional}
+          className={checkboxClassName}
+          onChange={(event) => {
+            onChange({ ...ingredient, isOptional: event.target.checked });
+          }}
+          type="checkbox"
+        />
+        Mark ingredient {index + 1} as optional.
+      </label>
+    </div>
+  );
+}
+
+type EquipmentFieldsProps = {
+  equipment: RecipeCreateEquipmentFormValue;
+  index: number;
+  onChange: (equipment: RecipeCreateEquipmentFormValue) => void;
+};
+
+function EquipmentFields({
+  equipment,
+  index,
+  onChange,
+}: EquipmentFieldsProps): JSX.Element {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <label>
+        <span className="text-sm font-medium text-foreground">Equipment name</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...equipment, name: event.target.value });
+          }}
+          placeholder="Chef's knife"
+          value={equipment.name}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Details</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...equipment, details: event.target.value });
+          }}
+          placeholder="10-inch skillet"
+          value={equipment.details}
+        />
+      </label>
+
+      <label className="md:col-span-2 flex items-center gap-3 rounded-2xl border border-border/70 bg-background/75 px-4 py-3 text-sm text-foreground">
+        <input
+          checked={equipment.isOptional}
+          className={checkboxClassName}
+          onChange={(event) => {
+            onChange({ ...equipment, isOptional: event.target.checked });
+          }}
+          type="checkbox"
+        />
+        Mark equipment {index + 1} as optional.
+      </label>
+    </div>
+  );
+}
+
+type StepFieldsProps = {
+  index: number;
+  onChange: (step: RecipeCreateStepFormValue) => void;
+  step: RecipeCreateStepFormValue;
+};
+
+function StepFields({ index, onChange, step }: StepFieldsProps): JSX.Element {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <label className="md:col-span-2">
+        <span className="text-sm font-medium text-foreground">Instruction</span>
+        <textarea
+          className={`${inputClassName} min-h-28 resize-y`}
+          onChange={(event) => {
+            onChange({ ...step, instruction: event.target.value });
+          }}
+          placeholder="Bring a large pot of salted water to a boil."
+          value={step.instruction}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Notes</span>
+        <input
+          className={inputClassName}
+          onChange={(event) => {
+            onChange({ ...step, notes: event.target.value });
+          }}
+          placeholder="Lower the heat if the sauce reduces too quickly."
+          value={step.notes}
+        />
+      </label>
+
+      <label>
+        <span className="text-sm font-medium text-foreground">Timer seconds</span>
+        <input
+          className={inputClassName}
+          inputMode="numeric"
+          onChange={(event) => {
+            onChange({ ...step, timerSeconds: event.target.value });
+          }}
+          placeholder="300"
+          value={step.timerSeconds}
+        />
+      </label>
+
+      <p className="md:col-span-2 text-xs uppercase tracking-[0.24em] text-muted-foreground">
+        Step {index + 1} stays in recipe order.
+      </p>
+    </div>
+  );
+}
+
+function updateCollectionItem<TItem>(
+  items: TItem[],
+  index: number,
+  nextItem: TItem,
+): TItem[] {
+  return items.map((item, itemIndex) => (itemIndex === index ? nextItem : item));
+}

--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -1,3 +1,7 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+
 import type { JSX } from "react";
 
 type RecipesPageHeaderProps = {
@@ -36,6 +40,11 @@ export function RecipesPageHeader({
             Mobile-friendly reading
           </span>
         </div>
+        <div className="mt-6">
+          <Button asChild size="lg" className="rounded-full px-5">
+            <Link to="/recipes/new">Create a recipe</Link>
+          </Button>
+        </div>
       </div>
 
       <aside className="rounded-[2rem] border border-border/70 bg-background/85 p-6 shadow-[0_20px_60px_-44px_rgba(69,52,35,0.5)]">
@@ -59,6 +68,15 @@ export function RecipesPageHeader({
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
               This first pass stays intentionally lean so filtering can arrive
               later without redesigning the route.
+            </p>
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-foreground">
+              Authoring now has a dedicated route.
+            </p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              The create flow stays behind auth, while guests can still follow
+              the same entry point and get routed toward sign-in guidance.
             </p>
           </div>
         </div>

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -1,8 +1,11 @@
+export { CreateRecipePage } from "./components/CreateRecipePage";
 export { RecipeDetailPage } from "./components/RecipeDetailPage";
 export { RecipeDetailHero } from "./components/RecipeDetailHero";
 export { RecipeDetailPageErrorState } from "./components/RecipeDetailPageErrorState";
 export { RecipeDetailPageLoading } from "./components/RecipeDetailPageLoading";
 export { RecipeDetailPageSections } from "./components/RecipeDetailPageSections";
+export { RecipeCreateAuthPrompt } from "./components/RecipeCreateAuthPrompt";
+export { RecipeCreateForm } from "./components/RecipeCreateForm";
 export { RecipesPage } from "./components/RecipesPage";
 export { RecipesPageContent } from "./components/RecipesPageContent";
 export { RecipesPageErrorState } from "./components/RecipesPageErrorState";
@@ -32,6 +35,7 @@ export {
   recipeDetailQueryOptions,
   recipeListQueryOptions,
 } from "./queries/recipeQueryOptions";
+export { recipeCreateFormSchema } from "./schemas/recipeFormSchema";
 export type {
   CreateRecipeEquipmentInput,
   CreateRecipeIngredientInput,
@@ -45,3 +49,13 @@ export type {
   RecipeListItem,
   RecipeStep,
 } from "./types/recipes";
+export {
+  createEmptyRecipeCreateFormValues,
+  createEmptyRecipeEquipmentFormValue,
+  createEmptyRecipeIngredientFormValue,
+  createEmptyRecipeStepFormValue,
+  type RecipeCreateEquipmentFormValue,
+  type RecipeCreateFormValues,
+  type RecipeCreateIngredientFormValue,
+  type RecipeCreateStepFormValue,
+} from "./utils/recipeFormValues";

--- a/src/features/recipes/schemas/recipeFormSchema.test.ts
+++ b/src/features/recipes/schemas/recipeFormSchema.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import { recipeCreateFormSchema } from "./recipeFormSchema";
+
+describe("recipeCreateFormSchema", () => {
+  it("parses authoring form values into create recipe input", () => {
+    const result = recipeCreateFormSchema.parse({
+      cookMinutes: "15",
+      description: "Roast until golden.",
+      equipment: [
+        {
+          details: "Large mixing bowl",
+          isOptional: false,
+          name: "Bowl",
+        },
+      ],
+      ingredients: [
+        {
+          amount: "2.5",
+          isOptional: false,
+          item: "Flour",
+          notes: "",
+          preparation: "sifted",
+          unit: "cups",
+        },
+      ],
+      isScalable: true,
+      prepMinutes: "10",
+      steps: [
+        {
+          instruction: "Whisk everything together.",
+          notes: "",
+          timerSeconds: "120",
+        },
+      ],
+      summary: "Simple loaf",
+      title: "Bread",
+      yieldQuantity: "1",
+      yieldUnit: "loaf",
+    });
+
+    expect(result).toEqual({
+      cookMinutes: 15,
+      description: "Roast until golden.",
+      equipment: [
+        {
+          details: "Large mixing bowl",
+          isOptional: false,
+          name: "Bowl",
+        },
+      ],
+      ingredients: [
+        {
+          amount: 2.5,
+          isOptional: false,
+          item: "Flour",
+          notes: null,
+          preparation: "sifted",
+          unit: "cups",
+        },
+      ],
+      isScalable: true,
+      prepMinutes: 10,
+      steps: [
+        {
+          instruction: "Whisk everything together.",
+          notes: null,
+          timerSeconds: 120,
+        },
+      ],
+      summary: "Simple loaf",
+      title: "Bread",
+      yieldQuantity: 1,
+      yieldUnit: "loaf",
+    });
+  });
+
+  it("rejects missing title, ingredients, or steps", () => {
+    const result = recipeCreateFormSchema.safeParse({
+      cookMinutes: "",
+      description: "",
+      equipment: [],
+      ingredients: [],
+      isScalable: true,
+      prepMinutes: "",
+      steps: [],
+      summary: "",
+      title: " ",
+      yieldQuantity: "",
+      yieldUnit: "",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues.map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([
+        "Add a recipe title.",
+        "Add at least one ingredient.",
+        "Add at least one step.",
+      ]),
+    );
+  });
+
+  it("rejects negative and non-integer timer values", () => {
+    const result = recipeCreateFormSchema.safeParse({
+      cookMinutes: "",
+      description: "",
+      equipment: [],
+      ingredients: [
+        {
+          amount: "-1",
+          isOptional: false,
+          item: "Salt",
+          notes: "",
+          preparation: "",
+          unit: "tsp",
+        },
+      ],
+      isScalable: false,
+      prepMinutes: "",
+      steps: [
+        {
+          instruction: "Season the dish.",
+          notes: "",
+          timerSeconds: "2.5",
+        },
+      ],
+      summary: "",
+      title: "Soup",
+      yieldQuantity: "",
+      yieldUnit: "",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues.map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([
+        "Use zero or a positive number.",
+        "Use zero or a positive whole number.",
+      ]),
+    );
+  });
+});

--- a/src/features/recipes/schemas/recipeFormSchema.ts
+++ b/src/features/recipes/schemas/recipeFormSchema.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+
+import type { CreateRecipeInput } from "../types/recipes";
+
+const optionalTrimmedTextSchema = z.string().transform((value) => value.trim());
+
+const optionalNumberStringSchema = z
+  .string()
+  .transform((value, context): number | undefined => {
+    const normalizedValue = value.trim();
+
+    if (normalizedValue === "") {
+      return undefined;
+    }
+
+    const parsedValue = Number(normalizedValue);
+
+    if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Use zero or a positive number.",
+      });
+      return z.NEVER;
+    }
+
+    return parsedValue;
+  });
+
+const optionalIntegerStringSchema = z
+  .string()
+  .transform((value, context): number | undefined => {
+    const normalizedValue = value.trim();
+
+    if (normalizedValue === "") {
+      return undefined;
+    }
+
+    const parsedValue = Number(normalizedValue);
+
+    if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Use zero or a positive whole number.",
+      });
+      return z.NEVER;
+    }
+
+    return parsedValue;
+  });
+
+const recipeIngredientSchema = z.object({
+  amount: optionalNumberStringSchema,
+  isOptional: z.boolean(),
+  item: z.string().trim().min(1, "Add an ingredient name."),
+  notes: optionalTrimmedTextSchema,
+  preparation: optionalTrimmedTextSchema,
+  unit: optionalTrimmedTextSchema,
+});
+
+const recipeEquipmentSchema = z.object({
+  details: optionalTrimmedTextSchema,
+  isOptional: z.boolean(),
+  name: z.string().trim().min(1, "Add an equipment item."),
+});
+
+const recipeStepSchema = z.object({
+  instruction: z.string().trim().min(1, "Add a step instruction."),
+  notes: optionalTrimmedTextSchema,
+  timerSeconds: optionalIntegerStringSchema,
+});
+
+export const recipeCreateFormSchema = z
+  .object({
+    cookMinutes: optionalIntegerStringSchema,
+    description: optionalTrimmedTextSchema,
+    equipment: z.array(recipeEquipmentSchema),
+    ingredients: z
+      .array(recipeIngredientSchema)
+      .min(1, "Add at least one ingredient."),
+    isScalable: z.boolean(),
+    prepMinutes: optionalIntegerStringSchema,
+    steps: z.array(recipeStepSchema).min(1, "Add at least one step."),
+    summary: optionalTrimmedTextSchema,
+    title: z.string().trim().min(1, "Add a recipe title."),
+    yieldQuantity: optionalNumberStringSchema,
+    yieldUnit: optionalTrimmedTextSchema,
+  })
+  .transform(
+    ({
+      cookMinutes,
+      description,
+      equipment,
+      ingredients,
+      isScalable,
+      prepMinutes,
+      steps,
+      summary,
+      title,
+      yieldQuantity,
+      yieldUnit,
+    }): CreateRecipeInput => ({
+      cookMinutes,
+      description,
+      equipment: equipment.map((item) => ({
+        details: normalizeOptionalText(item.details),
+        isOptional: item.isOptional,
+        name: item.name,
+      })),
+      ingredients: ingredients.map((ingredient) => ({
+        amount: ingredient.amount,
+        isOptional: ingredient.isOptional,
+        item: ingredient.item,
+        notes: normalizeOptionalText(ingredient.notes),
+        preparation: normalizeOptionalText(ingredient.preparation),
+        unit: normalizeOptionalText(ingredient.unit),
+      })),
+      isScalable,
+      prepMinutes,
+      steps: steps.map((step) => ({
+        instruction: step.instruction,
+        notes: normalizeOptionalText(step.notes),
+        timerSeconds: step.timerSeconds,
+      })),
+      summary,
+      title,
+      yieldQuantity,
+      yieldUnit: normalizeOptionalText(yieldUnit),
+    }),
+  );
+
+function normalizeOptionalText(value: string): string | null {
+  return value === "" ? null : value;
+}

--- a/src/features/recipes/utils/recipeFormValues.ts
+++ b/src/features/recipes/utils/recipeFormValues.ts
@@ -1,0 +1,77 @@
+export type RecipeCreateIngredientFormValue = {
+  amount: string;
+  isOptional: boolean;
+  item: string;
+  notes: string;
+  preparation: string;
+  unit: string;
+};
+
+export type RecipeCreateEquipmentFormValue = {
+  details: string;
+  isOptional: boolean;
+  name: string;
+};
+
+export type RecipeCreateStepFormValue = {
+  instruction: string;
+  notes: string;
+  timerSeconds: string;
+};
+
+export type RecipeCreateFormValues = {
+  cookMinutes: string;
+  description: string;
+  equipment: RecipeCreateEquipmentFormValue[];
+  ingredients: RecipeCreateIngredientFormValue[];
+  isScalable: boolean;
+  prepMinutes: string;
+  steps: RecipeCreateStepFormValue[];
+  summary: string;
+  title: string;
+  yieldQuantity: string;
+  yieldUnit: string;
+};
+
+export function createEmptyRecipeIngredientFormValue(): RecipeCreateIngredientFormValue {
+  return {
+    amount: "",
+    isOptional: false,
+    item: "",
+    notes: "",
+    preparation: "",
+    unit: "",
+  };
+}
+
+export function createEmptyRecipeEquipmentFormValue(): RecipeCreateEquipmentFormValue {
+  return {
+    details: "",
+    isOptional: false,
+    name: "",
+  };
+}
+
+export function createEmptyRecipeStepFormValue(): RecipeCreateStepFormValue {
+  return {
+    instruction: "",
+    notes: "",
+    timerSeconds: "",
+  };
+}
+
+export function createEmptyRecipeCreateFormValues(): RecipeCreateFormValues {
+  return {
+    cookMinutes: "",
+    description: "",
+    equipment: [createEmptyRecipeEquipmentFormValue()],
+    ingredients: [createEmptyRecipeIngredientFormValue()],
+    isScalable: true,
+    prepMinutes: "",
+    steps: [createEmptyRecipeStepFormValue()],
+    summary: "",
+    title: "",
+    yieldQuantity: "",
+    yieldUnit: "",
+  };
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as RecipesRouteImport } from './routes/recipes'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as RecipesNewRouteImport } from './routes/recipes.new'
 import { Route as RecipesRecipeIdRouteImport } from './routes/recipes.$recipeId'
 
 const RecipesRoute = RecipesRouteImport.update({
@@ -29,6 +30,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RecipesNewRoute = RecipesNewRouteImport.update({
+  id: '/new',
+  path: '/new',
+  getParentRoute: () => RecipesRoute,
+} as any)
 const RecipesRecipeIdRoute = RecipesRecipeIdRouteImport.update({
   id: '/$recipeId',
   path: '/$recipeId',
@@ -40,12 +46,14 @@ export interface FileRoutesByFullPath {
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
   '/recipes/$recipeId': typeof RecipesRecipeIdRoute
+  '/recipes/new': typeof RecipesNewRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
   '/recipes/$recipeId': typeof RecipesRecipeIdRoute
+  '/recipes/new': typeof RecipesNewRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -53,13 +61,25 @@ export interface FileRoutesById {
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
   '/recipes/$recipeId': typeof RecipesRecipeIdRoute
+  '/recipes/new': typeof RecipesNewRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/account' | '/recipes' | '/recipes/$recipeId'
+  fullPaths:
+    | '/'
+    | '/account'
+    | '/recipes'
+    | '/recipes/$recipeId'
+    | '/recipes/new'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/account' | '/recipes' | '/recipes/$recipeId'
-  id: '__root__' | '/' | '/account' | '/recipes' | '/recipes/$recipeId'
+  to: '/' | '/account' | '/recipes' | '/recipes/$recipeId' | '/recipes/new'
+  id:
+    | '__root__'
+    | '/'
+    | '/account'
+    | '/recipes'
+    | '/recipes/$recipeId'
+    | '/recipes/new'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -91,6 +111,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/recipes/new': {
+      id: '/recipes/new'
+      path: '/new'
+      fullPath: '/recipes/new'
+      preLoaderRoute: typeof RecipesNewRouteImport
+      parentRoute: typeof RecipesRoute
+    }
     '/recipes/$recipeId': {
       id: '/recipes/$recipeId'
       path: '/$recipeId'
@@ -103,10 +130,12 @@ declare module '@tanstack/react-router' {
 
 interface RecipesRouteChildren {
   RecipesRecipeIdRoute: typeof RecipesRecipeIdRoute
+  RecipesNewRoute: typeof RecipesNewRoute
 }
 
 const RecipesRouteChildren: RecipesRouteChildren = {
   RecipesRecipeIdRoute: RecipesRecipeIdRoute,
+  RecipesNewRoute: RecipesNewRoute,
 }
 
 const RecipesRouteWithChildren =

--- a/src/routes/recipes.new.tsx
+++ b/src/routes/recipes.new.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { CreateRecipePage } from "@/features/recipes";
+
+export const Route = createFileRoute("/recipes/new")({
+  component: CreateRecipePage,
+});


### PR DESCRIPTION
## Summary
- add a dedicated /recipes/new authoring route with a recipe-owned create page and clear guest or unconfigured auth gating
- add recipe form defaults and zod validation for basics, ingredients, equipment, and ordered steps before create mutation submission
- link the shelf header to the create route and send successful creates to the new recipe detail page

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No secrets added to the browser app
- Recipe creation remains gated by Supabase auth and backend ownership enforcement

Closes #11