### PR TITLE
fix(recipes): reset removed cover photo input

### DIFF
--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -33,6 +33,7 @@ export function CreateRecipePage(): JSX.Element {
   const createRecipeMutation = useMutation(createRecipeMutationOptions(queryClient));
   const [feedback, setFeedback] = useState<FormFeedback | null>(null);
   const [selectedCoverPhoto, setSelectedCoverPhoto] = useState<File | null>(null);
+  const [coverPhotoInputResetKey, setCoverPhotoInputResetKey] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [values, setValues] = useState(createEmptyRecipeCreateFormValues);
 
@@ -141,6 +142,7 @@ export function CreateRecipePage(): JSX.Element {
       <div className="mt-6">
         <RecipeCreateForm
           coverPhotoName={selectedCoverPhoto?.name ?? null}
+          coverPhotoInputResetKey={coverPhotoInputResetKey}
           isPending={isSubmitting}
           isPhotoAttached={selectedCoverPhoto !== null}
           onCoverPhotoChange={(file) => {
@@ -148,6 +150,7 @@ export function CreateRecipePage(): JSX.Element {
           }}
           onRemoveCoverPhoto={() => {
             setSelectedCoverPhoto(null);
+            setCoverPhotoInputResetKey((current) => current + 1);
           }}
           onSubmit={(event) => {
             event.preventDefault();

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -21,6 +21,7 @@ const checkboxClassName =
 
 type RecipeCreateFormProps = {
   coverPhotoName: string | null;
+  coverPhotoInputResetKey: number;
   isPhotoAttached: boolean;
   isPending: boolean;
   onCoverPhotoChange: (file: File | null) => void;
@@ -34,6 +35,7 @@ type RecipeCreateFormProps = {
 
 export function RecipeCreateForm({
   coverPhotoName,
+  coverPhotoInputResetKey,
   isPhotoAttached,
   isPending,
   onCoverPhotoChange,
@@ -204,6 +206,7 @@ export function RecipeCreateForm({
               accept="image/jpeg,image/png,image/webp"
               className={`${inputClassName} file:mr-3 file:rounded-full file:border-0 file:bg-primary/10 file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary`}
               disabled={isPending}
+              key={coverPhotoInputResetKey}
               onChange={(event) => {
                 onCoverPhotoChange(event.target.files?.[0] ?? null);
               }}


### PR DESCRIPTION
## Summary
- remount the cover photo file input when the selected image is removed
- keep the native file input UI in sync with the cleared React cover photo state

## Testing
- npm run test
- npm run lint
- npm run build

Closes #58