### PR TITLE
feat(recipes): add per-step timer controls

### DIFF
--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -1,8 +1,12 @@
+import { useStepTimer } from "../hooks/useStepTimer";
 import {
+  formatCountdownClock,
   formatIngredientText,
   formatStepTimer,
   getRecipeCountLabel,
 } from "../utils/recipePresentation";
+
+import { RecipeStepTimerControl } from "./RecipeStepTimerControl";
 
 import type {
   RecipeEquipment,
@@ -36,6 +40,7 @@ export function RecipeDetailCollectionSection(
   props: RecipeDetailCollectionSectionProps,
 ): JSX.Element {
   const isMethod = props.kind === "steps";
+  const stepTimer = useStepTimer();
 
   return (
     <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:p-6">
@@ -148,7 +153,10 @@ export function RecipeDetailCollectionSection(
                     </p>
                     {step.timerSeconds !== null ? (
                       <span className="rounded-full border border-amber-300/70 bg-amber-50/85 px-2.5 py-1 text-xs font-medium text-amber-950">
-                        {formatStepTimer(step.timerSeconds)}
+                        {stepTimer.activeStepId === step.id &&
+                        stepTimer.remainingSeconds !== null
+                          ? `${formatCountdownClock(stepTimer.remainingSeconds)} left`
+                          : formatStepTimer(step.timerSeconds)}
                       </span>
                     ) : null}
                   </div>
@@ -156,6 +164,21 @@ export function RecipeDetailCollectionSection(
                     <p className="mt-2 text-sm leading-6 text-muted-foreground">
                       {step.notes}
                     </p>
+                  ) : null}
+                  {step.timerSeconds !== null ? (
+                    <RecipeStepTimerControl
+                      isActive={stepTimer.activeStepId === step.id}
+                      onStart={() => {
+                        stepTimer.startTimer(step.id, step.timerSeconds ?? 0);
+                      }}
+                      onStop={stepTimer.stopTimer}
+                      remainingSeconds={
+                        stepTimer.activeStepId === step.id
+                          ? stepTimer.remainingSeconds
+                          : null
+                      }
+                      timerSeconds={step.timerSeconds}
+                    />
                   ) : null}
                 </div>
               </div>

--- a/src/features/recipes/components/RecipeStepTimerControl.tsx
+++ b/src/features/recipes/components/RecipeStepTimerControl.tsx
@@ -1,0 +1,69 @@
+import { BellRing, PauseCircle, PlayCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import { formatCountdownClock } from "../utils/recipePresentation";
+
+import type { JSX } from "react";
+
+type RecipeStepTimerControlProps = {
+  isActive: boolean;
+  onStart: () => void;
+  onStop: () => void;
+  remainingSeconds: number | null;
+  timerSeconds: number;
+};
+
+export function RecipeStepTimerControl({
+  isActive,
+  onStart,
+  onStop,
+  remainingSeconds,
+  timerSeconds,
+}: RecipeStepTimerControlProps): JSX.Element {
+  const displaySeconds = isActive ? (remainingSeconds ?? timerSeconds) : timerSeconds;
+
+  return (
+    <div className="mt-3 rounded-[1.2rem] border border-amber-300/60 bg-amber-50/75 px-3 py-3 shadow-[0_12px_28px_-24px_rgba(146,104,28,0.45)]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="flex size-8 items-center justify-center rounded-full bg-amber-100 text-amber-950">
+            <BellRing className="size-4" />
+          </span>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-950/80">
+              Step timer
+            </p>
+            <p className="text-sm font-medium text-amber-950">
+              {isActive ? `${formatCountdownClock(displaySeconds)} left` : formatCountdownClock(displaySeconds)}
+            </p>
+          </div>
+        </div>
+
+        {isActive ? (
+          <Button
+            className="rounded-full px-4"
+            onClick={onStop}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <PauseCircle />
+            Stop timer
+          </Button>
+        ) : (
+          <Button
+            className="rounded-full px-4"
+            onClick={onStart}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <PlayCircle />
+            Start timer
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/recipes/hooks/useStepTimer.ts
+++ b/src/features/recipes/hooks/useStepTimer.ts
@@ -1,0 +1,55 @@
+import { useEffect, useEffectEvent, useState } from "react";
+
+type UseStepTimerReturn = {
+  activeStepId: string | null;
+  remainingSeconds: number | null;
+  startTimer: (stepId: string, seconds: number) => void;
+  stopTimer: () => void;
+};
+
+export function useStepTimer(): UseStepTimerReturn {
+  const [activeStepId, setActiveStepId] = useState<string | null>(null);
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+
+  const tick = useEffectEvent(() => {
+    setRemainingSeconds((currentRemainingSeconds) => {
+      if (currentRemainingSeconds === null) {
+        return null;
+      }
+
+      if (currentRemainingSeconds <= 1) {
+        setActiveStepId(null);
+        return null;
+      }
+
+      return currentRemainingSeconds - 1;
+    });
+  });
+
+  useEffect(() => {
+    if (activeStepId === null || remainingSeconds === null) {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      tick();
+    }, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [activeStepId, remainingSeconds]);
+
+  return {
+    activeStepId,
+    remainingSeconds,
+    startTimer: (stepId: string, seconds: number) => {
+      setActiveStepId(stepId);
+      setRemainingSeconds(seconds);
+    },
+    stopTimer: () => {
+      setActiveStepId(null);
+      setRemainingSeconds(null);
+    },
+  };
+}

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -9,6 +9,7 @@ export { RecipeDeleteDialog } from "./components/RecipeDeleteDialog";
 export { RecipeDeleteSuccessBanner } from "./components/RecipeDeleteSuccessBanner";
 export { RecipeCreateForm } from "./components/RecipeCreateForm";
 export { RecipeScalingPanel } from "./components/RecipeScalingPanel";
+export { RecipeStepTimerControl } from "./components/RecipeStepTimerControl";
 export { RecipesPage } from "./components/RecipesPage";
 export { RecipesPageContent } from "./components/RecipesPageContent";
 export { RecipesPageErrorState } from "./components/RecipesPageErrorState";
@@ -73,3 +74,4 @@ export {
   scaleIngredientAmount,
   scaleRecipeYield,
 } from "./utils/recipeScaling";
+export { useStepTimer } from "./hooks/useStepTimer";

--- a/src/features/recipes/utils/recipePresentation.test.ts
+++ b/src/features/recipes/utils/recipePresentation.test.ts
@@ -4,6 +4,7 @@ import { RecipeDataAccessError } from "../queries/recipeApi";
 
 import {
   formatIngredientText,
+  formatCountdownClock,
   formatRecipeTime,
   formatRecipeYield,
   formatStepTimer,
@@ -118,6 +119,14 @@ describe("formatStepTimer", () => {
     expect(formatStepTimer(45)).toBe("45 sec timer");
     expect(formatStepTimer(600)).toBe("10 min timer");
     expect(formatStepTimer(125)).toBe("2 min 5 sec timer");
+  });
+});
+
+describe("formatCountdownClock", () => {
+  it("formats countdown output as minutes and zero-padded seconds", () => {
+    expect(formatCountdownClock(45)).toBe("0:45");
+    expect(formatCountdownClock(125)).toBe("2:05");
+    expect(formatCountdownClock(600)).toBe("10:00");
   });
 });
 

--- a/src/features/recipes/utils/recipePresentation.ts
+++ b/src/features/recipes/utils/recipePresentation.ts
@@ -88,6 +88,13 @@ export function formatStepTimer(timerSeconds: number): string {
   return `${wholeMinutes} min ${remainingSeconds} sec timer`;
 }
 
+export function formatCountdownClock(timerSeconds: number): string {
+  const wholeMinutes = Math.floor(timerSeconds / 60);
+  const remainingSeconds = timerSeconds % 60;
+
+  return `${wholeMinutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
 export function getRecipeCountLabel(
   count: number,
   singular: string,


### PR DESCRIPTION
## Summary
- add an in-page timer control for recipe steps that already carry timer metadata, without cluttering untimed steps
- keep countdown state in a recipe-owned hook so future timer-state enhancements have a stable landing spot
- extend recipe presentation coverage for countdown clock formatting used by the step timer UI

## Testing
- npm run test
- npm run lint
- npm run build

## Data and Security Impact
- No schema change
- No secrets added to the browser app
- Timer state stays entirely client-side and does not affect ownership or backend policy enforcement

Closes #19