### PR TITLE
fix(ui): simplify the app into a cleaner web layout

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -2,73 +2,47 @@ import { Link } from "@tanstack/react-router";
 import { BookOpenText, UserRound } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 import type { JSX } from "react";
 
 type AppShellHeaderProps = {
-  authSummary: {
-    badgeClassName: string;
-    badgeText: string;
-    ctaLabel: string;
-    supportingText: string;
-  };
+  authActionLabel: string;
 };
 
 export function AppShellHeader({
-  authSummary,
+  authActionLabel,
 }: AppShellHeaderProps): JSX.Element {
   return (
-    <header className="sticky top-0 z-20 border-b border-border/70 bg-background/88 backdrop-blur">
-      <div className="flex min-h-16 flex-wrap items-center justify-between gap-3 py-3">
-        <div className="flex min-w-0 items-center gap-6">
+    <header className="sticky top-0 z-20 border-b border-border bg-background/95 backdrop-blur">
+      <div className="flex min-h-15 items-center justify-between gap-4 py-3">
+        <div className="flex min-w-0 items-center gap-4 sm:gap-8">
           <Link
             to="/recipes"
-            className="min-w-0 transition hover:opacity-90"
+            className="flex min-w-0 items-center gap-2 text-base font-semibold tracking-tight text-foreground transition hover:opacity-85"
           >
-            <div className="flex min-w-0 items-center gap-3">
-              <div className="min-w-0">
-                <p className="text-sm font-semibold tracking-[0.08em] text-foreground uppercase">
-                  Recipe Book
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Recipes you want to keep.
-                </p>
-              </div>
-            </div>
+            <BookOpenText className="size-4 text-primary" />
+            <span className="truncate">Recipe Book</span>
           </Link>
 
-          <nav className="flex flex-wrap items-center gap-2">
-            <Button asChild variant="ghost" size="sm" className="h-9 rounded-md px-3">
+          <nav className="flex items-center gap-1">
+            <Button asChild className="rounded-md px-3" size="sm" variant="ghost">
               <Link
-                to="/recipes"
                 activeProps={{
                   className: "bg-accent text-accent-foreground",
                 }}
+                to="/recipes"
               >
-                <BookOpenText className="size-4" />
                 Recipes
               </Link>
             </Button>
           </nav>
         </div>
 
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <span
-            className={cn(
-              "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium",
-              authSummary.badgeClassName,
-            )}
-          >
-            {authSummary.badgeText}
-          </span>
-          <p className="hidden text-sm text-muted-foreground xl:block">
-            {authSummary.supportingText}
-          </p>
-          <Button asChild size="sm" className="h-9 rounded-md px-3 shadow-sm">
+        <div className="flex items-center gap-2">
+          <Button asChild className="rounded-md px-3" size="sm" variant="outline">
             <Link to="/account">
               <UserRound className="size-4" />
-              {authSummary.ctaLabel}
+              {authActionLabel}
             </Link>
           </Button>
         </div>

--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { LockKeyhole, Palette, Soup } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -18,7 +17,6 @@ import { createEmptyAuthFormValues } from "../utils/authFormValues";
 import { AuthenticatedAccountPanel } from "./AuthenticatedAccountPanel";
 import { AuthFormCard } from "./AuthFormCard";
 
-import type { AuthSessionState } from "../queries/sessionQueries";
 import type { JSX } from "react";
 
 type AuthFeedback = {
@@ -44,33 +42,18 @@ type CredentialMutation = {
   ) => void;
 };
 
-function getHeadlineText(
+function getHeadlineDescription(
   kind: "authenticated" | "guest" | "loading" | "unconfigured",
-): {
-  description: string;
-  title: string;
-} {
+): string {
   switch (kind) {
     case "authenticated":
-      return {
-        title: "Account",
-        description: "You are signed in.",
-      };
+      return "Manage your sign-in and app settings.";
     case "guest":
-      return {
-        title: "Account",
-        description: "Sign in to manage recipes.",
-      };
+      return "Sign in to create and delete recipes.";
     case "loading":
-      return {
-        title: "Account",
-        description: "Checking session status.",
-      };
+      return "Checking session status.";
     case "unconfigured":
-      return {
-        title: "Account",
-        description: "Auth is not configured.",
-      };
+      return "Auth is not configured in this environment.";
   }
 }
 
@@ -88,44 +71,27 @@ export function AccountPage(): JSX.Element {
   const kind = sessionQuery.isLoading
     ? "loading"
     : (sessionQuery.data?.kind ?? "guest");
-  const headline = getHeadlineText(kind);
-  const currentStateText = getCurrentStateText(
-    sessionQuery.isLoading,
-    sessionQuery.data,
-  );
+  const headlineDescription = getHeadlineDescription(kind);
   const isGuest = sessionQuery.data?.kind === "guest" || sessionQuery.data === undefined;
   const isConfigured = sessionQuery.data?.kind !== "unconfigured";
 
   return (
-    <main className="mx-auto flex w-full max-w-[76rem] flex-col gap-4 py-4 sm:py-6">
-      <section className="rounded-[1.75rem] border border-border/80 bg-card/95 px-5 py-6 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:px-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
+    <main className="w-full max-w-4xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           Account
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {headlineDescription}
         </p>
-        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="font-display text-3xl leading-none tracking-[-0.03em] text-foreground sm:text-4xl">
-              {headline.title}
-            </h1>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              {headline.description}
-            </p>
-          </div>
-          <div className="rounded-[1.25rem] border border-border/70 bg-background/80 px-4 py-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-              Status
-            </p>
-            <p className="mt-1 text-sm text-foreground">{currentStateText}</p>
-          </div>
-        </div>
       </section>
 
       {feedback !== null ? (
         <section
           className={
             feedback.tone === "success"
-              ? "rounded-[1.5rem] border border-emerald-300/70 bg-emerald-50/80 px-5 py-4 text-emerald-950"
-              : "rounded-[1.5rem] border border-destructive/20 bg-destructive/5 px-5 py-4 text-foreground"
+              ? "mt-6 rounded-lg border border-emerald-300/70 bg-emerald-50/80 px-5 py-4 text-emerald-950"
+              : "mt-6 rounded-lg border border-destructive/20 bg-destructive/5 px-5 py-4 text-foreground"
           }
         >
           <p className="text-sm font-semibold">{feedback.title}</p>
@@ -135,7 +101,7 @@ export function AccountPage(): JSX.Element {
         </section>
       ) : null}
 
-      <section className="grid gap-4 md:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
+      <div className="mt-6 space-y-8">
         <div className="space-y-4">
           {sessionQuery.data?.kind === "authenticated" ? (
             <AuthenticatedAccountPanel
@@ -162,7 +128,7 @@ export function AccountPage(): JSX.Element {
               sessionState={sessionQuery.data}
             />
           ) : (
-            <section className="grid gap-4 lg:grid-cols-2">
+            <section className="grid gap-4 md:grid-cols-2">
               <AuthFormCard
                 description="Use your existing account."
                 email={signInValues.email}
@@ -223,97 +189,52 @@ export function AccountPage(): JSX.Element {
           )}
 
           {!isConfigured ? (
-            <section className="rounded-[1.5rem] border border-border/70 bg-background/85 px-5 py-4">
+            <section className="rounded-lg border border-border bg-background px-5 py-4">
               <h2 className="text-sm font-semibold text-foreground">
                 Auth not configured
               </h2>
-              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 Add the public Supabase URL and anon key to enable sign-in.
               </p>
             </section>
           ) : null}
 
           {isGuest ? (
-            <section className="rounded-[1.5rem] border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
               <h2 className="text-sm font-semibold text-amber-950">
                 Sign in required
               </h2>
-              <p className="mt-1 text-sm leading-6 text-amber-950/85">
+              <p className="mt-1 text-sm text-amber-950/85">
                 Sign in before creating or deleting recipes.
               </p>
             </section>
           ) : null}
         </div>
 
-        <div className="space-y-4">
-          <section className="rounded-[1.5rem] border border-border/80 bg-background/85 p-4 shadow-[0_18px_48px_-38px_rgba(69,52,35,0.45)]">
-            <div className="flex items-center gap-3">
-              <div className="flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                <Palette className="size-4" />
-              </div>
-              <div>
-                <h2 className="text-sm font-semibold text-foreground">Appearance</h2>
-                <p className="text-sm text-muted-foreground">Choose a theme preset.</p>
-              </div>
-            </div>
-
-            <div className="mt-4">
-              <ThemePresetPicker
-                activeThemePresetId={activeThemePresetId}
-                onThemePresetChange={setActiveThemePresetId}
-                variant="compact"
-              />
-            </div>
-          </section>
-
-          <article className="rounded-[1.5rem] border border-border/80 bg-background/85 p-4 shadow-[0_18px_48px_-38px_rgba(69,52,35,0.45)]">
-            <div className="mb-3 flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-              <LockKeyhole className="size-4" />
-            </div>
-            <h2 className="text-sm font-semibold text-foreground">Access</h2>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Creating and deleting recipes requires sign-in.
+        <section className="space-y-4 border-t border-border pt-6">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+              Theme
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Choose the app appearance.
             </p>
-          </article>
+          </div>
+          <ThemePresetPicker
+            activeThemePresetId={activeThemePresetId}
+            onThemePresetChange={setActiveThemePresetId}
+            variant="compact"
+          />
+        </section>
 
-          <article className="rounded-[1.5rem] border border-border/80 bg-background/85 p-4 shadow-[0_18px_48px_-38px_rgba(69,52,35,0.45)]">
-            <div className="mb-3 flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-              <Soup className="size-5" />
-            </div>
-            <h2 className="text-sm font-semibold text-foreground">Recipes</h2>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Open the recipe shelf.
-            </p>
-            <Button asChild className="mt-4 w-full rounded-xl" size="lg" variant="outline">
-              <Link to="/recipes">Browse recipes</Link>
-            </Button>
-          </article>
+        <div className="border-t border-border pt-6">
+          <Button asChild className="rounded-md px-4" size="lg" variant="outline">
+            <Link to="/recipes">Browse recipes</Link>
+          </Button>
         </div>
-      </section>
+      </div>
     </main>
   );
-}
-
-function getCurrentStateText(
-  isLoading: boolean,
-  sessionState: AuthSessionState | undefined,
-): string {
-  if (isLoading) {
-    return "loading";
-  }
-
-  if (sessionState === undefined) {
-    return "guest";
-  }
-
-  switch (sessionState.kind) {
-    case "authenticated":
-      return sessionState.email ?? "signed in";
-    case "guest":
-      return "guest";
-    case "unconfigured":
-      return "unconfigured";
-  }
 }
 
 function submitCredentials(

--- a/src/features/auth/components/AuthFormCard.tsx
+++ b/src/features/auth/components/AuthFormCard.tsx
@@ -13,7 +13,7 @@ type AuthFormCardProps = {
 };
 
 const inputClassName =
-  "h-11 w-full rounded-[1rem] border border-border/70 bg-background/90 px-4 text-sm text-foreground outline-none transition focus:border-primary/50 focus:ring-3 focus:ring-primary/15";
+  "h-11 w-full rounded-md border border-border bg-background px-4 text-sm text-foreground outline-none transition focus:border-primary/50 focus:ring-3 focus:ring-primary/15";
 
 export function AuthFormCard({
   description,
@@ -27,11 +27,11 @@ export function AuthFormCard({
   title,
 }: AuthFormCardProps): JSX.Element {
   return (
-    <article className="rounded-[1.5rem] border border-border/80 bg-background/85 p-5 shadow-[0_18px_48px_-38px_rgba(69,52,35,0.45)]">
+    <article className="rounded-lg border border-border bg-background p-5">
       <h2 className="text-sm font-semibold text-foreground">
         {title}
       </h2>
-      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+      <p className="mt-1 text-sm text-muted-foreground">
         {description}
       </p>
 
@@ -70,7 +70,7 @@ export function AuthFormCard({
         </div>
 
         <button
-          className="inline-flex h-11 w-full items-center justify-center rounded-[1rem] bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-11 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
           disabled={isPending}
           type="submit"
         >

--- a/src/features/auth/components/AuthenticatedAccountPanel.tsx
+++ b/src/features/auth/components/AuthenticatedAccountPanel.tsx
@@ -15,16 +15,16 @@ export function AuthenticatedAccountPanel({
   sessionState,
 }: AuthenticatedAccountPanelProps): JSX.Element {
   return (
-    <article className="rounded-[1.5rem] border border-emerald-300/70 bg-emerald-50/80 p-5 shadow-[0_18px_48px_-38px_rgba(69,52,35,0.45)]">
-      <h2 className="text-sm font-semibold text-foreground">Signed in</h2>
-      <p className="mt-2 text-sm leading-6 text-muted-foreground">
-        {sessionState.email === null
-          ? "You can manage recipes."
-          : `Signed in as ${sessionState.email}.`}
-      </p>
-      <Button className="mt-4 w-full rounded-xl" disabled={isPending} onClick={onSignOut} size="lg">
+    <section className="flex flex-col gap-4 rounded-lg border border-border bg-background p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h2 className="text-sm font-semibold text-foreground">Signed in</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {sessionState.email ?? "This account can manage recipes."}
+        </p>
+      </div>
+      <Button className="rounded-md px-4" disabled={isPending} onClick={onSignOut} size="lg">
         {isPending ? "Signing out..." : "Sign out"}
       </Button>
-    </article>
+    </section>
   );
 }

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -39,15 +39,12 @@ export function CreateRecipePage(): JSX.Element {
 
   if (sessionQuery.isLoading) {
     return (
-      <main className="mx-auto w-full max-w-[84rem] py-6">
-        <section className="rounded-[2rem] border border-border/80 bg-card/95 px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-            Recipe Authoring
-          </p>
-          <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+      <main className="w-full max-w-6xl py-3 sm:py-4">
+        <section className="border-b border-border pb-4">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
             Loading
           </h1>
-          <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+          <p className="mt-2 text-sm text-muted-foreground">
             Checking session status.
           </p>
         </section>
@@ -117,21 +114,18 @@ export function CreateRecipePage(): JSX.Element {
   }
 
   return (
-    <main className="mx-auto w-full max-w-[84rem] py-6">
-      <section className="rounded-[2rem] border border-border/80 bg-[radial-gradient(circle_at_top_left,rgba(95,123,73,0.16),transparent_24%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-          Recipe Authoring
-        </p>
-        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+    <main className="w-full max-w-6xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
           Create recipe
         </h1>
-        <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+        <p className="mt-2 text-sm text-muted-foreground">
           Add the recipe details and save when you are ready.
         </p>
       </section>
 
       {feedback === null ? null : (
-        <section className="mt-6 rounded-[1.5rem] border border-destructive/20 bg-destructive/5 px-5 py-4 text-foreground">
+        <section className="mt-6 rounded-lg border border-destructive/20 bg-destructive/5 px-5 py-4 text-foreground">
           <p className="text-sm font-semibold">{feedback.title}</p>
           <p className="mt-1 text-sm leading-6 text-muted-foreground">
             {feedback.description}

--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -61,31 +61,22 @@ export function RecipeCookLogSection({
     sessionState.userId === recipe.ownerId;
 
   return (
-    <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:p-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-            Cook history
-          </p>
-          <h2 className="mt-2 font-display text-2xl tracking-[-0.03em] text-foreground sm:text-3xl">
-            Kitchen memories
-          </h2>
-        </div>
+    <section className="space-y-4 border-t border-border pt-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Kitchen memories
+        </h2>
         <p className="text-sm text-muted-foreground">
           {recipe.cookLogs.length} {recipe.cookLogs.length === 1 ? "entry" : "entries"}
         </p>
       </div>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
-        Keep a simple record of when this recipe was cooked, what changed, and
-        how it turned out.
-      </p>
 
       {feedback === null ? null : (
         <div
           className={
             feedback.tone === "success"
-              ? "mt-5 rounded-[1.4rem] border border-emerald-300/70 bg-emerald-50/85 px-4 py-4 text-emerald-950"
-              : "mt-5 rounded-[1.4rem] border border-destructive/20 bg-destructive/5 px-4 py-4 text-foreground"
+              ? "rounded-lg border border-emerald-300/70 bg-emerald-50/85 px-4 py-4 text-emerald-950"
+              : "rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-4 text-foreground"
           }
         >
           <p className="text-sm font-semibold">{feedback.title}</p>
@@ -97,7 +88,7 @@ export function RecipeCookLogSection({
 
       {isOwner ? (
         <form
-          className="mt-5 rounded-[1.5rem] border border-border/70 bg-background/80 p-4"
+          className="rounded-lg border border-border bg-background p-4"
           onSubmit={(event) => {
             event.preventDefault();
             void handleCreateCookLog();
@@ -120,7 +111,7 @@ export function RecipeCookLogSection({
               <span className="text-sm font-medium text-foreground">Photo</span>
               <input
                 accept="image/jpeg,image/png,image/webp"
-                className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-full file:border-0 file:bg-primary/10 file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary focus:border-primary focus:ring-2 focus:ring-primary/20"
+                className="mt-2 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
                 disabled={isSubmitting}
                 onChange={(event) => {
                   setSelectedPhoto(event.target.files?.[0] ?? null);
@@ -132,7 +123,7 @@ export function RecipeCookLogSection({
             <label className="md:col-span-2">
               <span className="text-sm font-medium text-foreground">Notes</span>
               <textarea
-                className="mt-2 min-h-28 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                className="mt-2 min-h-28 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
                 onChange={(event) => {
                   setNotes(event.target.value);
                 }}
@@ -143,12 +134,12 @@ export function RecipeCookLogSection({
           </div>
 
           <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-            <p className="text-sm leading-6 text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               {selectedPhoto === null
                 ? "No memory photo selected."
                 : `Selected photo: ${selectedPhoto.name}`}
             </p>
-            <Button className="rounded-full px-5" disabled={isSubmitting} size="lg" type="submit">
+            <Button className="rounded-md px-5" disabled={isSubmitting} size="lg" type="submit">
               {isSubmitting ? "Saving memory..." : "Save cook memory"}
             </Button>
           </div>
@@ -156,11 +147,11 @@ export function RecipeCookLogSection({
       ) : null}
 
       {recipe.cookLogs.length === 0 ? (
-        <div className="mt-5 rounded-[1.4rem] border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm leading-6 text-muted-foreground">
+        <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
           No cook memories were saved for this recipe yet.
         </div>
       ) : (
-        <ol className="mt-5 space-y-4">
+        <ol className="space-y-4">
           {recipe.cookLogs.map((cookLog) => (
             <CookLogCard key={cookLog.id} cookLog={cookLog} />
           ))}
@@ -219,20 +210,20 @@ function CookLogCard({
   const photoUrl = getRecipeCookLogPhotoUrl(cookLog.photoPath);
 
   return (
-    <li className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4 sm:px-5">
+    <li className="rounded-lg border border-border bg-background px-4 py-4 sm:px-5">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
         {photoUrl !== null ? (
           <img
             alt={`Cook memory from ${cookLog.cookedOn}`}
-            className="aspect-[4/3] w-full rounded-[1.2rem] border border-border/70 object-cover lg:w-52"
+            className="aspect-[4/3] w-full rounded-lg border border-border object-cover lg:w-52"
             src={photoUrl}
           />
         ) : null}
         <div className="min-w-0 flex-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          <p className="text-sm font-medium text-foreground">
             {cookLog.cookedOn}
           </p>
-          <p className="mt-2 text-sm leading-6 text-foreground">
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
             {cookLog.notes ?? "No notes were added for this cook memory."}
           </p>
         </div>

--- a/src/features/recipes/components/RecipeCoverImage.tsx
+++ b/src/features/recipes/components/RecipeCoverImage.tsx
@@ -12,27 +12,11 @@ export function RecipeCoverImage({
   coverImagePath,
   title,
   variant,
-}: RecipeCoverImageProps): JSX.Element {
+}: RecipeCoverImageProps): JSX.Element | null {
   const coverImageUrl = getRecipeCoverPhotoUrl(coverImagePath);
 
   if (coverImageUrl === null) {
-    return (
-      <div
-        className={getRecipeCoverImageClassName(variant)}
-        aria-label={`${title} cover placeholder`}
-      >
-        <div className="rounded-full border border-white/35 bg-white/10 px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-white/90">
-          Recipe photo
-        </div>
-        <p className="mt-3 max-w-xs font-display text-3xl leading-none tracking-[-0.04em] text-white sm:text-4xl">
-          {title}
-        </p>
-        <p className="mt-3 max-w-sm text-sm leading-6 text-white/80">
-          Add a cover photo during recipe creation to give this dish a visual
-          anchor in the shelf and detail views.
-        </p>
-      </div>
-    );
+    return null;
   }
 
   return (
@@ -47,11 +31,10 @@ export function RecipeCoverImage({
 }
 
 function getRecipeCoverImageClassName(variant: RecipeCoverImageProps["variant"]): string {
-  const baseClassName =
-    "overflow-hidden rounded-[1.75rem] border border-border/70 bg-[radial-gradient(circle_at_top_left,rgba(95,123,73,0.72),rgba(64,83,50,0.9))] shadow-[0_20px_60px_-46px_rgba(69,52,35,0.55)]";
+  const baseClassName = "overflow-hidden border border-border bg-muted";
 
   if (variant === "detail") {
-    return `${baseClassName} aspect-[4/3] min-h-64`;
+    return `${baseClassName} aspect-[16/10] rounded-xl`;
   }
 
   return `${baseClassName} aspect-[16/9]`;

--- a/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
+++ b/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
@@ -15,23 +15,20 @@ export function RecipeCreateAuthPrompt({
   const copy = getAuthPromptCopy(sessionState);
 
   return (
-    <main className="mx-auto w-full max-w-[84rem] py-6">
-      <section className="rounded-[2rem] border border-border/80 bg-[radial-gradient(circle_at_top_left,rgba(217,170,93,0.18),transparent_24%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-6 py-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-          Recipe Authoring
-        </p>
-        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+    <main className="w-full max-w-6xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
           {copy.title}
         </h1>
-        <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
           {copy.description}
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
-          <Button asChild size="lg" className="rounded-full px-5">
+          <Button asChild className="rounded-md px-5" size="lg">
             <Link to="/account">{copy.ctaLabel}</Link>
           </Button>
-          <Button asChild size="lg" variant="outline" className="rounded-full px-5">
-            <Link to="/recipes">Back to recipe shelf</Link>
+          <Button asChild className="rounded-md px-5" size="lg" variant="outline">
+            <Link to="/recipes">Back to recipes</Link>
           </Button>
         </div>
       </section>

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -15,7 +15,7 @@ import {
 import type { FormEvent, JSX } from "react";
 
 const inputClassName =
-  "mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20";
+  "mt-2 w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20";
 const checkboxClassName =
   "size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20";
 
@@ -45,22 +45,13 @@ export function RecipeCreateForm({
   values,
 }: RecipeCreateFormProps): JSX.Element {
   return (
-    <form className="space-y-6" onSubmit={onSubmit}>
-      <section className="rounded-[2rem] border border-border/80 bg-card/95 px-6 py-6 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8">
-        <div className="max-w-3xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-            Basics
-          </p>
-          <h2 className="mt-3 font-display text-3xl tracking-[-0.03em] text-foreground">
-            Start with the shape of the recipe.
-          </h2>
-          <p className="mt-3 text-sm leading-6 text-muted-foreground">
-            Capture the title, quick summary, yield, timing, and whether serving
-            scaling should stay available later.
-          </p>
-        </div>
+    <form className="space-y-10" onSubmit={onSubmit}>
+      <section className="space-y-6 border-b border-border pb-8">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          Basics
+        </h2>
 
-        <div className="mt-6 grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4 md:grid-cols-2">
           <label className="md:col-span-2">
             <span className="text-sm font-medium text-foreground">Title</span>
             <input
@@ -98,7 +89,7 @@ export function RecipeCreateForm({
                 const description = event.target.value;
                 setValues((current) => ({ ...current, description }));
               }}
-              placeholder="Add any context, serving notes, or why this dish earns a spot in the rotation."
+              placeholder="Add any context or serving notes."
               value={values.description}
             />
           </label>
@@ -163,7 +154,7 @@ export function RecipeCreateForm({
           </label>
         </div>
 
-        <label className="mt-5 flex items-center gap-3 rounded-2xl border border-border/70 bg-background/75 px-4 py-3 text-sm text-foreground">
+        <label className="flex items-center gap-3 text-sm text-foreground">
           <input
             checked={values.isScalable}
             className={checkboxClassName}
@@ -173,21 +164,20 @@ export function RecipeCreateForm({
             }}
             type="checkbox"
           />
-          Allow serving scaling for this recipe.
+          Allow ingredient scaling
         </label>
 
-        <div className="mt-5 rounded-[1.5rem] border border-border/70 bg-background/75 p-4">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div className="max-w-2xl">
-              <p className="text-sm font-medium text-foreground">Cover photo</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                Upload a JPG, PNG, or WebP image up to 5 MB. The file is stored
-                in Supabase Storage and the recipe saves only the storage path.
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Cover photo</h3>
+              <p className="text-sm text-muted-foreground">
+                JPG, PNG, or WebP up to 5 MB.
               </p>
             </div>
             {isPhotoAttached ? (
               <Button
-                className="rounded-full px-4"
+                className="rounded-md px-4"
                 onClick={onRemoveCoverPhoto}
                 size="sm"
                 type="button"
@@ -198,25 +188,20 @@ export function RecipeCreateForm({
             ) : null}
           </div>
 
-          <label className="mt-4 block">
-            <span className="text-sm font-medium text-foreground">
-              Select image
-            </span>
-            <input
-              accept="image/jpeg,image/png,image/webp"
-              className={`${inputClassName} file:mr-3 file:rounded-full file:border-0 file:bg-primary/10 file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary`}
-              disabled={isPending}
-              key={coverPhotoInputResetKey}
-              onChange={(event) => {
-                onCoverPhotoChange(event.target.files?.[0] ?? null);
-              }}
-              type="file"
-            />
-          </label>
+          <input
+            accept="image/jpeg,image/png,image/webp"
+            className={`${inputClassName} file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground`}
+            disabled={isPending}
+            key={coverPhotoInputResetKey}
+            onChange={(event) => {
+              onCoverPhotoChange(event.target.files?.[0] ?? null);
+            }}
+            type="file"
+          />
 
-          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             {coverPhotoName === null
-              ? "No cover photo selected yet."
+              ? "No cover photo selected."
               : `Selected file: ${coverPhotoName}`}
           </p>
         </div>
@@ -224,9 +209,9 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add ingredient"
-        description="Keep ingredients in cooking order so prep and shopping stay predictable."
-        items={values.ingredients}
         itemLabel="Ingredient"
+        items={values.ingredients}
+        minimumItems={1}
         onAdd={() => {
           setValues((current) => ({
             ...current,
@@ -263,9 +248,9 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add equipment"
-        description="Equipment is optional, but it helps future cooks see the setup at a glance."
-        items={values.equipment}
         itemLabel="Equipment"
+        items={values.equipment}
+        minimumItems={0}
         onAdd={() => {
           setValues((current) => ({
             ...current,
@@ -299,9 +284,9 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add step"
-        description="Steps stay ordered so the detail page can render a clean cooking flow immediately after creation."
-        items={values.steps}
         itemLabel="Step"
+        items={values.steps}
+        minimumItems={1}
         onAdd={() => {
           setValues((current) => ({
             ...current,
@@ -329,12 +314,12 @@ export function RecipeCreateForm({
         title="Steps"
       />
 
-      <div className="flex flex-wrap items-center justify-end gap-3">
-        <Button asChild size="lg" variant="outline" className="rounded-full px-5">
+      <div className="flex flex-wrap items-center justify-end gap-3 border-t border-border pt-6">
+        <Button asChild className="rounded-md px-5" size="lg" variant="outline">
           <Link to="/recipes">Cancel</Link>
         </Button>
         <Button
-          className="rounded-full px-6"
+          className="rounded-md px-6"
           disabled={isPending}
           size="lg"
           type="submit"
@@ -348,9 +333,9 @@ export function RecipeCreateForm({
 
 type RecipeCreateCollectionSectionProps<TItem> = {
   addLabel: string;
-  description: string;
-  items: TItem[];
   itemLabel: string;
+  items: TItem[];
+  minimumItems: number;
   onAdd: () => void;
   onRemove: (index: number) => void;
   renderItem: (item: TItem, index: number) => JSX.Element;
@@ -359,27 +344,22 @@ type RecipeCreateCollectionSectionProps<TItem> = {
 
 function RecipeCreateCollectionSection<TItem>({
   addLabel,
-  description,
-  items,
   itemLabel,
+  items,
+  minimumItems,
   onAdd,
   onRemove,
   renderItem,
   title,
 }: RecipeCreateCollectionSectionProps<TItem>): JSX.Element {
   return (
-    <section className="rounded-[2rem] border border-border/80 bg-background/85 px-6 py-6 shadow-[0_20px_60px_-44px_rgba(69,52,35,0.5)] sm:px-8">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="max-w-2xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-            {title}
-          </p>
-          <p className="mt-3 text-sm leading-6 text-muted-foreground">
-            {description}
-          </p>
-        </div>
+    <section className="space-y-4 border-b border-border pb-8">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          {title}
+        </h2>
         <Button
-          className="rounded-full px-5"
+          className="rounded-md px-4"
           onClick={onAdd}
           type="button"
           variant="outline"
@@ -388,18 +368,18 @@ function RecipeCreateCollectionSection<TItem>({
         </Button>
       </div>
 
-      <div className="mt-6 space-y-4">
+      <div className="space-y-4">
         {items.map((item, index) => (
           <article
             key={`${title}-${index + 1}`}
-            className="rounded-[1.5rem] border border-border/70 bg-card/90 p-4 shadow-[0_16px_40px_-34px_rgba(69,52,35,0.45)]"
+            className="rounded-lg border border-border bg-background p-4"
           >
             <div className="flex items-center justify-between gap-3">
               <p className="text-sm font-semibold text-foreground">
                 {itemLabel} {index + 1}
               </p>
               <Button
-                disabled={items.length === 1 && (title === "Ingredients" || title === "Steps")}
+                disabled={items.length <= minimumItems}
                 onClick={() => {
                   onRemove(index);
                 }}
@@ -432,7 +412,7 @@ function IngredientFields({
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <label className="md:col-span-2">
-        <span className="text-sm font-medium text-foreground">Ingredient name</span>
+        <span className="text-sm font-medium text-foreground">Ingredient</span>
         <input
           className={inputClassName}
           onChange={(event) => {
@@ -492,7 +472,7 @@ function IngredientFields({
         />
       </label>
 
-      <label className="md:col-span-2 flex items-center gap-3 rounded-2xl border border-border/70 bg-background/75 px-4 py-3 text-sm text-foreground">
+      <label className="md:col-span-2 flex items-center gap-3 text-sm text-foreground">
         <input
           checked={ingredient.isOptional}
           className={checkboxClassName}
@@ -501,7 +481,7 @@ function IngredientFields({
           }}
           type="checkbox"
         />
-        Mark ingredient {index + 1} as optional.
+        Optional ingredient {index + 1}
       </label>
     </div>
   );
@@ -521,7 +501,7 @@ function EquipmentFields({
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <label>
-        <span className="text-sm font-medium text-foreground">Equipment name</span>
+        <span className="text-sm font-medium text-foreground">Equipment</span>
         <input
           className={inputClassName}
           onChange={(event) => {
@@ -544,7 +524,7 @@ function EquipmentFields({
         />
       </label>
 
-      <label className="md:col-span-2 flex items-center gap-3 rounded-2xl border border-border/70 bg-background/75 px-4 py-3 text-sm text-foreground">
+      <label className="md:col-span-2 flex items-center gap-3 text-sm text-foreground">
         <input
           checked={equipment.isOptional}
           className={checkboxClassName}
@@ -553,7 +533,7 @@ function EquipmentFields({
           }}
           type="checkbox"
         />
-        Mark equipment {index + 1} as optional.
+        Optional equipment {index + 1}
       </label>
     </div>
   );
@@ -605,8 +585,8 @@ function StepFields({ index, onChange, step }: StepFieldsProps): JSX.Element {
         />
       </label>
 
-      <p className="md:col-span-2 text-xs uppercase tracking-[0.24em] text-muted-foreground">
-        Step {index + 1} stays in recipe order.
+      <p className="md:col-span-2 text-sm text-muted-foreground">
+        Step {index + 1}
       </p>
     </div>
   );

--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -17,20 +17,17 @@ import type { JSX } from "react";
 
 type RecipeDetailCollectionSectionProps =
   | {
-      description: string;
       items: RecipeIngredient[];
       kind: "ingredients";
       scaleFactor?: number;
       title: string;
     }
   | {
-      description: string;
       items: RecipeEquipment[];
       kind: "equipment";
       title: string;
     }
   | {
-      description: string;
       items: RecipeStep[];
       kind: "steps";
       title: string;
@@ -39,43 +36,29 @@ type RecipeDetailCollectionSectionProps =
 export function RecipeDetailCollectionSection(
   props: RecipeDetailCollectionSectionProps,
 ): JSX.Element {
-  const isMethod = props.kind === "steps";
   const stepTimer = useStepTimer();
 
   return (
-    <section className="rounded-[1.75rem] border border-border/70 bg-card/95 p-5 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.45)] sm:p-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-            {isMethod ? "Cooking flow" : "Recipe details"}
-          </p>
-          <h2 className="mt-2 font-display text-2xl tracking-[-0.03em] text-foreground sm:text-3xl">
-            {props.title}
-          </h2>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          {getCountText(props.kind, props.items.length)}
-        </p>
+    <section className="space-y-4 border-t border-border pt-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          {props.title}
+        </h2>
+        <p className="text-sm text-muted-foreground">{getCountText(props.kind, props.items.length)}</p>
       </div>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
-        {props.description}
-      </p>
 
       {props.items.length === 0 ? (
-        <div className="mt-5 rounded-[1.4rem] border border-dashed border-border/70 bg-background/70 px-4 py-5 text-sm leading-6 text-muted-foreground">
+        <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
           {getEmptyText(props.kind)}
         </div>
       ) : null}
 
       {props.kind === "ingredients" && props.items.length > 0 ? (
-        <ul className="mt-5 grid gap-3">
+        <ul className="divide-y divide-border rounded-lg border border-border bg-background">
           {props.items.map((ingredient) => (
-            <li
-              key={ingredient.id}
-              className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4"
-            >
+            <li key={ingredient.id} className="px-4 py-4">
               <div className="flex items-start gap-3">
-                <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-xs font-semibold text-muted-foreground">
+                <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
                   {ingredient.position}
                 </div>
                 <div className="min-w-0 flex-1">
@@ -84,7 +67,7 @@ export function RecipeDetailCollectionSection(
                       {formatIngredientText(ingredient, props.scaleFactor ?? 1)}
                     </p>
                     {ingredient.isOptional ? (
-                      <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                      <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
                         Optional
                       </span>
                     ) : null}
@@ -102,14 +85,11 @@ export function RecipeDetailCollectionSection(
       ) : null}
 
       {props.kind === "equipment" && props.items.length > 0 ? (
-        <ul className="mt-5 grid gap-3">
+        <ul className="divide-y divide-border rounded-lg border border-border bg-background">
           {props.items.map((equipment) => (
-            <li
-              key={equipment.id}
-              className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4"
-            >
+            <li key={equipment.id} className="px-4 py-4">
               <div className="flex items-start gap-3">
-                <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-xs font-semibold text-muted-foreground">
+                <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
                   {equipment.position}
                 </div>
                 <div className="min-w-0 flex-1">
@@ -118,7 +98,7 @@ export function RecipeDetailCollectionSection(
                       {equipment.name}
                     </p>
                     {equipment.isOptional ? (
-                      <span className="rounded-full border border-border/70 bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                      <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
                         Optional
                       </span>
                     ) : null}
@@ -136,14 +116,11 @@ export function RecipeDetailCollectionSection(
       ) : null}
 
       {props.kind === "steps" && props.items.length > 0 ? (
-        <ol className="mt-5 space-y-4">
+        <ol className="space-y-4">
           {props.items.map((step) => (
-            <li
-              key={step.id}
-              className="rounded-[1.4rem] border border-border/60 bg-background/85 px-4 py-4 sm:px-5"
-            >
+            <li key={step.id} className="rounded-lg border border-border bg-background px-4 py-4 sm:px-5">
               <div className="flex items-start gap-3 sm:gap-4">
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-[1rem] border border-border/70 bg-card text-sm font-semibold text-foreground shadow-[0_12px_24px_-20px_rgba(69,52,35,0.5)] sm:size-11">
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-foreground sm:size-10">
                   {step.position}
                 </div>
                 <div className="min-w-0 flex-1">
@@ -152,7 +129,7 @@ export function RecipeDetailCollectionSection(
                       {step.instruction}
                     </p>
                     {step.timerSeconds !== null ? (
-                      <span className="rounded-full border border-amber-300/70 bg-amber-50/85 px-2.5 py-1 text-xs font-medium text-amber-950">
+                      <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
                         {stepTimer.activeStepId === step.id &&
                         stepTimer.remainingSeconds !== null
                           ? `${formatCountdownClock(stepTimer.remainingSeconds)} left`

--- a/src/features/recipes/components/RecipeDetailHero.tsx
+++ b/src/features/recipes/components/RecipeDetailHero.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import type { AuthSessionState } from "@/features/auth";
 
 import {
   formatRecipeTime,
@@ -11,18 +12,23 @@ import {
 } from "../utils/recipePresentation";
 
 import { RecipeCoverImage } from "./RecipeCoverImage";
+import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipeDetailHeroProps = {
+  isSessionLoading: boolean;
   recipe: RecipeDetail;
   scaleFactor: number;
+  sessionState: AuthSessionState | undefined;
 };
 
 export function RecipeDetailHero({
+  isSessionLoading,
   recipe,
   scaleFactor,
+  sessionState,
 }: RecipeDetailHeroProps): JSX.Element {
   const summary = getRecipeSummary(recipe.summary, recipe.description);
   const description = recipe.description.trim();
@@ -33,83 +39,62 @@ export function RecipeDetailHero({
   ];
 
   return (
-    <>
-      <div className="sticky top-3 z-10 -mx-2 px-2 sm:static sm:mx-0 sm:px-0">
-        <Button
-          asChild
-          variant="ghost"
-          size="lg"
-          className="rounded-full border border-border/70 bg-background/90 px-4 shadow-[0_16px_42px_-36px_rgba(69,52,35,0.6)] backdrop-blur sm:bg-transparent sm:shadow-none"
-        >
+    <section className="space-y-6">
+      <div>
+        <Button asChild className="rounded-md px-3" size="lg" variant="ghost">
           <Link to="/recipes">
             <ArrowLeft />
-            Back to recipe shelf
+            Back to recipes
           </Link>
         </Button>
       </div>
 
-      <section className="overflow-hidden rounded-[2rem] border border-border/70 bg-[radial-gradient(circle_at_top_left,rgba(217,170,93,0.16),transparent_28%),linear-gradient(180deg,rgba(255,253,249,0.96),rgba(246,238,226,0.92))] px-5 py-6 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)] sm:px-8 sm:py-8">
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(17rem,1fr)] lg:items-start">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-              Recipe Detail
-            </p>
-            <h1 className="mt-3 font-display text-4xl leading-[0.95] tracking-[-0.05em] text-foreground sm:text-5xl lg:text-6xl">
-              {recipe.title}
-            </h1>
-            <p className="mt-4 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-              {summary}
-            </p>
-            {description !== "" && description !== summary ? (
-              <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
-                {description}
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)] lg:items-start">
+        <div className="min-w-0 space-y-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+                {recipe.title}
+              </h1>
+              <p className="mt-3 max-w-3xl text-base text-muted-foreground">
+                {summary}
               </p>
-            ) : null}
+              {description !== "" && description !== summary ? (
+                <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+                  {description}
+                </p>
+              ) : null}
+            </div>
+
+            <RecipeOwnerActionsPanel
+              isSessionLoading={isSessionLoading}
+              recipe={recipe}
+              sessionState={sessionState}
+            />
           </div>
 
-          <div className="space-y-4">
+          <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+            {metadata.map((item) => (
+              <span
+                key={item}
+                className="rounded-full border border-border bg-background px-3 py-1.5"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {recipe.coverImagePath !== null ? (
+          <div className="lg:justify-self-end">
             <RecipeCoverImage
               coverImagePath={recipe.coverImagePath}
               title={recipe.title}
               variant="detail"
             />
-
-            <aside className="rounded-[1.75rem] border border-border/70 bg-background/80 p-4 shadow-[0_20px_60px_-46px_rgba(69,52,35,0.55)]">
-              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-                Cook at a glance
-              </p>
-              <div className="mt-4 grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
-                {metadata.map((item, index) => (
-                  <div
-                    key={item}
-                    className="rounded-[1.25rem] border border-border/70 bg-card/90 px-3 py-3"
-                  >
-                    <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                      {getMetadataLabel(index)}
-                    </p>
-                    <p className="mt-2 text-sm font-medium leading-6 text-foreground">
-                      {item}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </aside>
           </div>
-        </div>
-      </section>
-    </>
+        ) : null}
+      </div>
+    </section>
   );
-}
-
-function getMetadataLabel(index: number): string {
-  switch (index) {
-    case 0:
-      return "Time";
-    case 1:
-      return "Yield";
-    case 2:
-      return "Scaling";
-    default:
-      return "Detail";
-  }
 }

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -29,10 +29,14 @@ export function RecipeDetailPage({
   const recipe = recipeDetailQuery.data;
 
   return (
-    <main className="mx-auto flex w-full max-w-[84rem] flex-col gap-6 py-6">
-      <RecipeDetailHero recipe={recipe} scaleFactor={scaleFactor} />
-      <RecipeDetailPageSections
+    <main className="flex w-full flex-col gap-8 py-3 sm:py-4">
+      <RecipeDetailHero
         isSessionLoading={sessionQuery.isLoading}
+        recipe={recipe}
+        scaleFactor={scaleFactor}
+        sessionState={sessionQuery.data}
+      />
+      <RecipeDetailPageSections
         onScaleChange={setScaleFactor}
         recipe={recipe}
         scaleFactor={scaleFactor}

--- a/src/features/recipes/components/RecipeDetailPageLoading.tsx
+++ b/src/features/recipes/components/RecipeDetailPageLoading.tsx
@@ -2,37 +2,42 @@ import type { JSX } from "react";
 
 export function RecipeDetailPageLoading(): JSX.Element {
   return (
-    <main className="mx-auto flex w-full max-w-[84rem] flex-col gap-6 py-6">
+    <main className="flex w-full flex-col gap-8 py-3 sm:py-4">
       <div aria-hidden="true" className="animate-pulse space-y-6">
-        <div className="h-10 w-44 rounded-full bg-muted" />
-        <div className="rounded-[2rem] border border-border/70 bg-card/90 p-8 shadow-[0_24px_80px_-50px_rgba(69,52,35,0.45)]">
-          <div className="h-4 w-28 rounded-full bg-muted" />
-          <div className="mt-4 h-12 w-3/4 rounded-2xl bg-muted" />
-          <div className="mt-4 space-y-2">
-            <div className="h-4 w-full rounded-full bg-muted" />
-            <div className="h-4 w-5/6 rounded-full bg-muted" />
-            <div className="h-4 w-2/3 rounded-full bg-muted" />
-          </div>
-          <div className="mt-6 flex flex-wrap gap-2">
-            <div className="h-7 w-28 rounded-full bg-muted" />
-            <div className="h-7 w-24 rounded-full bg-muted" />
-            <div className="h-7 w-24 rounded-full bg-muted" />
-          </div>
-        </div>
-        <div className="grid gap-4 md:grid-cols-3">
-          {Array.from({ length: 3 }, (_, index) => (
-            <div
-              key={`detail-loading-${index}`}
-              className="rounded-[1.75rem] border border-border/70 bg-background/85 p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]"
-            >
-              <div className="h-4 w-28 rounded-full bg-muted" />
-              <div className="mt-4 h-8 w-32 rounded-2xl bg-muted" />
-              <div className="mt-3 space-y-2">
-                <div className="h-4 w-full rounded-full bg-muted" />
-                <div className="h-4 w-4/5 rounded-full bg-muted" />
-              </div>
+        <div className="h-10 w-36 rounded-md bg-muted" />
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)]">
+          <div className="space-y-4">
+            <div className="h-12 w-3/4 rounded-md bg-muted" />
+            <div className="space-y-2">
+              <div className="h-4 w-full rounded-md bg-muted" />
+              <div className="h-4 w-5/6 rounded-md bg-muted" />
             </div>
-          ))}
+            <div className="flex flex-wrap gap-2">
+              <div className="h-8 w-24 rounded-full bg-muted" />
+              <div className="h-8 w-28 rounded-full bg-muted" />
+              <div className="h-8 w-24 rounded-full bg-muted" />
+            </div>
+          </div>
+          <div className="aspect-[16/10] rounded-xl bg-muted" />
+        </div>
+        <div className="space-y-6">
+          <div className="h-10 w-40 rounded-md bg-muted" />
+          <div className="grid gap-8 xl:grid-cols-2">
+            {Array.from({ length: 2 }, (_, index) => (
+              <div key={`detail-collection-loading-${index}`} className="space-y-4">
+                <div className="h-8 w-32 rounded-md bg-muted" />
+                <div className="space-y-3">
+                  <div className="h-20 rounded-lg bg-muted" />
+                  <div className="h-20 rounded-lg bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 space-y-2">
+            <div className="h-8 w-24 rounded-md bg-muted" />
+            <div className="h-28 rounded-lg bg-muted" />
+            <div className="h-28 rounded-lg bg-muted" />
+          </div>
         </div>
       </div>
     </main>

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -2,14 +2,12 @@ import type { AuthSessionState } from "@/features/auth";
 
 import { RecipeCookLogSection } from "./RecipeCookLogSection";
 import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
-import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
 import { RecipeScalingPanel } from "./RecipeScalingPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipeDetailPageSectionsProps = {
-  isSessionLoading: boolean;
   onScaleChange: (scaleFactor: number) => void;
   recipe: RecipeDetail;
   scaleFactor: number;
@@ -17,51 +15,39 @@ type RecipeDetailPageSectionsProps = {
 };
 
 export function RecipeDetailPageSections({
-  isSessionLoading,
   onScaleChange,
   recipe,
   scaleFactor,
   sessionState,
 }: RecipeDetailPageSectionsProps): JSX.Element {
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)] lg:items-start">
-      <div className="space-y-4">
-        <RecipeScalingPanel
-          onScaleChange={onScaleChange}
-          recipe={recipe}
-          scaleFactor={scaleFactor}
-        />
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-          <RecipeDetailCollectionSection
-            description="Ingredients stay in recipe order so grocery prep and cooking setup remain predictable."
-            items={recipe.ingredients}
-            kind="ingredients"
-            scaleFactor={scaleFactor}
-            title="Ingredients"
-          />
-          <RecipeDetailCollectionSection
-            description="Equipment is separated from ingredients so the reading flow stays calm while you cook."
-            items={recipe.equipment}
-            kind="equipment"
-            title="Equipment"
-          />
-        </div>
+    <div className="space-y-8">
+      <RecipeScalingPanel
+        onScaleChange={onScaleChange}
+        recipe={recipe}
+        scaleFactor={scaleFactor}
+      />
+
+      <div className="grid gap-8 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
         <RecipeDetailCollectionSection
-          description="Each step is presented in order, with any saved timer notes staying attached to the right instruction."
-          items={recipe.steps}
-          kind="steps"
-          title="Method"
+          items={recipe.ingredients}
+          kind="ingredients"
+          scaleFactor={scaleFactor}
+          title="Ingredients"
         />
-        <RecipeCookLogSection recipe={recipe} sessionState={sessionState} />
+        <RecipeDetailCollectionSection
+          items={recipe.equipment}
+          kind="equipment"
+          title="Equipment"
+        />
       </div>
 
-      <div className="lg:sticky lg:top-24">
-        <RecipeOwnerActionsPanel
-          isSessionLoading={isSessionLoading}
-          recipe={recipe}
-          sessionState={sessionState}
-        />
-      </div>
+      <RecipeDetailCollectionSection
+        items={recipe.steps}
+        kind="steps"
+        title="Method"
+      />
+      <RecipeCookLogSection recipe={recipe} sessionState={sessionState} />
     </div>
   );
 }

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -24,83 +24,63 @@ export function RecipeOwnerActionsPanel({
   isSessionLoading,
   recipe,
   sessionState,
-}: RecipeOwnerActionsPanelProps): JSX.Element {
+}: RecipeOwnerActionsPanelProps): JSX.Element | null {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const deleteRecipeMutation = useMutation(deleteRecipeMutationOptions(queryClient));
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
-  const state = getOwnerActionState(isSessionLoading, recipe, sessionState);
   const isOwner =
     !isSessionLoading &&
     sessionState !== undefined &&
     sessionState.kind === "authenticated" &&
     sessionState.userId === recipe.ownerId;
 
+  if (!isOwner) {
+    return null;
+  }
+
   return (
-    <aside className="rounded-[1.75rem] border border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
-      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-        Owner Actions
-      </p>
-      <h2 className="mt-3 font-display text-2xl tracking-[-0.03em] text-foreground">
-        {state.title}
-      </h2>
-      <p className="mt-3 text-sm leading-6 text-muted-foreground">
-        {state.description}
-      </p>
-      {feedback === null ? null : (
-        <div className="mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm leading-6 text-foreground">
-          <p className="font-semibold">Delete unavailable</p>
-          <p className="mt-1 text-muted-foreground">{feedback}</p>
-        </div>
-      )}
-      {state.ctaLabel !== null ? (
-        <Button
-          asChild
-          className="mt-5 w-full rounded-xl"
-          size="lg"
-          variant={state.ctaVariant}
-        >
-          <Link to={state.ctaTo}>{state.ctaLabel}</Link>
-        </Button>
-      ) : null}
-      {isOwner ? (
-        <RecipeDeleteDialog
-          description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
-          isPending={deleteRecipeMutation.isPending}
-          onConfirm={() => {
-            setFeedback(null);
-            deleteRecipeMutation.mutate(
-              { recipeId: recipe.id },
-              {
-                onError: (error) => {
-                  setFeedback(getDeleteErrorMessage(error));
-                },
-                onSuccess: () => {
-                  setIsDeleteDialogOpen(false);
-                  void navigate({
-                    search: { deleted: "1" },
-                    to: "/recipes",
-                  });
-                },
+    <div className="flex flex-col items-start gap-2 lg:items-end">
+      <RecipeDeleteDialog
+        description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
+        isPending={deleteRecipeMutation.isPending}
+        onConfirm={() => {
+          setFeedback(null);
+          deleteRecipeMutation.mutate(
+            { recipeId: recipe.id },
+            {
+              onError: (error) => {
+                setFeedback(getDeleteErrorMessage(error));
               },
-            );
-          }}
-          onOpenChange={(open) => {
-            setIsDeleteDialogOpen(open);
-            if (open) {
-              setFeedback(null);
-            }
-          }}
-          open={isDeleteDialogOpen}
-          title="Delete this recipe?"
-        >
-          <Button className="mt-3 w-full rounded-xl" size="lg" variant="destructive">
-            Delete recipe
-          </Button>
-        </RecipeDeleteDialog>
-      ) : null}
-    </aside>
+              onSuccess: () => {
+                setIsDeleteDialogOpen(false);
+                void navigate({
+                  search: { deleted: "1" },
+                  to: "/recipes",
+                });
+              },
+            },
+          );
+        }}
+        onOpenChange={(open) => {
+          setIsDeleteDialogOpen(open);
+          if (open) {
+            setFeedback(null);
+          }
+        }}
+        open={isDeleteDialogOpen}
+        title="Delete this recipe?"
+      >
+        <Button className="rounded-md px-4" size="lg" variant="destructive">
+          Delete
+        </Button>
+      </RecipeDeleteDialog>
+
+      {feedback === null ? null : (
+        <p className="text-sm text-destructive">{feedback}</p>
+      )}
+    </div>
   );
 }
 
@@ -114,69 +94,4 @@ function getDeleteErrorMessage(error: Error): string {
   }
 
   return "The recipe could not be deleted. Please try again.";
-}
-
-function getOwnerActionState(
-  isSessionLoading: boolean,
-  recipe: RecipeDetail,
-  sessionState: AuthSessionState | undefined,
-): {
-  ctaLabel: string | null;
-  ctaTo: "/account" | "/recipes";
-  ctaVariant: "default" | "outline";
-  description: string;
-  title: string;
-} {
-  if (isSessionLoading) {
-    return {
-      ctaLabel: null,
-      ctaTo: "/recipes",
-      ctaVariant: "outline",
-      description:
-        "Checking access for this recipe.",
-      title: "Checking access",
-    };
-  }
-
-  if (sessionState === undefined || sessionState.kind === "guest") {
-    return {
-      ctaLabel: "Go to account",
-      ctaTo: "/account",
-      ctaVariant: "default",
-      description:
-        "Sign in to manage recipes.",
-      title: "Sign in required",
-    };
-  }
-
-  if (sessionState.kind === "unconfigured") {
-    return {
-      ctaLabel: "Review account setup",
-      ctaTo: "/account",
-      ctaVariant: "outline",
-      description:
-        "Auth is not configured in this environment.",
-      title: "Auth setup needed",
-    };
-  }
-
-  if (sessionState.userId === recipe.ownerId) {
-    return {
-      ctaLabel: "Visit account",
-      ctaTo: "/account",
-      ctaVariant: "outline",
-      description:
-        "You can manage this recipe.",
-      title: "You own this recipe",
-    };
-  }
-
-  return {
-    ctaLabel: null,
-    ctaTo: "/recipes",
-    ctaVariant: "outline",
-    description:
-      "This recipe belongs to another account.",
-    title: "Public view only",
-  };
 }

--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -1,8 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-
 import {
   formatRecipeTime,
   formatRecipeYield,
@@ -23,7 +21,6 @@ export function RecipePreviewCard({
   recipe,
 }: RecipePreviewCardProps): JSX.Element {
   const summary = getRecipeSummary(recipe.summary, recipe.description);
-  const description = recipe.description.trim();
   const metadata = [
     formatRecipeTime(recipe),
     formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit),
@@ -31,50 +28,47 @@ export function RecipePreviewCard({
   ];
 
   return (
-    <article className="rounded-[2rem] border border-border/70 bg-card/95 p-5 shadow-[0_18px_54px_-40px_rgba(69,52,35,0.5)] sm:p-6">
-      <div className="flex flex-col gap-5">
-        <RecipeCoverImage
-          coverImagePath={recipe.coverImagePath}
-          title={recipe.title}
-          variant="list"
-        />
-        <div className="space-y-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primary">
-              Public recipe
-            </span>
-            {metadata.map((item) => (
-              <span
-                key={item}
-                className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground"
-              >
-                {item}
-              </span>
-            ))}
-          </div>
+    <article className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <RecipeCoverImage
+        coverImagePath={recipe.coverImagePath}
+        title={recipe.title}
+        variant="list"
+      />
 
-          <div>
-            <h2 className="font-display text-2xl tracking-[-0.03em] text-foreground sm:text-[2rem]">
+      <div className="flex h-full flex-col gap-4 p-5">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold tracking-tight text-foreground">
+            <Link
+              className="transition hover:text-primary"
+              params={{ recipeId: recipe.id }}
+              to="/recipes/$recipeId"
+            >
               {recipe.title}
-            </h2>
-            <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-              {summary}
-            </p>
-            {description !== "" && description !== summary ? (
-              <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
-                {description}
-              </p>
-            ) : null}
-          </div>
+            </Link>
+          </h2>
+          <p className="truncate text-sm text-muted-foreground">{summary}</p>
         </div>
 
-        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-border/70 pt-4">
-          <Button asChild variant="outline" size="lg" className="rounded-full px-4">
-            <Link to="/recipes/$recipeId" params={{ recipeId: recipe.id }}>
-              Open recipe
-              <ArrowRight />
-            </Link>
-          </Button>
+        <div className="flex flex-wrap gap-2">
+          {metadata.map((item) => (
+            <span
+              key={item}
+              className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-auto flex justify-end">
+          <Link
+            className="inline-flex items-center gap-1 text-sm font-medium text-primary transition hover:underline"
+            params={{ recipeId: recipe.id }}
+            to="/recipes/$recipeId"
+          >
+            Open
+            <ArrowRight className="size-4" />
+          </Link>
         </div>
       </div>
     </article>

--- a/src/features/recipes/components/RecipeScalingPanel.tsx
+++ b/src/features/recipes/components/RecipeScalingPanel.tsx
@@ -23,30 +23,21 @@ export function RecipeScalingPanel({
   const isScalable = canScaleRecipe(recipe);
 
   return (
-    <section className="rounded-[1.75rem] border border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(245,237,224,0.84))] p-5 shadow-[0_18px_54px_-42px_rgba(69,52,35,0.45)]">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-            Serving scale
-          </p>
-          <h2 className="mt-2 font-display text-2xl tracking-[-0.03em] text-foreground">
-            {getScalingPanelTitle(recipe, isScalable)}
-          </h2>
-        </div>
-        <span className="rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
-          {formatScaleLabel(scaleFactor)}
-        </span>
+    <section className="flex flex-col gap-4 border-t border-border pt-6 lg:flex-row lg:items-center lg:justify-between">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold tracking-tight text-foreground">
+          Scale ingredients
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {isScalable ? formatScaleLabel(scaleFactor) : getScalingPanelStatus(recipe)}
+        </p>
       </div>
 
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-        {getScalingPanelDescription(recipe, isScalable)}
-      </p>
-
-      <div className="mt-5 flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2">
         {recipeScaleOptions.map((option) => (
           <Button
             key={option.label}
-            className="rounded-full px-4"
+            className="rounded-md px-4"
             disabled={!isScalable}
             onClick={() => {
               onScaleChange(option.value);
@@ -63,32 +54,12 @@ export function RecipeScalingPanel({
   );
 }
 
-function getScalingPanelTitle(
+function getScalingPanelStatus(
   recipe: Pick<RecipeDetail, "isScalable" | "yieldQuantity">,
-  isScalable: boolean,
 ): string {
-  if (isScalable) {
-    return "Adjust the batch size";
-  }
-
   if (!recipe.isScalable) {
-    return "This recipe stays at its base yield";
+    return "This recipe uses a fixed yield.";
   }
 
-  return "Add a numeric yield to unlock scaling";
-}
-
-function getScalingPanelDescription(
-  recipe: Pick<RecipeDetail, "isScalable" | "yieldQuantity">,
-  isScalable: boolean,
-): string {
-  if (isScalable) {
-    return "Use half, base, or double to update the displayed yield and ingredient amounts without changing the saved recipe.";
-  }
-
-  if (!recipe.isScalable) {
-    return "The author marked this recipe as a fixed-yield dish, so the ingredient list stays anchored to the original batch size.";
-  }
-
-  return "Scaling is available for recipes with a numeric base yield. Once that metadata exists, the ingredient list can resize from this panel.";
+  return "Add a numeric yield to enable scaling.";
 }

--- a/src/features/recipes/components/RecipesEmptyState.tsx
+++ b/src/features/recipes/components/RecipesEmptyState.tsx
@@ -4,14 +4,14 @@ import type { JSX } from "react";
 
 export function RecipesEmptyState(): JSX.Element {
   return (
-    <section className="border border-dashed border-border/80 px-6 py-12 text-center sm:px-8">
-      <div className="mx-auto flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+    <section className="rounded-xl border border-dashed border-border px-6 py-12 text-center sm:px-8">
+      <div className="mx-auto flex size-11 items-center justify-center rounded-lg bg-muted text-muted-foreground">
         <NotebookText className="size-6" />
       </div>
-      <h2 className="mt-4 font-display text-3xl tracking-[-0.03em] text-foreground">
+      <h2 className="mt-4 text-2xl font-semibold tracking-tight text-foreground">
         No recipes yet.
       </h2>
-      <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+      <p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">
         Recipes will show up here when they are added.
       </p>
     </section>

--- a/src/features/recipes/components/RecipesPage.tsx
+++ b/src/features/recipes/components/RecipesPage.tsx
@@ -25,8 +25,8 @@ export function RecipesPage({
   const recipes = recipeListQuery.data;
 
   return (
-    <main className="mx-auto flex w-full max-w-[92rem] flex-col gap-6 py-6">
-      <RecipesPageHeader recipeCount={recipes.length} />
+    <main className="flex w-full flex-col gap-6 py-3 sm:py-4">
+      <RecipesPageHeader />
       {showDeletedBanner ? <RecipeDeleteSuccessBanner /> : null}
       <RecipesPageContent recipes={recipes} />
     </main>

--- a/src/features/recipes/components/RecipesPageContent.tsx
+++ b/src/features/recipes/components/RecipesPageContent.tsx
@@ -16,7 +16,7 @@ export function RecipesPageContent({
   }
 
   return (
-    <section className="grid gap-4">
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
       {recipes.map((recipe) => (
         <RecipePreviewCard key={recipe.id} recipe={recipe} />
       ))}

--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -4,41 +4,19 @@ import { Button } from "@/components/ui/button";
 
 import type { JSX } from "react";
 
-type RecipesPageHeaderProps = {
-  recipeCount?: number;
-};
-
-export function RecipesPageHeader({
-  recipeCount,
-}: RecipesPageHeaderProps): JSX.Element {
-  const countLabel =
-    recipeCount === undefined
-      ? "Browse recipes"
-      : `${recipeCount} ${recipeCount === 1 ? "recipe" : "recipes"}`;
-
+export function RecipesPageHeader(): JSX.Element {
   return (
-    <section className="border-b border-border/70 pb-5">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div className="max-w-3xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-            Recipe Shelf
-          </p>
-          <h1 className="mt-2 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
-            Recipes
-          </h1>
-          <p className="mt-3 text-sm leading-7 text-muted-foreground sm:text-base">
-            Browse recipes and open the ones you want to cook.
-          </p>
-        </div>
+    <section className="flex flex-col gap-4 border-b border-border pb-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          Recipes
+        </h1>
+      </div>
 
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-primary">
-            {countLabel}
-          </span>
-          <Button asChild size="lg" className="rounded-md px-4">
-            <Link to="/recipes/new">Create recipe</Link>
+      <div className="flex items-center gap-3">
+        <Button asChild className="rounded-md px-4" size="lg">
+          <Link to="/recipes/new">New recipe</Link>
           </Button>
-        </div>
       </div>
     </section>
   );

--- a/src/features/recipes/components/RecipesPageLoading.tsx
+++ b/src/features/recipes/components/RecipesPageLoading.tsx
@@ -4,29 +4,24 @@ import type { JSX } from "react";
 
 export function RecipesPageLoading(): JSX.Element {
   return (
-    <main className="mx-auto flex w-full max-w-[92rem] flex-col gap-6 py-6">
+    <main className="flex w-full flex-col gap-6 py-3 sm:py-4">
       <RecipesPageHeader />
-      <section aria-hidden="true" className="grid gap-4">
-        {Array.from({ length: 3 }, (_, index) => (
+      <section aria-hidden="true" className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }, (_, index) => (
           <div
             key={`loading-recipe-${index}`}
-            className="rounded-[2rem] border border-border/70 bg-card/90 p-6 shadow-[0_18px_54px_-40px_rgba(69,52,35,0.5)]"
+            className="rounded-xl border border-border bg-card p-5 shadow-sm"
           >
             <div className="animate-pulse space-y-4">
+              <div className="aspect-[16/9] rounded-lg bg-muted" />
+              <div className="h-7 w-2/3 rounded-md bg-muted" />
+              <div className="h-4 w-full rounded-md bg-muted" />
               <div className="flex flex-wrap gap-2">
-                <div className="h-7 w-32 rounded-full bg-muted" />
-                <div className="h-7 w-24 rounded-full bg-muted" />
-                <div className="h-7 w-28 rounded-full bg-muted" />
+                <div className="h-6 w-24 rounded-full bg-muted" />
+                <div className="h-6 w-20 rounded-full bg-muted" />
+                <div className="h-6 w-20 rounded-full bg-muted" />
               </div>
-              <div className="h-10 w-2/3 rounded-2xl bg-muted" />
-              <div className="space-y-2">
-                <div className="h-4 w-full rounded-full bg-muted" />
-                <div className="h-4 w-5/6 rounded-full bg-muted" />
-                <div className="h-4 w-2/3 rounded-full bg-muted" />
-              </div>
-              <div className="border-t border-border/70 pt-4">
-                <div className="h-10 w-36 rounded-full bg-muted" />
-              </div>
+              <div className="ml-auto h-5 w-16 rounded-md bg-muted" />
             </div>
           </div>
         ))}

--- a/src/features/theme/components/ThemePresetPicker.tsx
+++ b/src/features/theme/components/ThemePresetPicker.tsx
@@ -1,5 +1,3 @@
-import { Sparkles } from "lucide-react";
-
 import { cn } from "@/lib/utils";
 
 import { themePresets, type ThemePresetId } from "../utils/themePresets";
@@ -19,84 +17,97 @@ export function ThemePresetPicker({
 }: ThemePresetPickerProps): JSX.Element {
   const isCompact = variant === "compact";
 
+  if (isCompact) {
+    return (
+      <section className="grid gap-2 sm:grid-cols-3">
+        {themePresets.map((themePreset) => (
+          <ThemePresetOption
+            activeThemePresetId={activeThemePresetId}
+            isCompact={true}
+            key={themePreset.id}
+            onThemePresetChange={onThemePresetChange}
+            themePreset={themePreset}
+          />
+        ))}
+      </section>
+    );
+  }
+
   return (
-    <section
-      className={
+    <section className="space-y-4">
+      <div>
+        <p className="text-sm font-semibold text-foreground">Theme</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Choose the app appearance.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        {themePresets.map((themePreset) => (
+          <ThemePresetOption
+            activeThemePresetId={activeThemePresetId}
+            isCompact={false}
+            key={themePreset.id}
+            onThemePresetChange={onThemePresetChange}
+            themePreset={themePreset}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ThemePresetOption({
+  activeThemePresetId,
+  isCompact,
+  onThemePresetChange,
+  themePreset,
+}: {
+  activeThemePresetId: ThemePresetId;
+  isCompact: boolean;
+  onThemePresetChange: (themePresetId: ThemePresetId) => void;
+  themePreset: (typeof themePresets)[number];
+}): JSX.Element {
+  const isActive = themePreset.id === activeThemePresetId;
+
+  return (
+    <button
+      aria-pressed={isActive}
+      className={cn(
         isCompact
-          ? "rounded-[1.5rem] border border-border/70 bg-background/80 p-4"
-          : "rounded-[1.75rem] border border-border/70 bg-background/72 p-4 shadow-[0_18px_48px_-36px_rgba(69,52,35,0.5)]"
-      }
+          ? "rounded-md border px-3 py-3 text-left transition outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/30"
+          : "rounded-lg border px-3 py-3 text-left transition outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/30",
+        isActive
+          ? "border-primary/35 bg-primary/8"
+          : "border-border bg-background hover:border-primary/20 hover:bg-background",
+      )}
+      onClick={() => {
+        onThemePresetChange(themePreset.id);
+      }}
+      type="button"
     >
-      <div className="flex items-start gap-3">
-        <div
-          className={
-            isCompact
-              ? "mt-0.5 flex size-9 items-center justify-center rounded-xl bg-primary/10 text-primary"
-              : "mt-0.5 flex size-10 items-center justify-center rounded-2xl bg-primary/10 text-primary"
-          }
-        >
-          <Sparkles className="size-4" />
-        </div>
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-            Theme
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">
+            {themePreset.label}
           </p>
           {isCompact ? null : (
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Swap preset token sets without changing the recipe layout or focus
-              states.
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              {themePreset.description}
             </p>
           )}
         </div>
+        <div className="flex items-center gap-1.5">
+          {themePreset.swatches.map((swatch) => (
+            <span
+              key={swatch}
+              aria-hidden="true"
+              className="size-3.5 rounded-full border border-white/70 shadow-sm"
+              style={{ backgroundColor: swatch }}
+            />
+          ))}
+        </div>
       </div>
-
-      <div className={isCompact ? "mt-3 grid gap-2" : "mt-4 grid gap-2"}>
-        {themePresets.map((themePreset) => {
-          const isActive = themePreset.id === activeThemePresetId;
-
-          return (
-            <button
-              key={themePreset.id}
-              aria-pressed={isActive}
-              className={cn(
-                isCompact
-                  ? "rounded-[1rem] border px-3 py-2.5 text-left transition outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/30"
-                  : "rounded-[1.35rem] border px-3 py-3 text-left transition outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/30",
-                isActive
-                  ? "border-primary/35 bg-primary/8 shadow-[0_14px_36px_-28px_rgba(69,52,35,0.45)]"
-                  : "border-border/70 bg-background/78 hover:border-primary/20 hover:bg-background",
-              )}
-              onClick={() => {
-                onThemePresetChange(themePreset.id);
-              }}
-              type="button"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-sm font-semibold text-foreground">
-                    {themePreset.label}
-                  </p>
-                  {isCompact ? null : (
-                    <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                      {themePreset.description}
-                    </p>
-                  )}
-                </div>
-                <div className="flex items-center gap-1.5">
-                  {themePreset.swatches.map((swatch) => (
-                    <span
-                      key={swatch}
-                      aria-hidden="true"
-                      className="size-3.5 rounded-full border border-white/70 shadow-sm"
-                      style={{ backgroundColor: swatch }}
-                    />
-                  ))}
-                </div>
-              </div>
-            </button>
-          );
-        })}
-      </div>
-    </section>
+    </button>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -39,34 +39,7 @@
   --sidebar-border: oklch(0.89 0.018 80);
   --sidebar-ring: oklch(0.62 0.08 150);
   --app-body-background:
-    radial-gradient(circle at top left, rgba(116, 149, 92, 0.16), transparent 28%),
-    radial-gradient(circle at top right, rgba(217, 170, 93, 0.16), transparent 24%),
-    linear-gradient(
-      180deg,
-      rgba(255, 252, 247, 0.98) 0%,
-      rgba(247, 240, 229, 0.96) 44%,
-      rgba(252, 248, 241, 0.98) 100%
-    );
-  --app-shell-overlay:
-    radial-gradient(
-      circle at top left,
-      rgba(118, 150, 94, 0.18),
-      transparent 30%
-    ),
-    radial-gradient(
-      circle at top right,
-      rgba(220, 174, 104, 0.16),
-      transparent 24%
-    );
-  --app-shell-top-wash: linear-gradient(180deg, rgba(255, 255, 255, 0.42), transparent);
-  --app-shell-divider:
-    linear-gradient(90deg, transparent, rgba(94, 123, 73, 0.3), transparent);
-  --app-shell-header-surface:
-    linear-gradient(135deg, rgba(255, 252, 246, 0.92), rgba(244, 236, 222, 0.92));
-  --app-shell-footer-surface:
-    linear-gradient(180deg, rgba(255, 253, 249, 0.92), rgba(246, 238, 226, 0.92));
-  --app-shell-icon-gradient:
-    linear-gradient(180deg, rgba(95, 123, 73, 1), rgba(70, 96, 54, 1));
+    linear-gradient(180deg, rgba(252, 249, 244, 1), rgba(248, 243, 234, 1));
 }
 
 :root[data-theme-preset="light"] {
@@ -101,17 +74,7 @@
   --sidebar-border: oklch(0.9 0 0);
   --sidebar-ring: oklch(0.45 0 0);
   --app-body-background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.995), rgba(245, 245, 245, 0.99));
-  --app-shell-overlay: none;
-  --app-shell-top-wash: linear-gradient(180deg, rgba(255, 255, 255, 0.7), transparent);
-  --app-shell-divider:
-    linear-gradient(90deg, transparent, rgba(24, 24, 27, 0.1), transparent);
-  --app-shell-header-surface:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 248, 248, 0.98));
-  --app-shell-footer-surface:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 248, 248, 0.98));
-  --app-shell-icon-gradient:
-    linear-gradient(180deg, rgba(39, 39, 42, 1), rgba(24, 24, 27, 1));
+    linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(245, 245, 245, 1));
 }
 
 :root[data-theme-preset="dark"] {
@@ -147,18 +110,7 @@
   --sidebar-border: oklch(0.3 0 0 / 85%);
   --sidebar-ring: oklch(0.78 0 0);
   --app-body-background:
-    linear-gradient(180deg, rgba(9, 9, 11, 0.995), rgba(24, 24, 27, 0.99));
-  --app-shell-overlay:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.04), transparent 28%);
-  --app-shell-top-wash: linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent);
-  --app-shell-divider:
-    linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
-  --app-shell-header-surface:
-    linear-gradient(180deg, rgba(24, 24, 27, 0.96), rgba(17, 17, 19, 0.96));
-  --app-shell-footer-surface:
-    linear-gradient(180deg, rgba(24, 24, 27, 0.96), rgba(17, 17, 19, 0.96));
-  --app-shell-icon-gradient:
-    linear-gradient(180deg, rgba(250, 250, 250, 1), rgba(212, 212, 216, 1));
+    linear-gradient(180deg, rgba(9, 9, 11, 1), rgba(24, 24, 27, 1));
 }
 
 @theme inline {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -33,27 +33,17 @@ const ReactQueryDevtools = isDev
 
 function RootShell(): JSX.Element {
   const sessionQuery = useQuery(sessionQueryOptions);
-  const authSummary = getAuthSummary(sessionQuery.isLoading, sessionQuery.data);
+  const authActionLabel = getAuthActionLabel(
+    sessionQuery.isLoading,
+    sessionQuery.data,
+  );
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-background">
-      <div
-        className="pointer-events-none absolute inset-0"
-        style={{ backgroundImage: "var(--app-shell-overlay)" }}
-      />
-      <div
-        className="pointer-events-none absolute inset-x-0 top-0 h-64"
-        style={{ backgroundImage: "var(--app-shell-top-wash)" }}
-      />
-      <div
-        className="pointer-events-none absolute inset-x-8 top-40 h-px"
-        style={{ backgroundImage: "var(--app-shell-divider)" }}
-      />
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto flex min-h-screen w-full max-w-[96rem] flex-col px-4 sm:px-6 lg:px-8">
+        <AppShellHeader authActionLabel={authActionLabel} />
 
-      <div className="relative mx-auto flex min-h-screen w-full max-w-[92rem] flex-col px-4 sm:px-6 lg:px-8">
-        <AppShellHeader authSummary={authSummary} />
-
-        <div className="flex-1 py-4 sm:py-6">
+        <div className="flex-1 py-5 sm:py-6">
           <Outlet />
         </div>
       </div>
@@ -61,61 +51,25 @@ function RootShell(): JSX.Element {
   );
 }
 
-function getAuthSummary(
+function getAuthActionLabel(
   isLoading: boolean,
   sessionState: AuthSessionState | undefined,
-): {
-  badgeClassName: string;
-  badgeText: string;
-  ctaLabel: string;
-  supportingText: string;
-} {
+): string {
   if (isLoading) {
-    return {
-      badgeClassName:
-        "border border-border/70 bg-background/85 text-muted-foreground",
-      badgeText: "Checking access",
-      ctaLabel: "Account",
-      supportingText: "Loading account status.",
-    };
+    return "Account";
   }
 
   if (sessionState === undefined) {
-    return {
-      badgeClassName:
-        "border border-amber-300/70 bg-amber-50/85 text-amber-950",
-      badgeText: "Guest browsing",
-      ctaLabel: "Sign in",
-      supportingText: "Sign in to manage recipes.",
-    };
+    return "Sign in";
   }
 
   switch (sessionState.kind) {
     case "authenticated":
-      return {
-        badgeClassName:
-          "border border-emerald-300/80 bg-emerald-50/90 text-emerald-950",
-        badgeText:
-          sessionState.email === null ? "Signed in" : sessionState.email,
-        ctaLabel: "Account",
-        supportingText: "You can manage recipes from your account.",
-      };
+      return "Account";
     case "guest":
-      return {
-        badgeClassName:
-          "border border-amber-300/80 bg-amber-50/90 text-amber-950",
-        badgeText: "Guest browsing",
-        ctaLabel: "Sign in",
-        supportingText: "Browse recipes or sign in.",
-      };
+      return "Sign in";
     case "unconfigured":
-      return {
-        badgeClassName:
-          "border border-border/70 bg-background/85 text-muted-foreground",
-        badgeText: "Auth setup needed",
-        ctaLabel: "Account",
-        supportingText: "Auth is not configured in this environment.",
-      };
+      return "Account";
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify the app shell into a standard navbar with cleaner page framing and lighter backgrounds
- redesign the recipes list, detail, create, and account pages to remove heavy card wrappers and filler copy
- keep the existing recipe, auth, theme, scaling, delete, and cook-log behavior while making the UI feel more like a regular website

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only refactor
- no auth policy, storage policy, or schema behavior changed

Closes #64
