### PR TITLE
fix(layout): simplify the app shell

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { BookOpenText, ChefHat, UserRound } from "lucide-react";
+import { BookOpenText, UserRound } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -19,93 +19,58 @@ export function AppShellHeader({
   authSummary,
 }: AppShellHeaderProps): JSX.Element {
   return (
-    <header className="sticky top-0 z-20 pt-4 sm:pt-6">
-      <div
-        className="overflow-hidden rounded-[2.25rem] border border-border/80 shadow-[0_28px_90px_-60px_rgba(69,52,35,0.6)] backdrop-blur"
-        style={{ backgroundImage: "var(--app-shell-header-surface)" }}
-      >
-        <div className="border-b border-border/60 px-5 py-3 sm:px-6">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <p className="inline-flex items-center rounded-full border border-border/70 bg-background/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-              Recipe Book
-            </p>
-            <p className="text-xs leading-5 text-muted-foreground sm:text-sm">
-              Browse recipes and manage your account.
-            </p>
-          </div>
-        </div>
+    <header className="sticky top-0 z-20 border-b border-border/70 bg-background/88 backdrop-blur">
+      <div className="flex min-h-16 flex-wrap items-center justify-between gap-3 py-3">
+        <div className="flex min-w-0 items-center gap-6">
+          <Link
+            to="/recipes"
+            className="min-w-0 transition hover:opacity-90"
+          >
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold tracking-[0.08em] text-foreground uppercase">
+                  Recipe Book
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Recipes you want to keep.
+                </p>
+              </div>
+            </div>
+          </Link>
 
-        <div className="flex flex-col gap-5 px-5 py-5 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
+          <nav className="flex flex-wrap items-center gap-2">
+            <Button asChild variant="ghost" size="sm" className="h-9 rounded-md px-3">
               <Link
                 to="/recipes"
-                className="flex items-start gap-4 rounded-[1.75rem] transition hover:opacity-90"
+                activeProps={{
+                  className: "bg-accent text-accent-foreground",
+                }}
               >
-                <div
-                  className="flex size-14 items-center justify-center rounded-[1.5rem] text-primary-foreground shadow-[0_14px_40px_-24px_rgba(70,96,54,0.8)]"
-                  style={{ backgroundImage: "var(--app-shell-icon-gradient)" }}
-                >
-                  <ChefHat className="size-6" />
-                </div>
-                <div className="space-y-1.5">
-                  <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-                    Recipe Book
-                  </p>
-                  <p className="font-display text-2xl leading-none tracking-[-0.03em] text-foreground sm:text-3xl">
-                    Recipes you want to keep.
-                  </p>
-                  <p className="max-w-xl text-sm leading-6 text-muted-foreground">
-                    Browse, save, and revisit recipes.
-                  </p>
-                </div>
-              </Link>
-            </div>
-
-            <nav className="flex flex-wrap items-center gap-2">
-              <Button asChild variant="ghost" size="lg" className="rounded-full px-4">
-                <Link
-                  to="/recipes"
-                  activeProps={{
-                    className:
-                      "border border-primary/20 bg-primary text-primary-foreground shadow-sm",
-                  }}
-                  className="border border-border/70 bg-background/70"
-                >
-                  <BookOpenText />
-                  Recipe shelf
-                </Link>
-              </Button>
-            </nav>
-          </div>
-
-          <div className="flex flex-col gap-3 sm:max-w-sm sm:self-stretch lg:w-full lg:max-w-sm">
-            <div className="rounded-[1.75rem] border border-border/70 bg-background/70 p-4 shadow-[0_18px_48px_-36px_rgba(69,52,35,0.5)]">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-                Account
-              </p>
-              <div className="mt-3 flex items-center gap-2 text-sm">
-                <span
-                  className={cn(
-                    "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium",
-                    authSummary.badgeClassName,
-                  )}
-                >
-                  {authSummary.badgeText}
-                </span>
-              </div>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                {authSummary.supportingText}
-              </p>
-            </div>
-
-            <Button asChild size="lg" className="rounded-full px-4 shadow-sm">
-              <Link to="/account">
-                <UserRound />
-                {authSummary.ctaLabel}
+                <BookOpenText className="size-4" />
+                Recipes
               </Link>
             </Button>
-          </div>
+          </nav>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium",
+              authSummary.badgeClassName,
+            )}
+          >
+            {authSummary.badgeText}
+          </span>
+          <p className="hidden text-sm text-muted-foreground xl:block">
+            {authSummary.supportingText}
+          </p>
+          <Button asChild size="sm" className="h-9 rounded-md px-3 shadow-sm">
+            <Link to="/account">
+              <UserRound className="size-4" />
+              {authSummary.ctaLabel}
+            </Link>
+          </Button>
         </div>
       </div>
     </header>

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -1,2 +1,1 @@
-export { AppShellFooter } from "./AppShellFooter";
 export { AppShellHeader } from "./AppShellHeader";

