### PR TITLE
feat(recipes): add cook log memories

### DIFF
--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -1,0 +1,254 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { AuthSessionState } from "@/features/auth";
+
+import { isRecipeMutationAuthError } from "../queries/recipeAuth";
+import { createRecipeCookLog } from "../queries/recipeCookLogApi";
+import {
+  deleteRecipeCookLogPhoto,
+  getRecipeCookLogPhotoUrl,
+  RecipeCookLogPhotoError,
+  uploadRecipeCookLogPhoto,
+} from "../queries/recipeCookLogPhotoApi";
+import { recipeQueryKeys } from "../queries/recipeKeys";
+
+import type {
+  CreateRecipeCookLogInput,
+  RecipeCookLogEntry,
+  RecipeDetail,
+} from "../types/recipes";
+import type { JSX } from "react";
+
+type RecipeCookLogSectionProps = {
+  recipe: RecipeDetail;
+  sessionState: AuthSessionState | undefined;
+};
+
+type CookLogFeedback = {
+  description: string;
+  tone: "error" | "success";
+  title: string;
+};
+
+export function RecipeCookLogSection({
+  recipe,
+  sessionState,
+}: RecipeCookLogSectionProps): JSX.Element {
+  const queryClient = useQueryClient();
+  const cookLogMutation = useMutation<
+    RecipeCookLogEntry,
+    Error,
+    CreateRecipeCookLogInput
+  >({
+    mutationFn: (input) => createRecipeCookLog(input),
+    mutationKey: [...recipeQueryKeys.all, "cook-log", "create"] as const,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: recipeQueryKeys.detail(recipe.id),
+      });
+    },
+  });
+  const [cookedOn, setCookedOn] = useState("");
+  const [feedback, setFeedback] = useState<CookLogFeedback | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [notes, setNotes] = useState("");
+  const [selectedPhoto, setSelectedPhoto] = useState<File | null>(null);
+  const isOwner =
+    sessionState !== undefined &&
+    sessionState.kind === "authenticated" &&
+    sessionState.userId === recipe.ownerId;
+
+  return (
+    <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:p-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            Cook history
+          </p>
+          <h2 className="mt-2 font-display text-2xl tracking-[-0.03em] text-foreground sm:text-3xl">
+            Kitchen memories
+          </h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {recipe.cookLogs.length} {recipe.cookLogs.length === 1 ? "entry" : "entries"}
+        </p>
+      </div>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
+        Keep a simple record of when this recipe was cooked, what changed, and
+        how it turned out.
+      </p>
+
+      {feedback === null ? null : (
+        <div
+          className={
+            feedback.tone === "success"
+              ? "mt-5 rounded-[1.4rem] border border-emerald-300/70 bg-emerald-50/85 px-4 py-4 text-emerald-950"
+              : "mt-5 rounded-[1.4rem] border border-destructive/20 bg-destructive/5 px-4 py-4 text-foreground"
+          }
+        >
+          <p className="text-sm font-semibold">{feedback.title}</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {feedback.description}
+          </p>
+        </div>
+      )}
+
+      {isOwner ? (
+        <form
+          className="mt-5 rounded-[1.5rem] border border-border/70 bg-background/80 p-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleCreateCookLog();
+          }}
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <label>
+              <span className="text-sm font-medium text-foreground">Cooked on</span>
+              <input
+                className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                onChange={(event) => {
+                  setCookedOn(event.target.value);
+                }}
+                type="date"
+                value={cookedOn}
+              />
+            </label>
+
+            <label>
+              <span className="text-sm font-medium text-foreground">Photo</span>
+              <input
+                accept="image/jpeg,image/png,image/webp"
+                className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-full file:border-0 file:bg-primary/10 file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary focus:border-primary focus:ring-2 focus:ring-primary/20"
+                disabled={isSubmitting}
+                onChange={(event) => {
+                  setSelectedPhoto(event.target.files?.[0] ?? null);
+                }}
+                type="file"
+              />
+            </label>
+
+            <label className="md:col-span-2">
+              <span className="text-sm font-medium text-foreground">Notes</span>
+              <textarea
+                className="mt-2 min-h-28 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                onChange={(event) => {
+                  setNotes(event.target.value);
+                }}
+                placeholder="What changed, what worked, and what you want to remember next time."
+                value={notes}
+              />
+            </label>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm leading-6 text-muted-foreground">
+              {selectedPhoto === null
+                ? "No memory photo selected."
+                : `Selected photo: ${selectedPhoto.name}`}
+            </p>
+            <Button className="rounded-full px-5" disabled={isSubmitting} size="lg" type="submit">
+              {isSubmitting ? "Saving memory..." : "Save cook memory"}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      {recipe.cookLogs.length === 0 ? (
+        <div className="mt-5 rounded-[1.4rem] border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm leading-6 text-muted-foreground">
+          No cook memories were saved for this recipe yet.
+        </div>
+      ) : (
+        <ol className="mt-5 space-y-4">
+          {recipe.cookLogs.map((cookLog) => (
+            <CookLogCard key={cookLog.id} cookLog={cookLog} />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+
+  async function handleCreateCookLog(): Promise<void> {
+    setFeedback(null);
+    setIsSubmitting(true);
+
+    let uploadedPhotoPath: string | null = null;
+
+    try {
+      if (selectedPhoto !== null) {
+        uploadedPhotoPath = await uploadRecipeCookLogPhoto(selectedPhoto);
+      }
+
+      await cookLogMutation.mutateAsync({
+        cookedOn: cookedOn === "" ? null : cookedOn,
+        notes: notes.trim() === "" ? null : notes.trim(),
+        photoPath: uploadedPhotoPath,
+        recipeId: recipe.id,
+      });
+
+      setCookedOn("");
+      setNotes("");
+      setSelectedPhoto(null);
+      setFeedback({
+        description: "The cook log history has been refreshed with your latest entry.",
+        title: "Cook memory saved",
+        tone: "success",
+      });
+    } catch (error) {
+      if (uploadedPhotoPath !== null) {
+        await deleteRecipeCookLogPhoto(uploadedPhotoPath).catch(() => undefined);
+      }
+
+      setFeedback({
+        description: getCookLogErrorMessage(error),
+        title: "Cook memory could not be saved",
+        tone: "error",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+}
+
+function CookLogCard({
+  cookLog,
+}: {
+  cookLog: RecipeCookLogEntry;
+}): JSX.Element {
+  const photoUrl = getRecipeCookLogPhotoUrl(cookLog.photoPath);
+
+  return (
+    <li className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4 sm:px-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        {photoUrl !== null ? (
+          <img
+            alt={`Cook memory from ${cookLog.cookedOn}`}
+            className="aspect-[4/3] w-full rounded-[1.2rem] border border-border/70 object-cover lg:w-52"
+            src={photoUrl}
+          />
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+            {cookLog.cookedOn}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-foreground">
+            {cookLog.notes ?? "No notes were added for this cook memory."}
+          </p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function getCookLogErrorMessage(error: unknown): string {
+  if (isRecipeMutationAuthError(error) || error instanceof RecipeCookLogPhotoError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Something went wrong while saving the cook memory. Please try again.";
+}

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -1,5 +1,6 @@
 import type { AuthSessionState } from "@/features/auth";
 
+import { RecipeCookLogSection } from "./RecipeCookLogSection";
 import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
 import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
 import { RecipeScalingPanel } from "./RecipeScalingPanel";
@@ -51,6 +52,7 @@ export function RecipeDetailPageSections({
           kind="steps"
           title="Method"
         />
+        <RecipeCookLogSection recipe={recipe} sessionState={sessionState} />
       </div>
 
       <div className="lg:sticky lg:top-24">

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -6,6 +6,7 @@ export { RecipeDetailPageLoading } from "./components/RecipeDetailPageLoading";
 export { RecipeDetailPageSections } from "./components/RecipeDetailPageSections";
 export { RecipeCreateAuthPrompt } from "./components/RecipeCreateAuthPrompt";
 export { RecipeCoverImage } from "./components/RecipeCoverImage";
+export { RecipeCookLogSection } from "./components/RecipeCookLogSection";
 export { RecipeDeleteDialog } from "./components/RecipeDeleteDialog";
 export { RecipeDeleteSuccessBanner } from "./components/RecipeDeleteSuccessBanner";
 export { RecipeCreateForm } from "./components/RecipeCreateForm";
@@ -34,6 +35,16 @@ export {
   type RecipePhotoUploadErrorCode,
 } from "./queries/recipePhotoApi";
 export {
+  buildRecipeCookLogPhotoPath,
+  deleteRecipeCookLogPhoto,
+  getRecipeCookLogPhotoUrl,
+  recipeCookLogPhotoBucket,
+  RecipeCookLogPhotoError,
+  uploadRecipeCookLogPhoto,
+  validateRecipeCookLogPhoto,
+} from "./queries/recipeCookLogPhotoApi";
+export { createRecipeCookLog } from "./queries/recipeCookLogApi";
+export {
   isRecipeMutationAuthError,
   RecipeMutationAuthError,
   requireRecipeMutationAuth,
@@ -56,12 +67,14 @@ export {
   type RecipeShelfSearch,
 } from "./schemas/recipeShelfSearchSchema";
 export type {
+  CreateRecipeCookLogInput,
   CreateRecipeEquipmentInput,
   CreateRecipeIngredientInput,
   CreateRecipeInput,
   CreateRecipeStepInput,
   DeleteRecipeInput,
   DeleteRecipeResult,
+  RecipeCookLogEntry,
   RecipeDetail,
   RecipeEquipment,
   RecipeIngredient,

--- a/src/features/recipes/queries/recipeAdapters.ts
+++ b/src/features/recipes/queries/recipeAdapters.ts
@@ -1,10 +1,12 @@
 import type { Database } from "@/types/supabase";
 
 import type {
+  CreateRecipeCookLogInput,
   CreateRecipeEquipmentInput,
   CreateRecipeIngredientInput,
   CreateRecipeInput,
   CreateRecipeStepInput,
+  RecipeCookLogEntry,
   RecipeDetail,
   RecipeEquipment,
   RecipeIngredient,
@@ -22,10 +24,14 @@ type RecipeEquipmentInsert =
 type RecipeEquipmentRow = Database["public"]["Tables"]["recipe_equipment"]["Row"];
 type RecipeStepInsert = Database["public"]["Tables"]["recipe_steps"]["Insert"];
 type RecipeStepRow = Database["public"]["Tables"]["recipe_steps"]["Row"];
+type RecipeCookLogInsert =
+  Database["public"]["Tables"]["recipe_cook_logs"]["Insert"];
+export type RecipeCookLogRow = Database["public"]["Tables"]["recipe_cook_logs"]["Row"];
 
 export type RecipeListRecord = RecipeRow;
 
 export type RecipeDetailRecord = RecipeRow & {
+  recipe_cook_logs: RecipeCookLogRow[] | null;
   recipe_equipment: RecipeEquipmentRow[] | null;
   recipe_ingredients: RecipeIngredientRow[] | null;
   recipe_steps: RecipeStepRow[] | null;
@@ -87,9 +93,21 @@ export function buildRecipeStepInsertRows(
   }));
 }
 
+export function buildRecipeCookLogInsert(
+  input: CreateRecipeCookLogInput,
+): RecipeCookLogInsert {
+  return {
+    cooked_on: input.cookedOn ?? undefined,
+    notes: normalizeOptionalText(input.notes),
+    photo_path: normalizeOptionalText(input.photoPath),
+    recipe_id: input.recipeId,
+  };
+}
+
 export function mapRecipeDetailRecord(record: RecipeDetailRecord): RecipeDetail {
   return {
     ...mapRecipeListRecord(record),
+    cookLogs: sortCookLogs(record.recipe_cook_logs ?? []).map(mapRecipeCookLogRow),
     equipment: sortByPosition(record.recipe_equipment ?? []).map(
       mapRecipeEquipmentRow,
     ),
@@ -163,6 +181,19 @@ function mapRecipeStepRow(row: RecipeStepRow): RecipeStep {
   };
 }
 
+export function mapRecipeCookLogRow(row: RecipeCookLogRow): RecipeCookLogEntry {
+  return {
+    cookedOn: row.cooked_on,
+    createdAt: row.created_at,
+    id: row.id,
+    notes: row.notes,
+    ownerId: row.owner_id,
+    photoPath: row.photo_path,
+    recipeId: row.recipe_id,
+    updatedAt: row.updated_at,
+  };
+}
+
 function normalizeOptionalText(value: string | null | undefined): string | null {
   if (value === undefined || value === null) {
     return null;
@@ -179,4 +210,14 @@ function normalizeRecipeBodyText(value: string | null | undefined): string {
 
 function sortByPosition<T extends { position: number }>(items: T[]): T[] {
   return [...items].sort((left, right) => left.position - right.position);
+}
+
+function sortCookLogs<T extends { cooked_on: string; created_at: string }>(items: T[]): T[] {
+  return [...items].sort((left, right) => {
+    if (left.cooked_on === right.cooked_on) {
+      return right.created_at.localeCompare(left.created_at);
+    }
+
+    return right.cooked_on.localeCompare(left.cooked_on);
+  });
 }

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -72,6 +72,16 @@ const recipeDetailSelect = `
   cover_image_path,
   created_at,
   updated_at,
+  recipe_cook_logs (
+    id,
+    recipe_id,
+    owner_id,
+    cooked_on,
+    notes,
+    photo_path,
+    created_at,
+    updated_at
+  ),
   recipe_ingredients (
     id,
     position,

--- a/src/features/recipes/queries/recipeCookLogApi.ts
+++ b/src/features/recipes/queries/recipeCookLogApi.ts
@@ -1,0 +1,34 @@
+import { supabase } from "@/lib/supabase";
+
+import {
+  buildRecipeCookLogInsert,
+  mapRecipeCookLogRow,
+  type RecipeCookLogRow,
+} from "./recipeAdapters";
+import { requireRecipeMutationAuth } from "./recipeAuth";
+
+import type {
+  CreateRecipeCookLogInput,
+  RecipeCookLogEntry,
+} from "../types/recipes";
+
+type RecipeCookLogApiClient = NonNullable<typeof supabase>;
+
+export async function createRecipeCookLog(
+  input: CreateRecipeCookLogInput,
+  client: RecipeCookLogApiClient | null = supabase,
+): Promise<RecipeCookLogEntry> {
+  const recipeClient = await requireRecipeMutationAuth(client);
+  const { data, error } = await recipeClient
+    .from("recipe_cook_logs")
+    .insert(buildRecipeCookLogInsert(input))
+    .select("id, recipe_id, owner_id, cooked_on, notes, photo_path, created_at, updated_at")
+    .single()
+    .overrideTypes<RecipeCookLogRow, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return mapRecipeCookLogRow(data);
+}

--- a/src/features/recipes/queries/recipeCookLogPhotoApi.test.ts
+++ b/src/features/recipes/queries/recipeCookLogPhotoApi.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildRecipeCookLogPhotoPath,
+  getRecipeCookLogPhotoUrl,
+  recipeCookLogPhotoBucket,
+  RecipeCookLogPhotoError,
+  validateRecipeCookLogPhoto,
+} from "./recipeCookLogPhotoApi";
+
+describe("buildRecipeCookLogPhotoPath", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds a user-scoped storage path with a sanitized filename", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000456",
+    );
+
+    const path = buildRecipeCookLogPhotoPath(
+      "user-1",
+      new File(["photo"], "Sunday Dinner Memory.PNG", {
+        type: "image/png",
+      }),
+    );
+
+    expect(path).toBe(
+      "user-1/00000000-0000-4000-8000-000000000456-sunday-dinner-memory.png",
+    );
+  });
+});
+
+describe("validateRecipeCookLogPhoto", () => {
+  it("accepts supported image uploads under the size limit", () => {
+    expect(() => {
+      validateRecipeCookLogPhoto(
+        new File(["small"], "memory.webp", {
+          type: "image/webp",
+        }),
+      );
+    }).not.toThrow();
+  });
+
+  it("rejects unsupported file types and oversized uploads", () => {
+    expect(() => {
+      validateRecipeCookLogPhoto(
+        new File(["text"], "notes.txt", {
+          type: "text/plain",
+        }),
+      );
+    }).toThrow(RecipeCookLogPhotoError);
+
+    expect(() => {
+      validateRecipeCookLogPhoto(
+        new File([new Uint8Array(5 * 1024 * 1024 + 1)], "memory.jpg", {
+          type: "image/jpeg",
+        }),
+      );
+    }).toThrow(RecipeCookLogPhotoError);
+  });
+});
+
+describe("getRecipeCookLogPhotoUrl", () => {
+  it("builds a public URL through the configured storage bucket", () => {
+    const mockClient = {
+      storage: {
+        from: vi.fn().mockReturnValue({
+          getPublicUrl: vi.fn().mockReturnValue({
+            data: {
+              publicUrl: "https://example.com/cook-log-photo.jpg",
+            },
+          }),
+        }),
+      },
+    };
+
+    expect(
+      getRecipeCookLogPhotoUrl("user-1/cook-log-photo.jpg", mockClient as never),
+    ).toBe("https://example.com/cook-log-photo.jpg");
+    expect(mockClient.storage.from).toHaveBeenCalledWith(recipeCookLogPhotoBucket);
+  });
+
+  it("returns null when the path or client is missing", () => {
+    expect(getRecipeCookLogPhotoUrl(null, null)).toBeNull();
+  });
+});

--- a/src/features/recipes/queries/recipeCookLogPhotoApi.ts
+++ b/src/features/recipes/queries/recipeCookLogPhotoApi.ts
@@ -1,0 +1,155 @@
+import { supabase } from "@/lib/supabase";
+
+import { requireRecipeMutationAuth } from "./recipeAuth";
+
+type RecipeCookLogPhotoApiClient = NonNullable<typeof supabase>;
+
+export const recipeCookLogPhotoBucket = "recipe-cook-log-photos";
+
+const maxRecipeCookLogPhotoBytes = 5 * 1024 * 1024;
+const allowedRecipeCookLogPhotoTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+export class RecipeCookLogPhotoError extends Error {
+  readonly code:
+    | "invalid-file-type"
+    | "storage-delete-failed"
+    | "storage-unconfigured"
+    | "upload-too-large";
+
+  constructor(
+    code:
+      | "invalid-file-type"
+      | "storage-delete-failed"
+      | "storage-unconfigured"
+      | "upload-too-large",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.code = code;
+    this.name = "RecipeCookLogPhotoError";
+  }
+}
+
+export function buildRecipeCookLogPhotoPath(userId: string, file: File): string {
+  const sanitizedName = sanitizeRecipeCookLogPhotoName(file.name);
+
+  return `${userId}/${crypto.randomUUID()}-${sanitizedName}`;
+}
+
+export function getRecipeCookLogPhotoUrl(
+  photoPath: string | null,
+  client: RecipeCookLogPhotoApiClient | null = supabase,
+): string | null {
+  if (photoPath === null || client === null) {
+    return null;
+  }
+
+  return client.storage.from(recipeCookLogPhotoBucket).getPublicUrl(photoPath).data
+    .publicUrl;
+}
+
+export function validateRecipeCookLogPhoto(file: File): void {
+  if (!allowedRecipeCookLogPhotoTypes.has(file.type)) {
+    throw new RecipeCookLogPhotoError(
+      "invalid-file-type",
+      "Upload a JPG, PNG, or WebP image for the cook log photo.",
+    );
+  }
+
+  if (file.size > maxRecipeCookLogPhotoBytes) {
+    throw new RecipeCookLogPhotoError(
+      "upload-too-large",
+      "Cook log photos must stay under 5 MB.",
+    );
+  }
+}
+
+export async function uploadRecipeCookLogPhoto(
+  file: File,
+  client: RecipeCookLogPhotoApiClient | null = supabase,
+): Promise<string> {
+  validateRecipeCookLogPhoto(file);
+
+  const recipePhotoClient = await getRecipeCookLogPhotoClient(client);
+  const userId = await getRecipeCookLogPhotoUserId(recipePhotoClient);
+  const path = buildRecipeCookLogPhotoPath(userId, file);
+  const { error } = await recipePhotoClient.storage
+    .from(recipeCookLogPhotoBucket)
+    .upload(path, file, {
+      cacheControl: "3600",
+      contentType: file.type,
+      upsert: false,
+    });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return path;
+}
+
+export async function deleteRecipeCookLogPhoto(
+  photoPath: string | null,
+  client: RecipeCookLogPhotoApiClient | null = supabase,
+): Promise<void> {
+  if (photoPath === null) {
+    return;
+  }
+
+  const recipePhotoClient = await getRecipeCookLogPhotoClient(client);
+  const { error } = await recipePhotoClient.storage
+    .from(recipeCookLogPhotoBucket)
+    .remove([photoPath]);
+
+  if (error !== null) {
+    throw new RecipeCookLogPhotoError(
+      "storage-delete-failed",
+      "The uploaded cook log photo could not be cleaned up after the save failed.",
+      { cause: error },
+    );
+  }
+}
+
+async function getRecipeCookLogPhotoClient(
+  client: RecipeCookLogPhotoApiClient | null,
+): Promise<RecipeCookLogPhotoApiClient> {
+  const recipePhotoClient = await requireRecipeMutationAuth(client);
+
+  if (recipePhotoClient === null) {
+    throw new RecipeCookLogPhotoError(
+      "storage-unconfigured",
+      "Supabase is not configured for cook log photo uploads.",
+    );
+  }
+
+  return recipePhotoClient;
+}
+
+async function getRecipeCookLogPhotoUserId(
+  client: RecipeCookLogPhotoApiClient,
+): Promise<string> {
+  const { data } = await client.auth.getUser();
+
+  return data.user?.id ?? "unknown-user";
+}
+
+function sanitizeRecipeCookLogPhotoName(fileName: string): string {
+  const extension = getRecipeCookLogPhotoExtension(fileName);
+  const baseName = fileName.replace(/\.[^.]+$/, "").trim().toLowerCase();
+  const normalizedBaseName = baseName
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return `${normalizedBaseName === "" ? "cook-log-photo" : normalizedBaseName}.${extension}`;
+}
+
+function getRecipeCookLogPhotoExtension(fileName: string): string {
+  const extension = fileName.split(".").at(-1)?.toLowerCase() ?? "jpg";
+
+  return extension === "" ? "jpg" : extension;
+}

--- a/src/features/recipes/queries/recipeData.test.ts
+++ b/src/features/recipes/queries/recipeData.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildRecipeCookLogInsert,
   buildRecipeIngredientInsertRows,
   buildRecipeStepInsertRows,
   mapRecipeDetailRecord,
@@ -20,6 +21,38 @@ describe("mapRecipeDetailRecord", () => {
       is_scalable: true,
       owner_id: "owner-1",
       prep_minutes: 12,
+      recipe_cook_logs: [
+        {
+          cooked_on: "2026-03-23",
+          created_at: "2026-03-23T18:00:00.000Z",
+          id: "cook-log-2",
+          notes: "Added extra lemon juice.",
+          owner_id: "owner-1",
+          photo_path: null,
+          recipe_id: "recipe-1",
+          updated_at: "2026-03-23T18:00:00.000Z",
+        },
+        {
+          cooked_on: "2026-03-25",
+          created_at: "2026-03-25T20:00:00.000Z",
+          id: "cook-log-1",
+          notes: "Finished with parmesan.",
+          owner_id: "owner-1",
+          photo_path: "owner-1/cook-log-1.jpg",
+          recipe_id: "recipe-1",
+          updated_at: "2026-03-25T20:00:00.000Z",
+        },
+        {
+          cooked_on: "2026-03-25",
+          created_at: "2026-03-25T21:30:00.000Z",
+          id: "cook-log-3",
+          notes: "Tossed in extra pasta water.",
+          owner_id: "owner-1",
+          photo_path: null,
+          recipe_id: "recipe-1",
+          updated_at: "2026-03-25T21:30:00.000Z",
+        },
+      ],
       recipe_equipment: [
         {
           created_at: "2026-03-26T10:00:00.000Z",
@@ -100,6 +133,11 @@ describe("mapRecipeDetailRecord", () => {
     });
 
     expect(recipe.totalMinutes).toBe(30);
+    expect(recipe.cookLogs.map((item) => item.id)).toEqual([
+      "cook-log-3",
+      "cook-log-1",
+      "cook-log-2",
+    ]);
     expect(recipe.ingredients.map((item) => item.position)).toEqual([1, 2]);
     expect(recipe.equipment.map((item) => item.position)).toEqual([1, 2]);
     expect(recipe.steps.map((item) => item.position)).toEqual([1, 2]);
@@ -147,6 +185,22 @@ describe("recipe insert builders", () => {
         timer_seconds: 90,
       },
     ]);
+  });
+
+  it("normalizes cook log inserts for optional values", () => {
+    expect(
+      buildRecipeCookLogInsert({
+        cookedOn: null,
+        notes: " ",
+        photoPath: " ",
+        recipeId: "recipe-1",
+      }),
+    ).toEqual({
+      cooked_on: undefined,
+      notes: null,
+      photo_path: null,
+      recipe_id: "recipe-1",
+    });
   });
 });
 

--- a/src/features/recipes/queries/recipeQueryHelpers.test.ts
+++ b/src/features/recipes/queries/recipeQueryHelpers.test.ts
@@ -60,6 +60,7 @@ function createTestQueryClient(): QueryClient {
 function buildRecipeDetail(overrides: Partial<RecipeDetail> = {}): RecipeDetail {
   return {
     cookMinutes: 20,
+    cookLogs: [],
     coverImagePath: null,
     createdAt: "2026-03-27T10:00:00.000Z",
     description: "Silky lemon pasta with parmesan.",

--- a/src/features/recipes/types/recipes.ts
+++ b/src/features/recipes/types/recipes.ts
@@ -42,7 +42,19 @@ export type RecipeStep = {
   timerSeconds: number | null;
 };
 
+export type RecipeCookLogEntry = {
+  cookedOn: string;
+  createdAt: string;
+  id: string;
+  notes: string | null;
+  ownerId: string;
+  photoPath: string | null;
+  recipeId: string;
+  updatedAt: string;
+};
+
 export type RecipeDetail = RecipeListItem & {
+  cookLogs: RecipeCookLogEntry[];
   equipment: RecipeEquipment[];
   ingredients: RecipeIngredient[];
   steps: RecipeStep[];
@@ -82,6 +94,13 @@ export type CreateRecipeInput = {
   title: string;
   yieldQuantity?: number | null;
   yieldUnit?: string | null;
+};
+
+export type CreateRecipeCookLogInput = {
+  cookedOn?: string | null;
+  notes?: string | null;
+  photoPath?: string | null;
+  recipeId: string;
 };
 
 export type DeleteRecipeInput = {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -9,6 +9,47 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      recipe_cook_logs: {
+        Row: {
+          cooked_on: string;
+          created_at: string;
+          id: string;
+          notes: string | null;
+          owner_id: string;
+          photo_path: string | null;
+          recipe_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          cooked_on?: string;
+          created_at?: string;
+          id?: string;
+          notes?: string | null;
+          owner_id?: string;
+          photo_path?: string | null;
+          recipe_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          cooked_on?: string;
+          created_at?: string;
+          id?: string;
+          notes?: string | null;
+          owner_id?: string;
+          photo_path?: string | null;
+          recipe_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            columns: ["recipe_id"];
+            foreignKeyName: "recipe_cook_logs_recipe_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "recipes";
+          },
+        ];
+      };
       recipe_equipment: {
         Row: {
           created_at: string;

--- a/supabase/migrations/20260330235000_add_recipe_cook_logs.sql
+++ b/supabase/migrations/20260330235000_add_recipe_cook_logs.sql
@@ -1,0 +1,154 @@
+create table public.recipe_cook_logs (
+  id uuid primary key default extensions.gen_random_uuid (),
+  recipe_id uuid not null references public.recipes (id) on delete cascade,
+  owner_id uuid not null default auth.uid () references auth.users (id) on delete cascade,
+  cooked_on date not null default current_date,
+  notes text,
+  photo_path text,
+  created_at timestamptz not null default timezone ('utc', now()),
+  updated_at timestamptz not null default timezone ('utc', now()),
+  constraint recipe_cook_logs_notes_not_blank check (
+    notes is null
+    or char_length(btrim(notes)) > 0
+  ),
+  constraint recipe_cook_logs_photo_path_not_blank check (
+    photo_path is null
+    or char_length(btrim(photo_path)) > 0
+  )
+);
+
+create index recipe_cook_logs_recipe_id_cooked_on_idx on public.recipe_cook_logs (recipe_id, cooked_on desc, created_at desc);
+
+create trigger set_recipe_cook_logs_updated_at before
+update on public.recipe_cook_logs for each row
+execute function public.set_updated_at ();
+
+create trigger touch_recipe_on_cook_log_change
+after insert
+or
+update
+or delete on public.recipe_cook_logs for each row
+execute function public.touch_recipe_updated_at ();
+
+grant
+select
+  on public.recipe_cook_logs to anon,
+  authenticated;
+
+grant insert,
+update,
+delete on public.recipe_cook_logs to authenticated;
+
+alter table public.recipe_cook_logs enable row level security;
+
+create policy "Recipe cook logs are readable by everyone" on public.recipe_cook_logs for
+select
+  to anon,
+  authenticated using (true);
+
+create policy "Recipe owners can insert cook logs" on public.recipe_cook_logs for insert to authenticated
+with
+  check (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+    and exists (
+      select
+        1
+      from
+        public.recipes
+      where
+        recipes.id = recipe_cook_logs.recipe_id
+        and recipes.owner_id = (
+          select
+            auth.uid ()
+        )
+    )
+  );
+
+create policy "Recipe owners can update cook logs" on public.recipe_cook_logs
+for update
+  to authenticated using (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+  )
+with
+  check (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+  );
+
+create policy "Recipe owners can delete cook logs" on public.recipe_cook_logs for delete to authenticated using (
+  (
+    select
+      auth.uid ()
+  ) = owner_id
+);
+
+insert into
+  storage.buckets (
+    id,
+    name,
+    public,
+    file_size_limit,
+    allowed_mime_types
+  )
+values
+  (
+    'recipe-cook-log-photos',
+    'recipe-cook-log-photos',
+    true,
+    5242880,
+    array['image/jpeg', 'image/png', 'image/webp']
+  )
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+create policy "Recipe cook log photos are readable by everyone" on storage.objects for
+select
+  to anon,
+  authenticated using (bucket_id = 'recipe-cook-log-photos');
+
+create policy "Recipe owners can upload cook log photos" on storage.objects for insert to authenticated
+with
+  check (
+    bucket_id = 'recipe-cook-log-photos'
+    and (storage.foldername (name)) [1] = (
+      select
+        auth.uid ()
+    )::text
+  );
+
+create policy "Recipe owners can update cook log photos" on storage.objects
+for update
+  to authenticated using (
+    bucket_id = 'recipe-cook-log-photos'
+    and (storage.foldername (name)) [1] = (
+      select
+        auth.uid ()
+    )::text
+  )
+with
+  check (
+    bucket_id = 'recipe-cook-log-photos'
+    and (storage.foldername (name)) [1] = (
+      select
+        auth.uid ()
+    )::text
+  );
+
+create policy "Recipe owners can delete cook log photos" on storage.objects for delete to authenticated using (
+  bucket_id = 'recipe-cook-log-photos'
+  and (storage.foldername (name)) [1] = (
+    select
+      auth.uid ()
+  )::text
+);


### PR DESCRIPTION
## Summary
- add cook-log storage, RLS policies, and photo bucket support for recipe memories
- add cook-log create APIs, detail-page UI, and recipe detail query wiring
- extend recipe and Supabase types plus focused tests for cook-log mapping and photo helpers

## Validation
- npm run test
- npm run lint
- npm run build