### PR TITLE
fix(ux): simplify app copy

### DIFF
--- a/src/components/app/AppShellFooter.tsx
+++ b/src/components/app/AppShellFooter.tsx
@@ -7,21 +7,18 @@ import type { JSX } from "react";
 
 const footerHighlights = [
   {
-    title: "Browse first",
-    description:
-      "Keep recipe browsing open to guests so anyone can scan dinner ideas before committing to an account.",
+    title: "Browse",
+    description: "View recipes without signing in.",
     icon: Soup,
   },
   {
-    title: "Own your versions",
-    description:
-      "Recipe ownership, edits, and future cooking memories stay ready for signed-in cooks without cluttering the public flow.",
+    title: "Save",
+    description: "Use your account for recipe actions.",
     icon: NotebookText,
   },
   {
-    title: "Built for busy counters",
-    description:
-      "Readable spacing, clear sections, and mobile-friendly layout keep the experience usable while you cook.",
+    title: "Cook",
+    description: "Open recipes in a clean reading view.",
     icon: ShieldCheck,
   },
 ] as const;
@@ -37,15 +34,13 @@ export function AppShellFooter(): JSX.Element {
           <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-2xl space-y-3">
               <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-                Kitchen Notes
+                Recipe Book
               </p>
               <h2 className="font-display text-3xl leading-none tracking-[-0.03em] text-foreground">
-                A calm shell for browsing now and ownership later.
+                Keep your recipes in one place.
               </h2>
               <p className="text-sm leading-7 text-muted-foreground sm:text-base">
-                The layout stays uncluttered on a crowded counter, keeps recipe
-                discovery public, and leaves a clear place for account-driven
-                actions as the app grows.
+                Browse recipes, open details, and manage your account.
               </p>
             </div>
 
@@ -54,7 +49,7 @@ export function AppShellFooter(): JSX.Element {
                 <Link to="/recipes">Browse recipes</Link>
               </Button>
               <Button asChild size="lg" className="rounded-full px-4">
-                <Link to="/account">Account entry</Link>
+                <Link to="/account">Account</Link>
               </Button>
             </div>
           </div>
@@ -77,8 +72,7 @@ export function AppShellFooter(): JSX.Element {
           </div>
 
           <div className="mt-6 border-t border-border/60 pt-4 text-sm text-muted-foreground">
-            Designed to stay readable from a phone propped next to the cutting
-            board.
+            Simple recipe browsing and account access.
           </div>
         </div>
       </div>

--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -29,11 +29,10 @@ export function AppShellHeader({
         <div className="border-b border-border/60 px-5 py-3 sm:px-6">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <p className="inline-flex items-center rounded-full border border-border/70 bg-background/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-              Counter-ready recipe keeper
+              Recipe Book
             </p>
             <p className="text-xs leading-5 text-muted-foreground sm:text-sm">
-              Public browsing stays open now. Ownership tools can grow in place
-              later.
+              Browse recipes and manage your account.
             </p>
           </div>
         </div>
@@ -56,11 +55,10 @@ export function AppShellHeader({
                     Recipe Book
                   </p>
                   <p className="font-display text-2xl leading-none tracking-[-0.03em] text-foreground sm:text-3xl">
-                    Keep the dishes you actually cook.
+                    Recipes you want to keep.
                   </p>
                   <p className="max-w-xl text-sm leading-6 text-muted-foreground">
-                    Weeknight staples, helpful notes, and future ownership flows
-                    all sit inside one calm kitchen-ready shell.
+                    Browse, save, and revisit recipes.
                   </p>
                 </div>
               </Link>
@@ -86,7 +84,7 @@ export function AppShellHeader({
           <div className="flex flex-col gap-3 sm:max-w-sm sm:self-stretch lg:w-full lg:max-w-sm">
             <div className="rounded-[1.75rem] border border-border/70 bg-background/70 p-4 shadow-[0_18px_48px_-36px_rgba(69,52,35,0.5)]">
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-                Kitchen access
+                Account
               </p>
               <div className="mt-3 flex items-center gap-2 text-sm">
                 <span

--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -52,27 +52,23 @@ function getHeadlineText(
   switch (kind) {
     case "authenticated":
       return {
-        title: "Your account entry is ready.",
-        description:
-          "Signed-in state already feeds the shell, so recipe ownership actions can attach here without changing the public browsing flow.",
+        title: "Account",
+        description: "You are signed in.",
       };
     case "guest":
       return {
-        title: "Public browsing stays open.",
-        description:
-          "Guests can keep browsing recipes right now, and this page is where sign-in and future ownership actions will land.",
+        title: "Account",
+        description: "Sign in to manage recipes.",
       };
     case "loading":
       return {
-        title: "Checking your kitchen access.",
-        description:
-          "The app is confirming session state so the shell can show the right account treatment.",
+        title: "Account",
+        description: "Checking session status.",
       };
     case "unconfigured":
       return {
-        title: "Auth can plug in here when Supabase is ready.",
-        description:
-          "The account entry point is already part of the shell even if environment config has not been connected yet.",
+        title: "Account",
+        description: "Auth is not configured.",
       };
   }
 }
@@ -120,16 +116,12 @@ export function AccountPage(): JSX.Element {
                 <LockKeyhole className="size-5" />
               </div>
               <div>
-                <h2 className="font-medium">Shell-aware account status</h2>
+                <h2 className="font-medium">Status</h2>
                 <p className="text-sm text-muted-foreground">
                   Current state: {currentStateText}
                 </p>
               </div>
             </div>
-            <p className="mt-4 text-sm leading-6 text-muted-foreground">
-              The app shell now has a stable place for sign-in and future
-              account actions without blocking browsing routes.
-            </p>
           </div>
         </div>
       </section>
@@ -155,11 +147,10 @@ export function AccountPage(): JSX.Element {
             <Soup className="size-5" />
           </div>
           <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
-            Browse without friction
+            Recipes
           </h2>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            Recipe discovery remains public so the shell supports mixed-access
-            behavior from the beginning.
+            Browse the recipe shelf.
           </p>
           <Button asChild variant="outline" className="mt-4" size="lg">
             <Link to="/recipes">
@@ -174,12 +165,10 @@ export function AccountPage(): JSX.Element {
             <NotebookPen className="size-5" />
           </div>
           <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
-            Ownership guard behavior
+            Access
           </h2>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Public recipe routes stay open. Creating or deleting recipes still
-            requires an authenticated session, and existing UI prompts point
-            guests back here when ownership tools are needed.
+            Creating and deleting recipes requires sign-in.
           </p>
         </article>
       </section>
@@ -212,7 +201,7 @@ export function AccountPage(): JSX.Element {
         ) : (
           <>
             <AuthFormCard
-              description="Use your existing Supabase account to unlock recipe ownership actions while public browsing stays open."
+              description="Use your existing account."
               email={signInValues.email}
               isPending={signInMutation.isPending}
               onEmailChange={(event) => {
@@ -240,7 +229,7 @@ export function AccountPage(): JSX.Element {
               title="Sign in"
             />
             <AuthFormCard
-              description="Create a first-pass account so future recipe authoring and ownership flows have an authenticated foundation."
+              description="Create a new account."
               email={signUpValues.email}
               isPending={signUpMutation.isPending}
               onEmailChange={(event) => {
@@ -274,12 +263,10 @@ export function AccountPage(): JSX.Element {
       {!isConfigured ? (
         <section className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)]">
           <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-foreground">
-            Supabase auth is not configured here yet
+            Auth not configured
           </h2>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            Add the public Supabase URL and anon key to enable sign-in, sign-up,
-            and sign-out in this environment. Public recipe browsing can stay
-            available either way.
+            Add the public Supabase URL and anon key to enable sign-in.
           </p>
         </section>
       ) : null}
@@ -287,12 +274,10 @@ export function AccountPage(): JSX.Element {
       {isGuest ? (
         <section className="rounded-[1.75rem] border border-amber-300/70 bg-amber-50/80 px-5 py-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)]">
           <h2 className="font-display text-2xl leading-none tracking-[-0.02em] text-amber-950">
-            Guests can browse, but ownership still requires sign-in
+            Sign in required
           </h2>
           <p className="mt-2 text-sm leading-6 text-amber-950/85">
-            The recipe shelf and detail pages stay public, while future create,
-            edit, and delete actions will keep redirecting or prompting guests
-            here before they continue.
+            Sign in before creating or deleting recipes.
           </p>
         </section>
       ) : null}

--- a/src/features/auth/components/AuthenticatedAccountPanel.tsx
+++ b/src/features/auth/components/AuthenticatedAccountPanel.tsx
@@ -21,8 +21,8 @@ export function AuthenticatedAccountPanel({
       </h2>
       <p className="mt-2 text-sm leading-6 text-muted-foreground">
         {sessionState.email === null
-          ? "This session is ready for recipe ownership actions."
-          : `Signed in as ${sessionState.email}. Recipe create and delete flows can now rely on your authenticated session.`}
+          ? "You can manage recipes."
+          : `Signed in as ${sessionState.email}.`}
       </p>
       <Button className="mt-5 w-full rounded-[1rem]" disabled={isPending} onClick={onSignOut} size="lg">
         {isPending ? "Signing out..." : "Sign out"}

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -44,11 +44,10 @@ export function CreateRecipePage(): JSX.Element {
             Recipe Authoring
           </p>
           <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-            Checking kitchen access
+            Loading
           </h1>
           <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
-            The app is confirming session state before it shows owner-only
-            authoring tools.
+            Checking session status.
           </p>
         </section>
       </main>
@@ -123,12 +122,10 @@ export function CreateRecipePage(): JSX.Element {
           Recipe Authoring
         </p>
         <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-          Build a recipe without losing the cooking flow.
+          Create recipe
         </h1>
         <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-          Capture the basics first, then stack ingredients, equipment, and
-          ordered steps in one pass. Successful saves land on the new detail
-          page immediately.
+          Add the recipe details and save when you are ready.
         </p>
       </section>
 

--- a/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
+++ b/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
@@ -50,7 +50,7 @@ function getAuthPromptCopy(
     return {
       ctaLabel: "Sign in to continue",
       description:
-        "Recipe creation is an owner-only flow. Public browsing stays open, but you need an authenticated account before you can add basics, ingredients, equipment, and steps.",
+        "You need to sign in before creating a recipe.",
       title: "Sign in before creating a recipe",
     };
   }
@@ -58,7 +58,7 @@ function getAuthPromptCopy(
   return {
     ctaLabel: "Review account setup",
     description:
-      "This environment can browse public recipes, but Supabase auth is not configured yet, so owner-only authoring tools cannot submit safely.",
-    title: "Auth setup is still required",
+      "Auth is not configured in this environment.",
+    title: "Auth setup required",
   };
 }

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -133,8 +133,8 @@ function getOwnerActionState(
       ctaTo: "/recipes",
       ctaVariant: "outline",
       description:
-        "Ownership tools stay separate from the public reading view, and the app is checking whether this recipe belongs to you.",
-      title: "Checking kitchen access",
+        "Checking access for this recipe.",
+      title: "Checking access",
     };
   }
 
@@ -144,8 +144,8 @@ function getOwnerActionState(
       ctaTo: "/account",
       ctaVariant: "default",
       description:
-        "Anyone can read this recipe. Sign in from the account area before future create, edit, or delete actions become available.",
-      title: "Sign in for ownership tools",
+        "Sign in to manage recipes.",
+      title: "Sign in required",
     };
   }
 
@@ -155,8 +155,8 @@ function getOwnerActionState(
       ctaTo: "/account",
       ctaVariant: "outline",
       description:
-        "Public reading is still available, but ownership controls cannot light up until Supabase auth is configured for this environment.",
-      title: "Auth setup still needed",
+        "Auth is not configured in this environment.",
+      title: "Auth setup needed",
     };
   }
 
@@ -166,7 +166,7 @@ function getOwnerActionState(
       ctaTo: "/account",
       ctaVariant: "outline",
       description:
-        "This recipe belongs to you. Owner-only controls are intentionally separated here so edit and delete flows can land without disturbing the cooking view.",
+        "You can manage this recipe.",
       title: "You own this recipe",
     };
   }
@@ -176,7 +176,7 @@ function getOwnerActionState(
     ctaTo: "/recipes",
     ctaVariant: "outline",
     description:
-      "This recipe belongs to another cook. Public reading stays open, while any ownership actions remain private to the signed-in owner.",
+      "This recipe belongs to another account.",
     title: "Public view only",
   };
 }

--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -13,8 +13,8 @@ export function RecipesPageHeader({
 }: RecipesPageHeaderProps): JSX.Element {
   const countLabel =
     recipeCount === undefined
-      ? "Public browsing"
-      : `${recipeCount} ${recipeCount === 1 ? "recipe" : "recipes"} ready`;
+      ? "Browse recipes"
+      : `${recipeCount} ${recipeCount === 1 ? "recipe" : "recipes"}`;
 
   return (
     <section className="grid gap-4 xl:grid-cols-[1.3fr_0.7fr]">
@@ -23,11 +23,10 @@ export function RecipesPageHeader({
           Recipe Shelf
         </p>
         <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-          Find dinner ideas without the usual kitchen clutter.
+          Recipes
         </h1>
         <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-          Browse every public recipe in one calm list, then step into the detail
-          route when you want the fuller read.
+          Browse recipes and open the ones you want to cook.
         </p>
         <div className="mt-6 flex flex-wrap gap-2">
           <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-primary">
@@ -49,34 +48,31 @@ export function RecipesPageHeader({
 
       <aside className="rounded-[2rem] border border-border/70 bg-background/85 p-6 shadow-[0_20px_60px_-44px_rgba(69,52,35,0.5)]">
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-          What This View Covers
+          Quick Notes
         </p>
         <div className="mt-4 space-y-4">
           <div>
             <p className="text-sm font-semibold text-foreground">
-              Loading, empty, and error states stay explicit.
+              Public recipes
             </p>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              The shelf keeps its footing whether recipe data is still loading,
-              missing, or temporarily unavailable.
+              Browse without signing in.
             </p>
           </div>
           <div>
             <p className="text-sm font-semibold text-foreground">
-              The layout leaves room for search later.
+              Create recipes
             </p>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              This first pass stays intentionally lean so filtering can arrive
-              later without redesigning the route.
+              Available from the same shelf.
             </p>
           </div>
           <div>
             <p className="text-sm font-semibold text-foreground">
-              Authoring now has a dedicated route.
+              Read on any screen
             </p>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              The create flow stays behind auth, while guests can still follow
-              the same entry point and get routed toward sign-in guidance.
+              Works on desktop and mobile.
             </p>
           </div>
         </div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -89,8 +89,7 @@ function getAuthSummary(
         "border border-border/70 bg-background/85 text-muted-foreground",
       badgeText: "Checking access",
       ctaLabel: "Account",
-      supportingText:
-        "Public recipe browsing stays open while session state loads.",
+      supportingText: "Loading account status.",
     };
   }
 
@@ -100,7 +99,7 @@ function getAuthSummary(
         "border border-amber-300/70 bg-amber-50/85 text-amber-950",
       badgeText: "Guest browsing",
       ctaLabel: "Sign in",
-      supportingText: "Browse freely now and unlock recipe ownership later.",
+      supportingText: "Sign in to manage recipes.",
     };
   }
 
@@ -112,8 +111,7 @@ function getAuthSummary(
         badgeText:
           sessionState.email === null ? "Signed in" : sessionState.email,
         ctaLabel: "Account",
-        supportingText:
-          "Recipe ownership actions can grow from this account entry point.",
+        supportingText: "You can manage recipes from your account.",
       };
     case "guest":
       return {
@@ -121,8 +119,7 @@ function getAuthSummary(
           "border border-amber-300/80 bg-amber-50/90 text-amber-950",
         badgeText: "Guest browsing",
         ctaLabel: "Sign in",
-        supportingText:
-          "Guests can browse recipes without barriers and sign in when they need ownership tools.",
+        supportingText: "Browse recipes or sign in.",
       };
     case "unconfigured":
       return {
@@ -130,8 +127,7 @@ function getAuthSummary(
           "border border-border/70 bg-background/85 text-muted-foreground",
         badgeText: "Auth setup needed",
         ctaLabel: "Account",
-        supportingText:
-          "The account area is ready even when Supabase auth is not configured yet.",
+        supportingText: "Auth is not configured in this environment.",
       };
   }
 }


### PR DESCRIPTION
## Summary
- shorten the shell, account, and recipe page copy so the app feels less verbose
- replace explanatory filler with direct status text and simpler headings
- keep the existing flows intact while reducing the landing-page style narration

## Validation
- npm run test
- npm run lint
- npm run build