### PR TITLE
fix(recipes): avoid broken cook log embeds

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -12,6 +12,7 @@ import unusedImports from "eslint-plugin-unused-imports";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
+
 import type { ESLint } from "eslint";
 
 const boundariesConfig = createBoundariesConfig({

--- a/src/features/recipes/queries/recipeAdapters.ts
+++ b/src/features/recipes/queries/recipeAdapters.ts
@@ -31,7 +31,6 @@ export type RecipeCookLogRow = Database["public"]["Tables"]["recipe_cook_logs"][
 export type RecipeListRecord = RecipeRow;
 
 export type RecipeDetailRecord = RecipeRow & {
-  recipe_cook_logs: RecipeCookLogRow[] | null;
   recipe_equipment: RecipeEquipmentRow[] | null;
   recipe_ingredients: RecipeIngredientRow[] | null;
   recipe_steps: RecipeStepRow[] | null;
@@ -104,10 +103,13 @@ export function buildRecipeCookLogInsert(
   };
 }
 
-export function mapRecipeDetailRecord(record: RecipeDetailRecord): RecipeDetail {
+export function mapRecipeDetailRecord(
+  record: RecipeDetailRecord,
+  cookLogs: RecipeCookLogRow[] = [],
+): RecipeDetail {
   return {
     ...mapRecipeListRecord(record),
-    cookLogs: sortCookLogs(record.recipe_cook_logs ?? []).map(mapRecipeCookLogRow),
+    cookLogs: sortCookLogs(cookLogs).map(mapRecipeCookLogRow),
     equipment: sortByPosition(record.recipe_equipment ?? []).map(
       mapRecipeEquipmentRow,
     ),

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -11,6 +11,7 @@ import {
   type RecipeListRecord,
 } from "./recipeAdapters";
 import { requireRecipeMutationAuth } from "./recipeAuth";
+import { listRecipeCookLogs } from "./recipeCookLogApi";
 
 import type {
   CreateRecipeInput,
@@ -72,16 +73,6 @@ const recipeDetailSelect = `
   cover_image_path,
   created_at,
   updated_at,
-  recipe_cook_logs (
-    id,
-    recipe_id,
-    owner_id,
-    cooked_on,
-    notes,
-    photo_path,
-    created_at,
-    updated_at
-  ),
   recipe_ingredients (
     id,
     position,
@@ -194,7 +185,9 @@ export async function getRecipeDetail(
     );
   }
 
-  return mapRecipeDetailRecord(data);
+  const cookLogs = await listRecipeCookLogs(recipeId, recipeClient);
+
+  return mapRecipeDetailRecord(data, cookLogs);
 }
 
 export async function listRecipes(

--- a/src/features/recipes/queries/recipeCookLogApi.test.ts
+++ b/src/features/recipes/queries/recipeCookLogApi.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  isRecipeCookLogSchemaUnavailableError,
+  listRecipeCookLogs,
+} from "./recipeCookLogApi";
+
+describe("isRecipeCookLogSchemaUnavailableError", () => {
+  it("detects missing cook log schema cache errors", () => {
+    expect(
+      isRecipeCookLogSchemaUnavailableError({
+        code: "PGRST205",
+        message:
+          "Could not find the table 'public.recipe_cook_logs' in the schema cache",
+      }),
+    ).toBe(true);
+
+    expect(
+      isRecipeCookLogSchemaUnavailableError({
+        code: "PGRST200",
+        details:
+          "Searched for a foreign key relationship between 'recipes' and 'recipe_cook_logs' in the schema 'public', but no matches were found.",
+        message:
+          "Could not find a relationship between 'recipes' and 'recipe_cook_logs' in the schema cache",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(
+      isRecipeCookLogSchemaUnavailableError({
+        code: "PGRST116",
+        message: "JSON object requested, multiple (or no) rows returned",
+      }),
+    ).toBe(false);
+    expect(isRecipeCookLogSchemaUnavailableError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("listRecipeCookLogs", () => {
+  it("returns rows when the cook log table is available", async () => {
+    const eq = vi.fn().mockReturnValue({
+      overrideTypes: vi.fn().mockResolvedValue({
+        data: [
+          {
+            cooked_on: "2026-04-03",
+            created_at: "2026-04-03T10:00:00.000Z",
+            id: "log-1",
+            notes: "Great batch",
+            owner_id: "owner-1",
+            photo_path: null,
+            recipe_id: "recipe-1",
+            updated_at: "2026-04-03T10:00:00.000Z",
+          },
+        ],
+        error: null,
+      }),
+    });
+    const client = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq,
+        }),
+      }),
+    };
+
+    await expect(listRecipeCookLogs("recipe-1", client as never)).resolves.toEqual([
+      {
+        cooked_on: "2026-04-03",
+        created_at: "2026-04-03T10:00:00.000Z",
+        id: "log-1",
+        notes: "Great batch",
+        owner_id: "owner-1",
+        photo_path: null,
+        recipe_id: "recipe-1",
+        updated_at: "2026-04-03T10:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("falls back to an empty list when the cook log table is unavailable", async () => {
+    const eq = vi.fn().mockReturnValue({
+      overrideTypes: vi.fn().mockResolvedValue({
+        data: null,
+        error: {
+          code: "PGRST205",
+          message:
+            "Could not find the table 'public.recipe_cook_logs' in the schema cache",
+        },
+      }),
+    });
+    const client = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq,
+        }),
+      }),
+    };
+
+    await expect(listRecipeCookLogs("recipe-1", client as never)).resolves.toEqual(
+      [],
+    );
+  });
+});

--- a/src/features/recipes/queries/recipeCookLogApi.ts
+++ b/src/features/recipes/queries/recipeCookLogApi.ts
@@ -14,6 +14,12 @@ import type {
 
 type RecipeCookLogApiClient = NonNullable<typeof supabase>;
 
+type RecipeCookLogReadError = {
+  code?: string;
+  details?: string | null;
+  message?: string;
+};
+
 export async function createRecipeCookLog(
   input: CreateRecipeCookLogInput,
   client: RecipeCookLogApiClient | null = supabase,
@@ -31,4 +37,48 @@ export async function createRecipeCookLog(
   }
 
   return mapRecipeCookLogRow(data);
+}
+
+export async function listRecipeCookLogs(
+  recipeId: string,
+  client: RecipeCookLogApiClient | null = supabase,
+): Promise<RecipeCookLogRow[]> {
+  if (client === null) {
+    return [];
+  }
+
+  const { data, error } = await client
+    .from("recipe_cook_logs")
+    .select("id, recipe_id, owner_id, cooked_on, notes, photo_path, created_at, updated_at")
+    .eq("recipe_id", recipeId)
+    .overrideTypes<RecipeCookLogRow[], { merge: false }>();
+
+  if (error !== null) {
+    if (isRecipeCookLogSchemaUnavailableError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+
+  return data ?? [];
+}
+
+export function isRecipeCookLogSchemaUnavailableError(error: unknown): boolean {
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    !("code" in error) ||
+    !("message" in error)
+  ) {
+    return false;
+  }
+
+  const { code, details, message } = error as RecipeCookLogReadError;
+  const combinedText = `${details ?? ""} ${message ?? ""}`;
+
+  return (
+    (code === "PGRST200" || code === "PGRST205") &&
+    combinedText.includes("recipe_cook_logs")
+  );
 }

--- a/src/features/recipes/queries/recipeData.test.ts
+++ b/src/features/recipes/queries/recipeData.test.ts
@@ -21,38 +21,6 @@ describe("mapRecipeDetailRecord", () => {
       is_scalable: true,
       owner_id: "owner-1",
       prep_minutes: 12,
-      recipe_cook_logs: [
-        {
-          cooked_on: "2026-03-23",
-          created_at: "2026-03-23T18:00:00.000Z",
-          id: "cook-log-2",
-          notes: "Added extra lemon juice.",
-          owner_id: "owner-1",
-          photo_path: null,
-          recipe_id: "recipe-1",
-          updated_at: "2026-03-23T18:00:00.000Z",
-        },
-        {
-          cooked_on: "2026-03-25",
-          created_at: "2026-03-25T20:00:00.000Z",
-          id: "cook-log-1",
-          notes: "Finished with parmesan.",
-          owner_id: "owner-1",
-          photo_path: "owner-1/cook-log-1.jpg",
-          recipe_id: "recipe-1",
-          updated_at: "2026-03-25T20:00:00.000Z",
-        },
-        {
-          cooked_on: "2026-03-25",
-          created_at: "2026-03-25T21:30:00.000Z",
-          id: "cook-log-3",
-          notes: "Tossed in extra pasta water.",
-          owner_id: "owner-1",
-          photo_path: null,
-          recipe_id: "recipe-1",
-          updated_at: "2026-03-25T21:30:00.000Z",
-        },
-      ],
       recipe_equipment: [
         {
           created_at: "2026-03-26T10:00:00.000Z",
@@ -130,7 +98,38 @@ describe("mapRecipeDetailRecord", () => {
       updated_at: "2026-03-26T10:15:00.000Z",
       yield_quantity: 4,
       yield_unit: "servings",
-    });
+    }, [
+      {
+        cooked_on: "2026-03-23",
+        created_at: "2026-03-23T18:00:00.000Z",
+        id: "cook-log-2",
+        notes: "Added extra lemon juice.",
+        owner_id: "owner-1",
+        photo_path: null,
+        recipe_id: "recipe-1",
+        updated_at: "2026-03-23T18:00:00.000Z",
+      },
+      {
+        cooked_on: "2026-03-25",
+        created_at: "2026-03-25T20:00:00.000Z",
+        id: "cook-log-1",
+        notes: "Finished with parmesan.",
+        owner_id: "owner-1",
+        photo_path: "owner-1/cook-log-1.jpg",
+        recipe_id: "recipe-1",
+        updated_at: "2026-03-25T20:00:00.000Z",
+      },
+      {
+        cooked_on: "2026-03-25",
+        created_at: "2026-03-25T21:30:00.000Z",
+        id: "cook-log-3",
+        notes: "Tossed in extra pasta water.",
+        owner_id: "owner-1",
+        photo_path: null,
+        recipe_id: "recipe-1",
+        updated_at: "2026-03-25T21:30:00.000Z",
+      },
+    ]);
 
     expect(recipe.totalMinutes).toBe(30);
     expect(recipe.cookLogs.map((item) => item.id)).toEqual([


### PR DESCRIPTION
## Summary
- stop embedding cook logs in the main recipe detail select so create redirects do not fail on stale local schema caches
- load cook logs through a separate query path and fall back to an empty list when the cook log table is unavailable locally
- add focused tests for the cook log schema-cache fallback behavior

## Testing
- npm run test
- npm run lint
- npm run build

Closes #59