--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -68,10 +68,7 @@ export function RecipePreviewCard({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-4">
-          <p className="text-sm leading-6 text-muted-foreground">
-            Open the detail route for the fuller read while cooking.
-          </p>
+        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-border/70 pt-4">
           <Button asChild variant="outline" size="lg" className="rounded-full px-4">
             <Link to="/recipes/$recipeId" params={{ recipeId: recipe.id }}>
               Open recipe

--- a/src/features/recipes/components/RecipesEmptyState.tsx
+++ b/src/features/recipes/components/RecipesEmptyState.tsx
@@ -4,16 +4,15 @@ import type { JSX } from "react";
 
 export function RecipesEmptyState(): JSX.Element {
   return (
-    <section className="rounded-[2rem] border border-dashed border-border/80 bg-background/80 px-6 py-10 text-center shadow-[0_20px_60px_-48px_rgba(69,52,35,0.5)] sm:px-8">
-      <div className="mx-auto flex size-14 items-center justify-center rounded-[1.4rem] bg-primary/10 text-primary">
+    <section className="border border-dashed border-border/80 px-6 py-12 text-center sm:px-8">
+      <div className="mx-auto flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
         <NotebookText className="size-6" />
       </div>
-      <h2 className="mt-5 font-display text-3xl tracking-[-0.03em] text-foreground">
-        The recipe shelf is empty for now.
+      <h2 className="mt-4 font-display text-3xl tracking-[-0.03em] text-foreground">
+        No recipes yet.
       </h2>
       <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
-        When public recipes are added, they will appear here with quick-scanning
-        cards and links into their detail view.
+        Recipes will show up here when they are added.
       </p>
     </section>
   );

--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -17,66 +17,29 @@ export function RecipesPageHeader({
       : `${recipeCount} ${recipeCount === 1 ? "recipe" : "recipes"}`;
 
   return (
-    <section className="grid gap-4 2xl:grid-cols-[minmax(0,1.5fr)_minmax(24rem,0.75fr)]">
-      <div className="rounded-[2rem] border border-border/70 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-          Recipe Shelf
-        </p>
-        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-          Recipes
-        </h1>
-        <p className="mt-4 max-w-4xl text-sm leading-7 text-muted-foreground sm:text-base">
-          Browse recipes and open the ones you want to cook.
-        </p>
-        <div className="mt-6 flex flex-wrap gap-2">
+    <section className="border-b border-border/70 pb-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+            Recipe Shelf
+          </p>
+          <h1 className="mt-2 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+            Recipes
+          </h1>
+          <p className="mt-3 text-sm leading-7 text-muted-foreground sm:text-base">
+            Browse recipes and open the ones you want to cook.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
           <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-primary">
             {countLabel}
           </span>
-          <span className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
-            No sign-in required
-          </span>
-          <span className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
-            Mobile-friendly reading
-          </span>
-        </div>
-        <div className="mt-6">
-          <Button asChild size="lg" className="rounded-full px-5">
-            <Link to="/recipes/new">Create a recipe</Link>
+          <Button asChild size="lg" className="rounded-md px-4">
+            <Link to="/recipes/new">Create recipe</Link>
           </Button>
         </div>
       </div>
-
-      <aside className="rounded-[2rem] border border-border/70 bg-background/85 p-6 shadow-[0_20px_60px_-44px_rgba(69,52,35,0.5)]">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-          Quick Notes
-        </p>
-        <div className="mt-4 space-y-4">
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              Public recipes
-            </p>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Browse without signing in.
-            </p>
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              Create recipes
-            </p>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Available from the same shelf.
-            </p>
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              Read on any screen
-            </p>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Works on desktop and mobile.
-            </p>
-          </div>
-        </div>
-      </aside>
     </section>
   );
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,7 +2,7 @@ import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
 import { lazy, Suspense, type JSX } from "react";
 
-import { AppShellFooter, AppShellHeader } from "@/components/app";
+import { AppShellHeader } from "@/components/app";
 import {
   preloadSessionState,
   sessionQueryOptions,
@@ -36,7 +36,7 @@ function RootShell(): JSX.Element {
   const authSummary = getAuthSummary(sessionQuery.isLoading, sessionQuery.data);
 
   return (
-    <div className="relative min-h-screen overflow-hidden">
+    <div className="relative min-h-screen overflow-hidden bg-background">
       <div
         className="pointer-events-none absolute inset-0"
         style={{ backgroundImage: "var(--app-shell-overlay)" }}
@@ -56,8 +56,6 @@ function RootShell(): JSX.Element {
         <div className="flex-1 py-4 sm:py-6">
           <Outlet />
         </div>
-
-        <AppShellFooter />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the oversized shell card header with a standard sticky app header
- remove the shell footer surface and simplify the recipe shelf header and empty state
- keep cards focused on actual recipe content instead of repeated informational panels

## Testing
- npm run test
- npm run lint
- npm run build

Closes #53