### PR TITLE
feat(recipes): add serving scaling controls

### DIFF
--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -16,6 +16,7 @@ type RecipeDetailCollectionSectionProps =
       description: string;
       items: RecipeIngredient[];
       kind: "ingredients";
+      scaleFactor?: number;
       title: string;
     }
   | {
@@ -75,7 +76,7 @@ export function RecipeDetailCollectionSection(
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <p className="text-sm font-medium leading-6 text-foreground sm:text-[0.95rem]">
-                      {formatIngredientText(ingredient)}
+                      {formatIngredientText(ingredient, props.scaleFactor ?? 1)}
                     </p>
                     {ingredient.isOptional ? (
                       <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">

--- a/src/features/recipes/components/RecipeDetailHero.tsx
+++ b/src/features/recipes/components/RecipeDetailHero.tsx
@@ -15,16 +15,18 @@ import type { JSX } from "react";
 
 type RecipeDetailHeroProps = {
   recipe: RecipeDetail;
+  scaleFactor: number;
 };
 
 export function RecipeDetailHero({
   recipe,
+  scaleFactor,
 }: RecipeDetailHeroProps): JSX.Element {
   const summary = getRecipeSummary(recipe.summary, recipe.description);
   const description = recipe.description.trim();
   const metadata = [
     formatRecipeTime(recipe),
-    formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit),
+    formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit, scaleFactor),
     getRecipeScalingLabel(recipe.isScalable),
   ];
 

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 
 import { sessionQueryOptions } from "@/features/auth";
 
@@ -19,6 +20,7 @@ export function RecipeDetailPage({
 }: RecipeDetailPageProps): JSX.Element {
   const recipeDetailQuery = useQuery(recipeDetailQueryOptions(recipeId));
   const sessionQuery = useQuery(sessionQueryOptions);
+  const [scaleFactor, setScaleFactor] = useState(1);
 
   if (recipeDetailQuery.data === undefined) {
     return <RecipeDetailPageLoading />;
@@ -28,10 +30,12 @@ export function RecipeDetailPage({
 
   return (
     <main className="mx-auto flex max-w-5xl flex-col gap-6 py-6">
-      <RecipeDetailHero recipe={recipe} />
+      <RecipeDetailHero recipe={recipe} scaleFactor={scaleFactor} />
       <RecipeDetailPageSections
         isSessionLoading={sessionQuery.isLoading}
+        onScaleChange={setScaleFactor}
         recipe={recipe}
+        scaleFactor={scaleFactor}
         sessionState={sessionQuery.data}
       />
     </main>

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -2,29 +2,40 @@ import type { AuthSessionState } from "@/features/auth";
 
 import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
 import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
+import { RecipeScalingPanel } from "./RecipeScalingPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipeDetailPageSectionsProps = {
   isSessionLoading: boolean;
+  onScaleChange: (scaleFactor: number) => void;
   recipe: RecipeDetail;
+  scaleFactor: number;
   sessionState: AuthSessionState | undefined;
 };
 
 export function RecipeDetailPageSections({
   isSessionLoading,
+  onScaleChange,
   recipe,
+  scaleFactor,
   sessionState,
 }: RecipeDetailPageSectionsProps): JSX.Element {
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)] lg:items-start">
       <div className="space-y-4">
+        <RecipeScalingPanel
+          onScaleChange={onScaleChange}
+          recipe={recipe}
+          scaleFactor={scaleFactor}
+        />
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
           <RecipeDetailCollectionSection
             description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
             items={recipe.ingredients}
             kind="ingredients"
+            scaleFactor={scaleFactor}
             title="Ingredients"
           />
           <RecipeDetailCollectionSection

--- a/src/features/recipes/components/RecipeScalingPanel.tsx
+++ b/src/features/recipes/components/RecipeScalingPanel.tsx
@@ -1,0 +1,94 @@
+import { Button } from "@/components/ui/button";
+
+import {
+  canScaleRecipe,
+  formatScaleLabel,
+  recipeScaleOptions,
+} from "../utils/recipeScaling";
+
+import type { RecipeDetail } from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipeScalingPanelProps = {
+  onScaleChange: (scaleFactor: number) => void;
+  recipe: RecipeDetail;
+  scaleFactor: number;
+};
+
+export function RecipeScalingPanel({
+  onScaleChange,
+  recipe,
+  scaleFactor,
+}: RecipeScalingPanelProps): JSX.Element {
+  const isScalable = canScaleRecipe(recipe);
+
+  return (
+    <section className="rounded-[1.75rem] border border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            Serving scale
+          </p>
+          <h2 className="mt-2 font-display text-2xl tracking-[-0.03em] text-foreground">
+            {getScalingPanelTitle(recipe, isScalable)}
+          </h2>
+        </div>
+        <span className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
+          {formatScaleLabel(scaleFactor)}
+        </span>
+      </div>
+
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+        {getScalingPanelDescription(recipe, isScalable)}
+      </p>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {recipeScaleOptions.map((option) => (
+          <Button
+            key={option.label}
+            className="rounded-full px-4"
+            disabled={!isScalable}
+            onClick={() => {
+              onScaleChange(option.value);
+            }}
+            size="sm"
+            type="button"
+            variant={scaleFactor === option.value ? "default" : "outline"}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function getScalingPanelTitle(
+  recipe: Pick<RecipeDetail, "isScalable" | "yieldQuantity">,
+  isScalable: boolean,
+): string {
+  if (isScalable) {
+    return "Adjust the batch size";
+  }
+
+  if (!recipe.isScalable) {
+    return "This recipe stays at its base yield";
+  }
+
+  return "Add a numeric yield to unlock scaling";
+}
+
+function getScalingPanelDescription(
+  recipe: Pick<RecipeDetail, "isScalable" | "yieldQuantity">,
+  isScalable: boolean,
+): string {
+  if (isScalable) {
+    return "Use half, base, or double to update the displayed yield and ingredient amounts without changing the saved recipe.";
+  }
+
+  if (!recipe.isScalable) {
+    return "The author marked this recipe as a fixed-yield dish, so the ingredient list stays anchored to the original batch size.";
+  }
+
+  return "Scaling is available for recipes with a numeric base yield. Once that metadata exists, the ingredient list can resize from this panel.";
+}

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -8,6 +8,7 @@ export { RecipeCreateAuthPrompt } from "./components/RecipeCreateAuthPrompt";
 export { RecipeDeleteDialog } from "./components/RecipeDeleteDialog";
 export { RecipeDeleteSuccessBanner } from "./components/RecipeDeleteSuccessBanner";
 export { RecipeCreateForm } from "./components/RecipeCreateForm";
+export { RecipeScalingPanel } from "./components/RecipeScalingPanel";
 export { RecipesPage } from "./components/RecipesPage";
 export { RecipesPageContent } from "./components/RecipesPageContent";
 export { RecipesPageErrorState } from "./components/RecipesPageErrorState";
@@ -65,3 +66,10 @@ export {
   type RecipeCreateIngredientFormValue,
   type RecipeCreateStepFormValue,
 } from "./utils/recipeFormValues";
+export {
+  canScaleRecipe,
+  formatScaleLabel,
+  recipeScaleOptions,
+  scaleIngredientAmount,
+  scaleRecipeYield,
+} from "./utils/recipeScaling";

--- a/src/features/recipes/utils/recipePresentation.test.ts
+++ b/src/features/recipes/utils/recipePresentation.test.ts
@@ -55,6 +55,11 @@ describe("formatRecipeYield", () => {
     expect(formatRecipeYield(4, "servings")).toBe("4 servings");
   });
 
+  it("applies the active scale factor to the displayed yield", () => {
+    expect(formatRecipeYield(4, "servings", 0.5)).toBe("2 servings");
+    expect(formatRecipeYield(4, "servings", 2)).toBe("8 servings");
+  });
+
   it("falls back cleanly when quantity or unit is missing", () => {
     expect(formatRecipeYield(null, "loaves")).toBe("loaves");
     expect(formatRecipeYield(2, null)).toBe("2 servings");
@@ -80,6 +85,20 @@ describe("formatIngredientText", () => {
         unit: "cups",
       }),
     ).toBe("1.5 cups flour");
+  });
+
+  it("applies the active scale factor to ingredient amounts", () => {
+    expect(
+      formatIngredientText(
+        {
+          amount: 1.5,
+          item: "flour",
+          preparation: null,
+          unit: "cups",
+        },
+        2,
+      ),
+    ).toBe("3 cups flour");
   });
 
   it("falls back to the ingredient item when no amount metadata exists", () => {

--- a/src/features/recipes/utils/recipePresentation.ts
+++ b/src/features/recipes/utils/recipePresentation.ts
@@ -1,5 +1,7 @@
 import { RecipeDataAccessError } from "../queries/recipeApi";
 
+import { scaleIngredientAmount, scaleRecipeYield } from "./recipeScaling";
+
 type RecipeLoadSurface = "detail" | "list";
 
 type RecipeLoadErrorCopy = {
@@ -30,20 +32,23 @@ export function formatRecipeTime(recipe: {
 export function formatRecipeYield(
   yieldQuantity: number | null,
   yieldUnit: string | null,
+  scaleFactor = 1,
 ): string {
-  if (yieldQuantity === null && yieldUnit === null) {
+  const scaledYieldQuantity = scaleRecipeYield(yieldQuantity, scaleFactor);
+
+  if (scaledYieldQuantity === null && yieldUnit === null) {
     return "Yield not set";
   }
 
-  if (yieldQuantity === null) {
+  if (scaledYieldQuantity === null) {
     return yieldUnit ?? "Yield not set";
   }
 
   if (yieldUnit === null) {
-    return `${yieldQuantity} servings`;
+    return `${scaledYieldQuantity} servings`;
   }
 
-  return `${yieldQuantity} ${yieldUnit}`;
+  return `${scaledYieldQuantity} ${yieldUnit}`;
 }
 
 export function formatIngredientText(ingredient: {
@@ -51,8 +56,9 @@ export function formatIngredientText(ingredient: {
   item: string;
   preparation: string | null;
   unit: string | null;
-}): string {
-  const amountText = ingredient.amount === null ? null : `${ingredient.amount}`;
+}, scaleFactor = 1): string {
+  const scaledAmount = scaleIngredientAmount(ingredient.amount, scaleFactor);
+  const amountText = scaledAmount === null ? null : `${scaledAmount}`;
   const unitText = ingredient.unit;
   const lead = [amountText, unitText].filter(Boolean).join(" ").trim();
   const itemText =

--- a/src/features/recipes/utils/recipeScaling.test.ts
+++ b/src/features/recipes/utils/recipeScaling.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canScaleRecipe,
+  formatScaleLabel,
+  scaleIngredientAmount,
+  scaleRecipeYield,
+} from "./recipeScaling";
+
+describe("canScaleRecipe", () => {
+  it("allows scaling when the recipe is marked scalable and has a numeric yield", () => {
+    expect(canScaleRecipe({ isScalable: true, yieldQuantity: 4 })).toBe(true);
+  });
+
+  it("blocks scaling when yield metadata is missing or fixed", () => {
+    expect(canScaleRecipe({ isScalable: true, yieldQuantity: null })).toBe(false);
+    expect(canScaleRecipe({ isScalable: false, yieldQuantity: 4 })).toBe(false);
+  });
+});
+
+describe("scaleIngredientAmount", () => {
+  it("scales ingredient amounts and preserves nulls", () => {
+    expect(scaleIngredientAmount(2, 0.5)).toBe(1);
+    expect(scaleIngredientAmount(1.333, 2)).toBe(2.67);
+    expect(scaleIngredientAmount(null, 2)).toBeNull();
+  });
+});
+
+describe("scaleRecipeYield", () => {
+  it("scales the displayed yield quantity", () => {
+    expect(scaleRecipeYield(4, 0.5)).toBe(2);
+    expect(scaleRecipeYield(3, 2)).toBe(6);
+  });
+});
+
+describe("formatScaleLabel", () => {
+  it("formats the supported shortcuts and custom multipliers", () => {
+    expect(formatScaleLabel(1)).toBe("Base");
+    expect(formatScaleLabel(0.5)).toBe("Half batch");
+    expect(formatScaleLabel(2)).toBe("Double batch");
+    expect(formatScaleLabel(1.25)).toBe("1.25x batch");
+  });
+});

--- a/src/features/recipes/utils/recipeScaling.ts
+++ b/src/features/recipes/utils/recipeScaling.ts
@@ -1,0 +1,55 @@
+import type { RecipeDetail } from "../types/recipes";
+
+export const recipeScaleOptions = [
+  { label: "Half", value: 0.5 },
+  { label: "Base", value: 1 },
+  { label: "Double", value: 2 },
+] as const;
+
+export function canScaleRecipe(
+  recipe: Pick<RecipeDetail, "isScalable" | "yieldQuantity">,
+): boolean {
+  return recipe.isScalable && recipe.yieldQuantity !== null && recipe.yieldQuantity > 0;
+}
+
+export function scaleIngredientAmount(
+  amount: number | null,
+  scaleFactor: number,
+): number | null {
+  if (amount === null) {
+    return null;
+  }
+
+  return normalizeScaledNumber(amount * scaleFactor);
+}
+
+export function scaleRecipeYield(
+  yieldQuantity: number | null,
+  scaleFactor: number,
+): number | null {
+  if (yieldQuantity === null) {
+    return null;
+  }
+
+  return normalizeScaledNumber(yieldQuantity * scaleFactor);
+}
+
+export function formatScaleLabel(scaleFactor: number): string {
+  if (scaleFactor === 1) {
+    return "Base";
+  }
+
+  if (scaleFactor === 0.5) {
+    return "Half batch";
+  }
+
+  if (scaleFactor === 2) {
+    return "Double batch";
+  }
+
+  return `${normalizeScaledNumber(scaleFactor)}x batch`;
+}
+
+function normalizeScaledNumber(value: number): number {
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
## Summary
- add a detail-page serving scale panel with half, base, and double actions for recipes that have numeric yield metadata and allow scaling
- update displayed yield and ingredient amounts client-side without mutating the saved recipe, while keeping fixed-yield recipes visibly locked
- add scaling utility coverage and extend recipe presentation tests for scaled ingredient and yield output

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No secrets added to the browser app
- Scaling is a client-side read enhancement only and does not weaken ownership or backend policy enforcement

Closes #17