### PR TITLE
feat(recipes): add delete confirmation flow

### DIFF
--- a/src/features/recipes/components/RecipeDeleteDialog.tsx
+++ b/src/features/recipes/components/RecipeDeleteDialog.tsx
@@ -1,0 +1,61 @@
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+
+import { Button } from "@/components/ui/button";
+
+import type { JSX, ReactNode } from "react";
+
+type RecipeDeleteDialogProps = {
+  children: ReactNode;
+  description: string;
+  isPending: boolean;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  title: string;
+};
+
+export function RecipeDeleteDialog({
+  children,
+  description,
+  isPending,
+  onConfirm,
+  onOpenChange,
+  open,
+  title,
+}: RecipeDeleteDialogProps): JSX.Element {
+  return (
+    <AlertDialog.Root onOpenChange={onOpenChange} open={open}>
+      <AlertDialog.Trigger asChild>{children}</AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className="fixed inset-0 z-40 bg-[rgba(38,28,19,0.58)] backdrop-blur-sm" />
+        <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 rounded-[1.75rem] border border-border/80 bg-[linear-gradient(180deg,rgba(255,253,249,0.98),rgba(244,236,222,0.96))] p-6 shadow-[0_28px_90px_-50px_rgba(69,52,35,0.65)] outline-none">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-destructive/80">
+            Destructive action
+          </p>
+          <AlertDialog.Title className="mt-3 font-display text-3xl tracking-[-0.03em] text-foreground">
+            {title}
+          </AlertDialog.Title>
+          <AlertDialog.Description className="mt-3 text-sm leading-7 text-muted-foreground">
+            {description}
+          </AlertDialog.Description>
+          <div className="mt-6 flex flex-wrap justify-end gap-3">
+            <AlertDialog.Cancel asChild>
+              <Button className="rounded-full px-5" variant="outline">
+                Keep recipe
+              </Button>
+            </AlertDialog.Cancel>
+            <Button
+              className="rounded-full px-5"
+              disabled={isPending}
+              onClick={onConfirm}
+              type="button"
+              variant="destructive"
+            >
+              {isPending ? "Deleting..." : "Delete recipe"}
+            </Button>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+}

--- a/src/features/recipes/components/RecipeDeleteSuccessBanner.tsx
+++ b/src/features/recipes/components/RecipeDeleteSuccessBanner.tsx
@@ -1,0 +1,13 @@
+import type { JSX } from "react";
+
+export function RecipeDeleteSuccessBanner(): JSX.Element {
+  return (
+    <section className="rounded-[1.5rem] border border-emerald-300/70 bg-emerald-50/85 px-5 py-4 text-emerald-950 shadow-[0_16px_44px_-34px_rgba(26,84,62,0.35)]">
+      <p className="text-sm font-semibold">Recipe deleted</p>
+      <p className="mt-1 text-sm leading-6 text-emerald-900/80">
+        The recipe was removed and the shelf has been refreshed so stale entries
+        do not linger.
+      </p>
+    </section>
+  );
+}

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -1,7 +1,15 @@
-import { Link } from "@tanstack/react-router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import type { AuthSessionState } from "@/features/auth";
+
+import { RecipeDataAccessError } from "../queries/recipeApi";
+import { isRecipeMutationAuthError } from "../queries/recipeAuth";
+import { deleteRecipeMutationOptions } from "../queries/recipeMutationOptions";
+
+import { RecipeDeleteDialog } from "./RecipeDeleteDialog";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
@@ -17,7 +25,17 @@ export function RecipeOwnerActionsPanel({
   recipe,
   sessionState,
 }: RecipeOwnerActionsPanelProps): JSX.Element {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const deleteRecipeMutation = useMutation(deleteRecipeMutationOptions(queryClient));
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
   const state = getOwnerActionState(isSessionLoading, recipe, sessionState);
+  const isOwner =
+    !isSessionLoading &&
+    sessionState !== undefined &&
+    sessionState.kind === "authenticated" &&
+    sessionState.userId === recipe.ownerId;
 
   return (
     <aside className="rounded-[1.75rem] border border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
@@ -30,6 +48,12 @@ export function RecipeOwnerActionsPanel({
       <p className="mt-3 text-sm leading-6 text-muted-foreground">
         {state.description}
       </p>
+      {feedback === null ? null : (
+        <div className="mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm leading-6 text-foreground">
+          <p className="font-semibold">Delete unavailable</p>
+          <p className="mt-1 text-muted-foreground">{feedback}</p>
+        </div>
+      )}
       {state.ctaLabel !== null ? (
         <Button
           asChild
@@ -40,8 +64,56 @@ export function RecipeOwnerActionsPanel({
           <Link to={state.ctaTo}>{state.ctaLabel}</Link>
         </Button>
       ) : null}
+      {isOwner ? (
+        <RecipeDeleteDialog
+          description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
+          isPending={deleteRecipeMutation.isPending}
+          onConfirm={() => {
+            setFeedback(null);
+            deleteRecipeMutation.mutate(
+              { recipeId: recipe.id },
+              {
+                onError: (error) => {
+                  setFeedback(getDeleteErrorMessage(error));
+                },
+                onSuccess: () => {
+                  setIsDeleteDialogOpen(false);
+                  void navigate({
+                    search: { deleted: "1" },
+                    to: "/recipes",
+                  });
+                },
+              },
+            );
+          }}
+          onOpenChange={(open) => {
+            setIsDeleteDialogOpen(open);
+            if (open) {
+              setFeedback(null);
+            }
+          }}
+          open={isDeleteDialogOpen}
+          title="Delete this recipe?"
+        >
+          <Button className="mt-3 w-full rounded-xl" size="lg" variant="destructive">
+            Delete recipe
+          </Button>
+        </RecipeDeleteDialog>
+      ) : null}
     </aside>
   );
+}
+
+function getDeleteErrorMessage(error: Error): string {
+  if (isRecipeMutationAuthError(error)) {
+    return error.message;
+  }
+
+  if (error instanceof RecipeDataAccessError) {
+    return error.message;
+  }
+
+  return "The recipe could not be deleted. Please try again.";
 }
 
 function getOwnerActionState(

--- a/src/features/recipes/components/RecipesPage.tsx
+++ b/src/features/recipes/components/RecipesPage.tsx
@@ -2,13 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 
 import { recipeListQueryOptions } from "../queries/recipeQueryOptions";
 
+import { RecipeDeleteSuccessBanner } from "./RecipeDeleteSuccessBanner";
 import { RecipesPageContent } from "./RecipesPageContent";
 import { RecipesPageHeader } from "./RecipesPageHeader";
 import { RecipesPageLoading } from "./RecipesPageLoading";
 
 import type { JSX } from "react";
 
-export function RecipesPage(): JSX.Element {
+type RecipesPageProps = {
+  showDeletedBanner?: boolean;
+};
+
+export function RecipesPage({
+  showDeletedBanner = false,
+}: RecipesPageProps): JSX.Element {
   const recipeListQuery = useQuery(recipeListQueryOptions());
 
   if (recipeListQuery.data === undefined) {
@@ -20,6 +27,7 @@ export function RecipesPage(): JSX.Element {
   return (
     <main className="mx-auto flex max-w-6xl flex-col gap-6 py-6">
       <RecipesPageHeader recipeCount={recipes.length} />
+      {showDeletedBanner ? <RecipeDeleteSuccessBanner /> : null}
       <RecipesPageContent recipes={recipes} />
     </main>
   );

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -5,6 +5,8 @@ export { RecipeDetailPageErrorState } from "./components/RecipeDetailPageErrorSt
 export { RecipeDetailPageLoading } from "./components/RecipeDetailPageLoading";
 export { RecipeDetailPageSections } from "./components/RecipeDetailPageSections";
 export { RecipeCreateAuthPrompt } from "./components/RecipeCreateAuthPrompt";
+export { RecipeDeleteDialog } from "./components/RecipeDeleteDialog";
+export { RecipeDeleteSuccessBanner } from "./components/RecipeDeleteSuccessBanner";
 export { RecipeCreateForm } from "./components/RecipeCreateForm";
 export { RecipesPage } from "./components/RecipesPage";
 export { RecipesPageContent } from "./components/RecipesPageContent";
@@ -36,6 +38,10 @@ export {
   recipeListQueryOptions,
 } from "./queries/recipeQueryOptions";
 export { recipeCreateFormSchema } from "./schemas/recipeFormSchema";
+export {
+  recipeShelfSearchSchema,
+  type RecipeShelfSearch,
+} from "./schemas/recipeShelfSearchSchema";
 export type {
   CreateRecipeEquipmentInput,
   CreateRecipeIngredientInput,

--- a/src/features/recipes/schemas/recipeShelfSearchSchema.test.ts
+++ b/src/features/recipes/schemas/recipeShelfSearchSchema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { recipeShelfSearchSchema } from "./recipeShelfSearchSchema";
+
+describe("recipeShelfSearchSchema", () => {
+  it("accepts an empty search state", () => {
+    expect(recipeShelfSearchSchema.parse({})).toEqual({});
+  });
+
+  it("accepts the delete success flag", () => {
+    expect(recipeShelfSearchSchema.parse({ deleted: "1" })).toEqual({
+      deleted: "1",
+    });
+  });
+
+  it("rejects unexpected deleted values", () => {
+    const result = recipeShelfSearchSchema.safeParse({ deleted: "0" });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/recipes/schemas/recipeShelfSearchSchema.ts
+++ b/src/features/recipes/schemas/recipeShelfSearchSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const recipeShelfSearchSchema = z.object({
+  deleted: z.enum(["1"]).optional(),
+});
+
+export type RecipeShelfSearch = z.infer<typeof recipeShelfSearchSchema>;

--- a/src/routes/recipes.tsx
+++ b/src/routes/recipes.tsx
@@ -2,14 +2,24 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import {
   preloadRecipeList,
+  recipeShelfSearchSchema,
   RecipesPage,
   RecipesPageErrorState,
   RecipesPageLoading,
 } from "@/features/recipes";
 
+import type { JSX } from "react";
+
+function RecipesRouteComponent(): JSX.Element {
+  const search = Route.useSearch();
+
+  return <RecipesPage showDeletedBanner={search.deleted === "1"} />;
+}
+
 export const Route = createFileRoute("/recipes")({
   loader: ({ context }) => preloadRecipeList(context.queryClient),
-  component: RecipesPage,
+  validateSearch: recipeShelfSearchSchema,
+  component: RecipesRouteComponent,
   errorComponent: RecipesPageErrorState,
   pendingComponent: RecipesPageLoading,
   pendingMs: 0,


### PR DESCRIPTION
## Summary
- add an owner-only recipe delete flow with a Radix alert dialog and clear destructive confirmation copy in the recipe detail sidebar
- surface deletion failures in the owner panel and redirect successful deletes back to the shelf with a one-time success banner
- keep recipe list and detail cache state aligned through the existing delete mutation invalidation path

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No secrets added to the browser app
- Delete remains backend-enforced through Supabase auth and ownership policy checks

Closes #12