### PR TITLE
feat(theme): add shell theme presets

### DIFF
--- a/src/components/app/AppShellFooter.tsx
+++ b/src/components/app/AppShellFooter.tsx
@@ -29,7 +29,10 @@ const footerHighlights = [
 export function AppShellFooter(): JSX.Element {
   return (
     <footer className="pb-10 pt-4 sm:pt-6">
-      <div className="overflow-hidden rounded-[2rem] border border-border/80 bg-[linear-gradient(180deg,rgba(255,253,249,0.92),rgba(246,238,226,0.92))] shadow-[0_24px_90px_-60px_rgba(69,52,35,0.55)] backdrop-blur">
+      <div
+        className="overflow-hidden rounded-[2rem] border border-border/80 shadow-[0_24px_90px_-60px_rgba(69,52,35,0.55)] backdrop-blur"
+        style={{ backgroundImage: "var(--app-shell-footer-surface)" }}
+      >
         <div className="px-5 py-6 sm:px-6">
           <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl space-y-3">

--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -4,7 +4,7 @@ import { BookOpenText, ChefHat, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 
 type AppShellHeaderProps = {
   authSummary: {
@@ -13,14 +13,19 @@ type AppShellHeaderProps = {
     ctaLabel: string;
     supportingText: string;
   };
+  themePresetPicker: ReactNode;
 };
 
 export function AppShellHeader({
   authSummary,
+  themePresetPicker,
 }: AppShellHeaderProps): JSX.Element {
   return (
     <header className="sticky top-0 z-20 pt-4 sm:pt-6">
-      <div className="overflow-hidden rounded-[2.25rem] border border-border/80 bg-[linear-gradient(135deg,rgba(255,252,246,0.92),rgba(244,236,222,0.92))] shadow-[0_28px_90px_-60px_rgba(69,52,35,0.6)] backdrop-blur">
+      <div
+        className="overflow-hidden rounded-[2.25rem] border border-border/80 shadow-[0_28px_90px_-60px_rgba(69,52,35,0.6)] backdrop-blur"
+        style={{ backgroundImage: "var(--app-shell-header-surface)" }}
+      >
         <div className="border-b border-border/60 px-5 py-3 sm:px-6">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <p className="inline-flex items-center rounded-full border border-border/70 bg-background/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
@@ -40,7 +45,10 @@ export function AppShellHeader({
                 to="/recipes"
                 className="flex items-start gap-4 rounded-[1.75rem] transition hover:opacity-90"
               >
-                <div className="flex size-14 items-center justify-center rounded-[1.5rem] bg-[linear-gradient(180deg,rgba(95,123,73,1),rgba(70,96,54,1))] text-primary-foreground shadow-[0_14px_40px_-24px_rgba(70,96,54,0.8)]">
+                <div
+                  className="flex size-14 items-center justify-center rounded-[1.5rem] text-primary-foreground shadow-[0_14px_40px_-24px_rgba(70,96,54,0.8)]"
+                  style={{ backgroundImage: "var(--app-shell-icon-gradient)" }}
+                >
                   <ChefHat className="size-6" />
                 </div>
                 <div className="space-y-1.5">
@@ -94,6 +102,8 @@ export function AppShellHeader({
                 {authSummary.supportingText}
               </p>
             </div>
+
+            {themePresetPicker}
 
             <Button asChild size="lg" className="rounded-full px-4 shadow-sm">
               <Link to="/account">

--- a/src/features/theme/components/ThemePresetPicker.tsx
+++ b/src/features/theme/components/ThemePresetPicker.tsx
@@ -1,0 +1,80 @@
+import { Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { themePresets, type ThemePresetId } from "../utils/themePresets";
+
+import type { JSX } from "react";
+
+type ThemePresetPickerProps = {
+  activeThemePresetId: ThemePresetId;
+  onThemePresetChange: (themePresetId: ThemePresetId) => void;
+};
+
+export function ThemePresetPicker({
+  activeThemePresetId,
+  onThemePresetChange,
+}: ThemePresetPickerProps): JSX.Element {
+  return (
+    <section className="rounded-[1.75rem] border border-border/70 bg-background/72 p-4 shadow-[0_18px_48px_-36px_rgba(69,52,35,0.5)]">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <Sparkles className="size-4" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+            Color mood
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Swap preset token sets without changing the recipe layout or focus
+            states.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-2">
+        {themePresets.map((themePreset) => {
+          const isActive = themePreset.id === activeThemePresetId;
+
+          return (
+            <button
+              key={themePreset.id}
+              aria-pressed={isActive}
+              className={cn(
+                "rounded-[1.35rem] border px-3 py-3 text-left transition outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/30",
+                isActive
+                  ? "border-primary/35 bg-primary/8 shadow-[0_14px_36px_-28px_rgba(69,52,35,0.45)]"
+                  : "border-border/70 bg-background/78 hover:border-primary/20 hover:bg-background",
+              )}
+              onClick={() => {
+                onThemePresetChange(themePreset.id);
+              }}
+              type="button"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {themePreset.label}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                    {themePreset.description}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  {themePreset.swatches.map((swatch) => (
+                    <span
+                      key={swatch}
+                      aria-hidden="true"
+                      className="size-3.5 rounded-full border border-white/70 shadow-sm"
+                      style={{ backgroundColor: swatch }}
+                    />
+                  ))}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/features/theme/components/ThemePresetProvider.tsx
+++ b/src/features/theme/components/ThemePresetProvider.tsx
@@ -1,0 +1,33 @@
+import { startTransition, useEffect, useState } from "react";
+
+import { ThemePresetContext } from "../context/themePresetContext";
+import { defaultThemePresetId, type ThemePresetId } from "../utils/themePresets";
+
+import type { JSX, PropsWithChildren } from "react";
+
+export function ThemePresetProvider({
+  children,
+}: PropsWithChildren): JSX.Element {
+  const [activeThemePresetId, setActiveThemePresetId] =
+    useState<ThemePresetId>(defaultThemePresetId);
+
+  useEffect(() => {
+    document.documentElement.dataset.themePreset = activeThemePresetId;
+    document.documentElement.style.colorScheme = "light";
+  }, [activeThemePresetId]);
+
+  return (
+    <ThemePresetContext.Provider
+      value={{
+        activeThemePresetId,
+        setActiveThemePresetId: (themePresetId) => {
+          startTransition(() => {
+            setActiveThemePresetId(themePresetId);
+          });
+        },
+      }}
+    >
+      {children}
+    </ThemePresetContext.Provider>
+  );
+}

--- a/src/features/theme/context/themePresetContext.ts
+++ b/src/features/theme/context/themePresetContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+
+import type { ThemePresetId } from "../utils/themePresets";
+
+export type ThemePresetContextValue = {
+  activeThemePresetId: ThemePresetId;
+  setActiveThemePresetId: (themePresetId: ThemePresetId) => void;
+};
+
+export const ThemePresetContext = createContext<ThemePresetContextValue | null>(
+  null,
+);

--- a/src/features/theme/hooks/useThemePreset.ts
+++ b/src/features/theme/hooks/useThemePreset.ts
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+
+import {
+  ThemePresetContext,
+  type ThemePresetContextValue,
+} from "../context/themePresetContext";
+
+export function useThemePreset(): ThemePresetContextValue {
+  const themePresetContext = useContext(ThemePresetContext);
+
+  if (themePresetContext === null) {
+    throw new Error("useThemePreset must be used inside ThemePresetProvider.");
+  }
+
+  return themePresetContext;
+}

--- a/src/features/theme/index.ts
+++ b/src/features/theme/index.ts
@@ -1,0 +1,11 @@
+export { ThemePresetPicker } from "./components/ThemePresetPicker";
+export { ThemePresetProvider } from "./components/ThemePresetProvider";
+export { useThemePreset } from "./hooks/useThemePreset";
+export {
+  defaultThemePresetId,
+  getThemePreset,
+  isThemePresetId,
+  themePresets,
+  type ThemePreset,
+  type ThemePresetId,
+} from "./utils/themePresets";

--- a/src/features/theme/utils/themePresets.test.ts
+++ b/src/features/theme/utils/themePresets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultThemePresetId,
+  getThemePreset,
+  isThemePresetId,
+  themePresets,
+} from "./themePresets";
+
+describe("themePresets", () => {
+  it("keeps pantry as the default preset", () => {
+    expect(defaultThemePresetId).toBe("pantry");
+    expect(themePresets[0]?.id).toBe("pantry");
+  });
+
+  it("exposes unique preset ids", () => {
+    expect(new Set(themePresets.map((preset) => preset.id)).size).toBe(
+      themePresets.length,
+    );
+  });
+});
+
+describe("getThemePreset", () => {
+  it("returns the requested preset when the id is known", () => {
+    expect(getThemePreset("garden")).toMatchObject({
+      id: "garden",
+      label: "Garden",
+    });
+  });
+
+  it("falls back to the default preset when the id is unknown", () => {
+    expect(getThemePreset("unknown")).toMatchObject({
+      id: defaultThemePresetId,
+    });
+  });
+});
+
+describe("isThemePresetId", () => {
+  it("narrows known preset ids", () => {
+    expect(isThemePresetId("pantry")).toBe(true);
+    expect(isThemePresetId("unknown")).toBe(false);
+  });
+});

--- a/src/features/theme/utils/themePresets.ts
+++ b/src/features/theme/utils/themePresets.ts
@@ -1,0 +1,56 @@
+export type ThemePresetId = "pantry" | "garden" | "citrus";
+
+export type ThemePreset = {
+  description: string;
+  id: ThemePresetId;
+  label: string;
+  swatches: [string, string, string];
+};
+
+export const defaultThemePresetId = "pantry";
+
+export const themePresets: ThemePreset[] = [
+  {
+    id: "pantry",
+    label: "Pantry",
+    description: "Warm herbs and parchment tones that keep the recipe shell calm.",
+    swatches: ["#5f7b49", "#d9aa5d", "#f4ecde"],
+  },
+  {
+    id: "garden",
+    label: "Garden",
+    description: "Soft sage and fresh greens for a lighter counter-side mood.",
+    swatches: ["#4e826f", "#acc75c", "#e7f4ed"],
+  },
+  {
+    id: "citrus",
+    label: "Citrus",
+    description: "Terracotta and preserved lemon accents with clear contrast.",
+    swatches: ["#cf7843", "#e4b851", "#f8ebdc"],
+  },
+] as const;
+
+const fallbackThemePreset = themePresets[0];
+
+if (fallbackThemePreset === undefined) {
+  throw new Error("At least one theme preset must be defined.");
+}
+
+const themePresetIds = new Set<ThemePresetId>(
+  themePresets.map((preset) => preset.id),
+);
+const themePresetsById = new Map<ThemePresetId, ThemePreset>(
+  themePresets.map((preset) => [preset.id, preset]),
+);
+
+export function getThemePreset(themePresetId: string): ThemePreset {
+  if (!isThemePresetId(themePresetId)) {
+    return fallbackThemePreset;
+  }
+
+  return themePresetsById.get(themePresetId) ?? fallbackThemePreset;
+}
+
+export function isThemePresetId(value: string): value is ThemePresetId {
+  return themePresetIds.has(value as ThemePresetId);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,159 @@
   --sidebar-accent-foreground: oklch(0.32 0.03 48);
   --sidebar-border: oklch(0.89 0.018 80);
   --sidebar-ring: oklch(0.62 0.08 150);
+  --app-body-background:
+    radial-gradient(circle at top left, rgba(116, 149, 92, 0.16), transparent 28%),
+    radial-gradient(circle at top right, rgba(217, 170, 93, 0.16), transparent 24%),
+    linear-gradient(
+      180deg,
+      rgba(255, 252, 247, 0.98) 0%,
+      rgba(247, 240, 229, 0.96) 44%,
+      rgba(252, 248, 241, 0.98) 100%
+    );
+  --app-shell-overlay:
+    radial-gradient(
+      circle at top left,
+      rgba(118, 150, 94, 0.18),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at top right,
+      rgba(220, 174, 104, 0.16),
+      transparent 24%
+    );
+  --app-shell-top-wash: linear-gradient(180deg, rgba(255, 255, 255, 0.42), transparent);
+  --app-shell-divider:
+    linear-gradient(90deg, transparent, rgba(94, 123, 73, 0.3), transparent);
+  --app-shell-header-surface:
+    linear-gradient(135deg, rgba(255, 252, 246, 0.92), rgba(244, 236, 222, 0.92));
+  --app-shell-footer-surface:
+    linear-gradient(180deg, rgba(255, 253, 249, 0.92), rgba(246, 238, 226, 0.92));
+  --app-shell-icon-gradient:
+    linear-gradient(180deg, rgba(95, 123, 73, 1), rgba(70, 96, 54, 1));
+}
+
+:root[data-theme-preset="garden"] {
+  --background: oklch(0.985 0.01 146);
+  --foreground: oklch(0.31 0.032 156);
+  --card: oklch(0.992 0.006 150);
+  --card-foreground: oklch(0.31 0.032 156);
+  --popover: oklch(0.996 0.004 150);
+  --popover-foreground: oklch(0.31 0.032 156);
+  --primary: oklch(0.47 0.085 160);
+  --primary-foreground: oklch(0.985 0.008 150);
+  --secondary: oklch(0.955 0.023 154);
+  --secondary-foreground: oklch(0.31 0.032 156);
+  --muted: oklch(0.965 0.014 150);
+  --muted-foreground: oklch(0.56 0.02 155);
+  --accent: oklch(0.935 0.034 118);
+  --accent-foreground: oklch(0.31 0.032 156);
+  --border: oklch(0.9 0.018 150);
+  --input: oklch(0.9 0.018 150);
+  --ring: oklch(0.64 0.09 160);
+  --chart-1: oklch(0.63 0.11 160);
+  --chart-2: oklch(0.8 0.08 132);
+  --chart-3: oklch(0.72 0.08 188);
+  --chart-4: oklch(0.68 0.07 82);
+  --chart-5: oklch(0.58 0.06 212);
+  --sidebar: oklch(0.99 0.006 150);
+  --sidebar-foreground: oklch(0.31 0.032 156);
+  --sidebar-primary: oklch(0.47 0.085 160);
+  --sidebar-primary-foreground: oklch(0.985 0.008 150);
+  --sidebar-accent: oklch(0.955 0.023 154);
+  --sidebar-accent-foreground: oklch(0.31 0.032 156);
+  --sidebar-border: oklch(0.9 0.018 150);
+  --sidebar-ring: oklch(0.64 0.09 160);
+  --app-body-background:
+    radial-gradient(circle at top left, rgba(87, 150, 125, 0.18), transparent 30%),
+    radial-gradient(circle at top right, rgba(191, 214, 122, 0.16), transparent 24%),
+    linear-gradient(
+      180deg,
+      rgba(248, 253, 249, 0.98) 0%,
+      rgba(237, 246, 239, 0.96) 44%,
+      rgba(248, 252, 247, 0.98) 100%
+    );
+  --app-shell-overlay:
+    radial-gradient(
+      circle at top left,
+      rgba(71, 133, 111, 0.18),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at top right,
+      rgba(174, 199, 92, 0.18),
+      transparent 24%
+    );
+  --app-shell-top-wash: linear-gradient(180deg, rgba(255, 255, 255, 0.46), transparent);
+  --app-shell-divider:
+    linear-gradient(90deg, transparent, rgba(71, 133, 111, 0.34), transparent);
+  --app-shell-header-surface:
+    linear-gradient(135deg, rgba(248, 253, 249, 0.92), rgba(231, 244, 237, 0.92));
+  --app-shell-footer-surface:
+    linear-gradient(180deg, rgba(251, 255, 252, 0.92), rgba(234, 244, 238, 0.92));
+  --app-shell-icon-gradient:
+    linear-gradient(180deg, rgba(78, 130, 111, 1), rgba(56, 96, 81, 1));
+}
+
+:root[data-theme-preset="citrus"] {
+  --background: oklch(0.986 0.01 62);
+  --foreground: oklch(0.33 0.035 36);
+  --card: oklch(0.992 0.006 60);
+  --card-foreground: oklch(0.33 0.035 36);
+  --popover: oklch(0.996 0.004 60);
+  --popover-foreground: oklch(0.33 0.035 36);
+  --primary: oklch(0.53 0.11 42);
+  --primary-foreground: oklch(0.985 0.008 70);
+  --secondary: oklch(0.958 0.024 74);
+  --secondary-foreground: oklch(0.33 0.035 36);
+  --muted: oklch(0.966 0.015 60);
+  --muted-foreground: oklch(0.58 0.02 38);
+  --accent: oklch(0.94 0.04 82);
+  --accent-foreground: oklch(0.33 0.035 36);
+  --border: oklch(0.9 0.02 58);
+  --input: oklch(0.9 0.02 58);
+  --ring: oklch(0.62 0.11 42);
+  --chart-1: oklch(0.65 0.12 42);
+  --chart-2: oklch(0.78 0.1 78);
+  --chart-3: oklch(0.69 0.08 22);
+  --chart-4: oklch(0.73 0.08 100);
+  --chart-5: oklch(0.61 0.07 210);
+  --sidebar: oklch(0.99 0.006 60);
+  --sidebar-foreground: oklch(0.33 0.035 36);
+  --sidebar-primary: oklch(0.53 0.11 42);
+  --sidebar-primary-foreground: oklch(0.985 0.008 70);
+  --sidebar-accent: oklch(0.958 0.024 74);
+  --sidebar-accent-foreground: oklch(0.33 0.035 36);
+  --sidebar-border: oklch(0.9 0.02 58);
+  --sidebar-ring: oklch(0.62 0.11 42);
+  --app-body-background:
+    radial-gradient(circle at top left, rgba(228, 143, 80, 0.18), transparent 30%),
+    radial-gradient(circle at top right, rgba(231, 196, 96, 0.16), transparent 24%),
+    linear-gradient(
+      180deg,
+      rgba(255, 250, 244, 0.98) 0%,
+      rgba(250, 239, 226, 0.96) 44%,
+      rgba(255, 247, 239, 0.98) 100%
+    );
+  --app-shell-overlay:
+    radial-gradient(
+      circle at top left,
+      rgba(210, 120, 68, 0.18),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at top right,
+      rgba(228, 184, 81, 0.18),
+      transparent 24%
+    );
+  --app-shell-top-wash: linear-gradient(180deg, rgba(255, 255, 255, 0.44), transparent);
+  --app-shell-divider:
+    linear-gradient(90deg, transparent, rgba(201, 121, 66, 0.34), transparent);
+  --app-shell-header-surface:
+    linear-gradient(135deg, rgba(255, 250, 244, 0.92), rgba(248, 235, 220, 0.92));
+  --app-shell-footer-surface:
+    linear-gradient(180deg, rgba(255, 252, 247, 0.92), rgba(247, 233, 217, 0.92));
+  --app-shell-icon-gradient:
+    linear-gradient(180deg, rgba(207, 120, 67, 1), rgba(166, 91, 51, 1));
 }
 
 .dark {
@@ -124,15 +277,7 @@
   }
   body {
     @apply bg-background text-foreground antialiased;
-    background-image:
-      radial-gradient(circle at top left, rgba(116, 149, 92, 0.16), transparent 28%),
-      radial-gradient(circle at top right, rgba(217, 170, 93, 0.16), transparent 24%),
-      linear-gradient(
-        180deg,
-        rgba(255, 252, 247, 0.98) 0%,
-        rgba(247, 240, 229, 0.96) 44%,
-        rgba(252, 248, 241, 0.98) 100%
-      );
+    background-image: var(--app-body-background);
     background-attachment: fixed;
   }
   html {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,6 +8,11 @@ import {
   sessionQueryOptions,
   type AuthSessionState,
 } from "@/features/auth";
+import {
+  ThemePresetPicker,
+  ThemePresetProvider,
+  useThemePreset,
+} from "@/features/theme";
 import { type AppRouterContext } from "@/lib/queryClient";
 
 const isDev = import.meta.env.DEV;
@@ -31,15 +36,33 @@ const ReactQueryDevtools = isDev
 function RootShell(): JSX.Element {
   const sessionQuery = useQuery(sessionQueryOptions);
   const authSummary = getAuthSummary(sessionQuery.isLoading, sessionQuery.data);
+  const { activeThemePresetId, setActiveThemePresetId } = useThemePreset();
 
   return (
     <div className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(118,150,94,0.18),transparent_30%),radial-gradient(circle_at_top_right,rgba(220,174,104,0.16),transparent_24%)]" />
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-64 bg-[linear-gradient(180deg,rgba(255,255,255,0.42),transparent)]" />
-      <div className="pointer-events-none absolute inset-x-8 top-40 h-px bg-[linear-gradient(90deg,transparent,rgba(94,123,73,0.3),transparent)]" />
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ backgroundImage: "var(--app-shell-overlay)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-64"
+        style={{ backgroundImage: "var(--app-shell-top-wash)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-x-8 top-40 h-px"
+        style={{ backgroundImage: "var(--app-shell-divider)" }}
+      />
 
       <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col px-4 sm:px-6">
-        <AppShellHeader authSummary={authSummary} />
+        <AppShellHeader
+          authSummary={authSummary}
+          themePresetPicker={
+            <ThemePresetPicker
+              activeThemePresetId={activeThemePresetId}
+              onThemePresetChange={setActiveThemePresetId}
+            />
+          }
+        />
 
         <div className="flex-1 py-4 sm:py-6">
           <Outlet />
@@ -118,7 +141,9 @@ function RootLayout(): JSX.Element {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <RootShell />
+      <ThemePresetProvider>
+        <RootShell />
+      </ThemePresetProvider>
       {TanStackRouterDevtools !== null && ReactQueryDevtools !== null ? (
         <Suspense fallback={null}>
           <TanStackRouterDevtools />


### PR DESCRIPTION
## Summary
- add a theme feature with pantry, garden, and citrus preset definitions plus a shared shell picker
- apply presets at the root shell through css variables so the header, footer, and page atmosphere update together
- keep the default pantry look intact while adding focused preset tests and shell-level wiring

## Validation
- npm run test
- npm run lint
- npm run build