### PR TITLE
fix(recipes): render create page route

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as RecipesRouteImport } from './routes/recipes'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as RecipesIndexRouteImport } from './routes/recipes.index'
 import { Route as RecipesNewRouteImport } from './routes/recipes.new'
 import { Route as RecipesRecipeIdRouteImport } from './routes/recipes.$recipeId'
 
@@ -30,6 +31,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RecipesIndexRoute = RecipesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => RecipesRoute,
+} as any)
 const RecipesNewRoute = RecipesNewRouteImport.update({
   id: '/new',
   path: '/new',
@@ -47,13 +53,14 @@ export interface FileRoutesByFullPath {
   '/recipes': typeof RecipesRouteWithChildren
   '/recipes/$recipeId': typeof RecipesRecipeIdRoute
   '/recipes/new': typeof RecipesNewRoute
+  '/recipes/': typeof RecipesIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
-  '/recipes': typeof RecipesRouteWithChildren
   '/recipes/$recipeId': typeof RecipesRecipeIdRoute
   '/recipes/new': typeof RecipesNewRoute
+  '/recipes': typeof RecipesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -62,6 +69,7 @@ export interface FileRoutesById {
   '/recipes': typeof RecipesRouteWithChildren
   '/recipes/$recipeId': typeof RecipesRecipeIdRoute
   '/recipes/new': typeof RecipesNewRoute
+  '/recipes/': typeof RecipesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -71,8 +79,9 @@ export interface FileRouteTypes {
     | '/recipes'
     | '/recipes/$recipeId'
     | '/recipes/new'
+    | '/recipes/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/account' | '/recipes' | '/recipes/$recipeId' | '/recipes/new'
+  to: '/' | '/account' | '/recipes/$recipeId' | '/recipes/new' | '/recipes'
   id:
     | '__root__'
     | '/'
@@ -80,6 +89,7 @@ export interface FileRouteTypes {
     | '/recipes'
     | '/recipes/$recipeId'
     | '/recipes/new'
+    | '/recipes/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -111,6 +121,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/recipes/': {
+      id: '/recipes/'
+      path: '/'
+      fullPath: '/recipes/'
+      preLoaderRoute: typeof RecipesIndexRouteImport
+      parentRoute: typeof RecipesRoute
+    }
     '/recipes/new': {
       id: '/recipes/new'
       path: '/new'
@@ -131,11 +148,13 @@ declare module '@tanstack/react-router' {
 interface RecipesRouteChildren {
   RecipesRecipeIdRoute: typeof RecipesRecipeIdRoute
   RecipesNewRoute: typeof RecipesNewRoute
+  RecipesIndexRoute: typeof RecipesIndexRoute
 }
 
 const RecipesRouteChildren: RecipesRouteChildren = {
   RecipesRecipeIdRoute: RecipesRecipeIdRoute,
   RecipesNewRoute: RecipesNewRoute,
+  RecipesIndexRoute: RecipesIndexRoute,
 }
 
 const RecipesRouteWithChildren =

--- a/src/routes/recipes.index.tsx
+++ b/src/routes/recipes.index.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import {
+  preloadRecipeList,
+  recipeShelfSearchSchema,
+  RecipesPage,
+  RecipesPageErrorState,
+  RecipesPageLoading,
+} from "@/features/recipes";
+
+import type { JSX } from "react";
+
+function RecipesIndexRouteComponent(): JSX.Element {
+  const search = Route.useSearch();
+
+  return <RecipesPage showDeletedBanner={search.deleted === "1"} />;
+}
+
+export const Route = createFileRoute("/recipes/")({
+  loader: ({ context }) => preloadRecipeList(context.queryClient),
+  validateSearch: recipeShelfSearchSchema,
+  component: RecipesIndexRouteComponent,
+  errorComponent: RecipesPageErrorState,
+  pendingComponent: RecipesPageLoading,
+  pendingMs: 0,
+});

--- a/src/routes/recipes.tsx
+++ b/src/routes/recipes.tsx
@@ -1,26 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
-
-import {
-  preloadRecipeList,
-  recipeShelfSearchSchema,
-  RecipesPage,
-  RecipesPageErrorState,
-  RecipesPageLoading,
-} from "@/features/recipes";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 import type { JSX } from "react";
 
-function RecipesRouteComponent(): JSX.Element {
-  const search = Route.useSearch();
-
-  return <RecipesPage showDeletedBanner={search.deleted === "1"} />;
+function RecipesLayoutRoute(): JSX.Element {
+  return <Outlet />;
 }
 
 export const Route = createFileRoute("/recipes")({
-  loader: ({ context }) => preloadRecipeList(context.queryClient),
-  validateSearch: recipeShelfSearchSchema,
-  component: RecipesRouteComponent,
-  errorComponent: RecipesPageErrorState,
-  pendingComponent: RecipesPageLoading,
-  pendingMs: 0,
+  component: RecipesLayoutRoute,
 });


### PR DESCRIPTION
## Summary
- convert /recipes into a layout route so nested recipe pages can render through an outlet
- move the recipe shelf page to a dedicated /recipes index route
- refresh the generated route tree so /recipes/new resolves to the create page instead of disappearing behind the parent route

## Validation
- npm run test
- npm run lint
- npm run build