### PR TITLE
fix(layout): widen app shell surfaces

### DIFF
--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -97,7 +97,7 @@ export function AccountPage(): JSX.Element {
   const isConfigured = sessionQuery.data?.kind !== "unconfigured";
 
   return (
-    <main className="mx-auto flex max-w-4xl flex-col gap-4 py-4 sm:py-6">
+    <main className="mx-auto flex w-full max-w-[76rem] flex-col gap-4 py-4 sm:py-6">
       <section className="rounded-[1.75rem] border border-border/80 bg-card/95 px-5 py-6 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:px-6">
         <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
           Account

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -38,7 +38,7 @@ export function CreateRecipePage(): JSX.Element {
 
   if (sessionQuery.isLoading) {
     return (
-      <main className="mx-auto max-w-4xl py-6">
+      <main className="mx-auto w-full max-w-[84rem] py-6">
         <section className="rounded-[2rem] border border-border/80 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
           <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
             Recipe Authoring
@@ -116,7 +116,7 @@ export function CreateRecipePage(): JSX.Element {
   }
 
   return (
-    <main className="mx-auto max-w-5xl py-6">
+    <main className="mx-auto w-full max-w-[84rem] py-6">
       <section className="rounded-[2rem] border border-border/80 bg-[radial-gradient(circle_at_top_left,rgba(95,123,73,0.16),transparent_24%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
         <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
           Recipe Authoring

--- a/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
+++ b/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
@@ -15,7 +15,7 @@ export function RecipeCreateAuthPrompt({
   const copy = getAuthPromptCopy(sessionState);
 
   return (
-    <main className="mx-auto max-w-4xl py-6">
+    <main className="mx-auto w-full max-w-[84rem] py-6">
       <section className="rounded-[2rem] border border-border/80 bg-[radial-gradient(circle_at_top_left,rgba(217,170,93,0.18),transparent_24%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
         <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
           Recipe Authoring

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -29,7 +29,7 @@ export function RecipeDetailPage({
   const recipe = recipeDetailQuery.data;
 
   return (
-    <main className="mx-auto flex max-w-5xl flex-col gap-6 py-6">
+    <main className="mx-auto flex w-full max-w-[84rem] flex-col gap-6 py-6">
       <RecipeDetailHero recipe={recipe} scaleFactor={scaleFactor} />
       <RecipeDetailPageSections
         isSessionLoading={sessionQuery.isLoading}

--- a/src/features/recipes/components/RecipeDetailPageErrorState.tsx
+++ b/src/features/recipes/components/RecipeDetailPageErrorState.tsx
@@ -13,7 +13,7 @@ export function RecipeDetailPageErrorState({
   const copy = getRecipeLoadErrorCopy(error, "detail");
 
   return (
-    <main className="mx-auto flex max-w-5xl flex-col gap-6 py-6">
+    <main className="mx-auto flex w-full max-w-[84rem] flex-col gap-6 py-6">
       <div className="flex flex-wrap items-center gap-3">
         <Button asChild variant="ghost" size="lg" className="rounded-full px-4">
           <Link to="/recipes">Back to recipe shelf</Link>

--- a/src/features/recipes/components/RecipeDetailPageLoading.tsx
+++ b/src/features/recipes/components/RecipeDetailPageLoading.tsx
@@ -2,7 +2,7 @@ import type { JSX } from "react";
 
 export function RecipeDetailPageLoading(): JSX.Element {
   return (
-    <main className="mx-auto flex max-w-5xl flex-col gap-6 py-6">
+    <main className="mx-auto flex w-full max-w-[84rem] flex-col gap-6 py-6">
       <div aria-hidden="true" className="animate-pulse space-y-6">
         <div className="h-10 w-44 rounded-full bg-muted" />
         <div className="rounded-[2rem] border border-border/70 bg-card/90 p-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)]">

--- a/src/features/recipes/components/RecipesPage.tsx
+++ b/src/features/recipes/components/RecipesPage.tsx
@@ -25,7 +25,7 @@ export function RecipesPage({
   const recipes = recipeListQuery.data;
 
   return (
-    <main className="mx-auto flex max-w-6xl flex-col gap-6 py-6">
+    <main className="mx-auto flex w-full max-w-[92rem] flex-col gap-6 py-6">
       <RecipesPageHeader recipeCount={recipes.length} />
       {showDeletedBanner ? <RecipeDeleteSuccessBanner /> : null}
       <RecipesPageContent recipes={recipes} />

--- a/src/features/recipes/components/RecipesPageErrorState.tsx
+++ b/src/features/recipes/components/RecipesPageErrorState.tsx
@@ -15,7 +15,7 @@ export function RecipesPageErrorState({
   const copy = getRecipeLoadErrorCopy(error, "list");
 
   return (
-    <main className="mx-auto flex max-w-6xl flex-col gap-6 py-6">
+    <main className="mx-auto flex w-full max-w-[92rem] flex-col gap-6 py-6">
       <RecipesPageHeader />
       <section className="rounded-[2rem] border border-destructive/20 bg-destructive/5 px-6 py-8 shadow-[0_20px_60px_-48px_rgba(120,53,15,0.45)] sm:px-8">
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-destructive">

--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -17,7 +17,7 @@ export function RecipesPageHeader({
       : `${recipeCount} ${recipeCount === 1 ? "recipe" : "recipes"}`;
 
   return (
-    <section className="grid gap-4 xl:grid-cols-[1.3fr_0.7fr]">
+    <section className="grid gap-4 2xl:grid-cols-[minmax(0,1.5fr)_minmax(24rem,0.75fr)]">
       <div className="rounded-[2rem] border border-border/70 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
         <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
           Recipe Shelf
@@ -25,7 +25,7 @@ export function RecipesPageHeader({
         <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
           Recipes
         </h1>
-        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+        <p className="mt-4 max-w-4xl text-sm leading-7 text-muted-foreground sm:text-base">
           Browse recipes and open the ones you want to cook.
         </p>
         <div className="mt-6 flex flex-wrap gap-2">

--- a/src/features/recipes/components/RecipesPageLoading.tsx
+++ b/src/features/recipes/components/RecipesPageLoading.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function RecipesPageLoading(): JSX.Element {
   return (
-    <main className="mx-auto flex max-w-6xl flex-col gap-6 py-6">
+    <main className="mx-auto flex w-full max-w-[92rem] flex-col gap-6 py-6">
       <RecipesPageHeader />
       <section aria-hidden="true" className="grid gap-4">
         {Array.from({ length: 3 }, (_, index) => (

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -50,7 +50,7 @@ function RootShell(): JSX.Element {
         style={{ backgroundImage: "var(--app-shell-divider)" }}
       />
 
-      <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col px-4 sm:px-6">
+      <div className="relative mx-auto flex min-h-screen w-full max-w-[92rem] flex-col px-4 sm:px-6 lg:px-8">
         <AppShellHeader authSummary={authSummary} />
 
         <div className="flex-1 py-4 sm:py-6">


### PR DESCRIPTION
## Summary
- widen the shared shell container so desktop pages use more of the viewport
- expand the main recipe, detail, create, and account page containers
- loosen the recipe shelf header layout so it feels less constrained on large screens

## Testing
- npm run test
- npm run lint
- npm run build

Closes #47