### PR TITLE
fix(recipes): refine detail page layout

### DIFF
--- a/src/features/recipes/components/RecipeDetailHero.tsx
+++ b/src/features/recipes/components/RecipeDetailHero.tsx
@@ -2,7 +2,6 @@ import { Link } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import type { AuthSessionState } from "@/features/auth";
 
 import {
   formatRecipeTime,
@@ -12,26 +11,22 @@ import {
 } from "../utils/recipePresentation";
 
 import { RecipeCoverImage } from "./RecipeCoverImage";
-import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipeDetailHeroProps = {
-  isSessionLoading: boolean;
   recipe: RecipeDetail;
   scaleFactor: number;
-  sessionState: AuthSessionState | undefined;
 };
 
 export function RecipeDetailHero({
-  isSessionLoading,
   recipe,
   scaleFactor,
-  sessionState,
 }: RecipeDetailHeroProps): JSX.Element {
   const summary = getRecipeSummary(recipe.summary, recipe.description);
   const description = recipe.description.trim();
+  const hasCoverImage = recipe.coverImagePath !== null;
   const metadata = [
     formatRecipeTime(recipe),
     formatRecipeYield(recipe.yieldQuantity, recipe.yieldUnit, scaleFactor),
@@ -49,28 +44,26 @@ export function RecipeDetailHero({
         </Button>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)] lg:items-start">
+      <div
+        className={
+          hasCoverImage
+            ? "grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)] lg:items-start"
+            : "space-y-5"
+        }
+      >
         <div className="min-w-0 space-y-5">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-            <div className="min-w-0">
-              <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
-                {recipe.title}
-              </h1>
-              <p className="mt-3 max-w-3xl text-base text-muted-foreground">
-                {summary}
+          <div className="min-w-0">
+            <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+              {recipe.title}
+            </h1>
+            <p className="mt-3 max-w-3xl text-base text-muted-foreground">
+              {summary}
+            </p>
+            {description !== "" && description !== summary ? (
+              <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+                {description}
               </p>
-              {description !== "" && description !== summary ? (
-                <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
-                  {description}
-                </p>
-              ) : null}
-            </div>
-
-            <RecipeOwnerActionsPanel
-              isSessionLoading={isSessionLoading}
-              recipe={recipe}
-              sessionState={sessionState}
-            />
+            ) : null}
           </div>
 
           <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -30,13 +30,9 @@ export function RecipeDetailPage({
 
   return (
     <main className="flex w-full flex-col gap-8 py-3 sm:py-4">
-      <RecipeDetailHero
-        isSessionLoading={sessionQuery.isLoading}
-        recipe={recipe}
-        scaleFactor={scaleFactor}
-        sessionState={sessionQuery.data}
-      />
+      <RecipeDetailHero recipe={recipe} scaleFactor={scaleFactor} />
       <RecipeDetailPageSections
+        isSessionLoading={sessionQuery.isLoading}
         onScaleChange={setScaleFactor}
         recipe={recipe}
         scaleFactor={scaleFactor}

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -2,12 +2,14 @@ import type { AuthSessionState } from "@/features/auth";
 
 import { RecipeCookLogSection } from "./RecipeCookLogSection";
 import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
+import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
 import { RecipeScalingPanel } from "./RecipeScalingPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipeDetailPageSectionsProps = {
+  isSessionLoading: boolean;
   onScaleChange: (scaleFactor: number) => void;
   recipe: RecipeDetail;
   scaleFactor: number;
@@ -15,6 +17,7 @@ type RecipeDetailPageSectionsProps = {
 };
 
 export function RecipeDetailPageSections({
+  isSessionLoading,
   onScaleChange,
   recipe,
   scaleFactor,
@@ -48,6 +51,11 @@ export function RecipeDetailPageSections({
         title="Method"
       />
       <RecipeCookLogSection recipe={recipe} sessionState={sessionState} />
+      <RecipeOwnerActionsPanel
+        isSessionLoading={isSessionLoading}
+        recipe={recipe}
+        sessionState={sessionState}
+      />
     </div>
   );
 }

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -41,46 +41,56 @@ export function RecipeOwnerActionsPanel({
   }
 
   return (
-    <div className="flex flex-col items-start gap-2 lg:items-end">
-      <RecipeDeleteDialog
-        description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
-        isPending={deleteRecipeMutation.isPending}
-        onConfirm={() => {
-          setFeedback(null);
-          deleteRecipeMutation.mutate(
-            { recipeId: recipe.id },
-            {
-              onError: (error) => {
-                setFeedback(getDeleteErrorMessage(error));
-              },
-              onSuccess: () => {
-                setIsDeleteDialogOpen(false);
-                void navigate({
-                  search: { deleted: "1" },
-                  to: "/recipes",
-                });
-              },
-            },
-          );
-        }}
-        onOpenChange={(open) => {
-          setIsDeleteDialogOpen(open);
-          if (open) {
+    <section className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="max-w-2xl">
+          <h2 className="text-sm font-semibold text-foreground">Danger zone</h2>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Delete this recipe if you no longer want it on the shelf. This
+            removes the detail, ingredients, equipment, and method steps.
+          </p>
+        </div>
+
+        <RecipeDeleteDialog
+          description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
+          isPending={deleteRecipeMutation.isPending}
+          onConfirm={() => {
             setFeedback(null);
-          }
-        }}
-        open={isDeleteDialogOpen}
-        title="Delete this recipe?"
-      >
-        <Button className="rounded-md px-4" size="lg" variant="destructive">
-          Delete
-        </Button>
-      </RecipeDeleteDialog>
+            deleteRecipeMutation.mutate(
+              { recipeId: recipe.id },
+              {
+                onError: (error) => {
+                  setFeedback(getDeleteErrorMessage(error));
+                },
+                onSuccess: () => {
+                  setIsDeleteDialogOpen(false);
+                  void navigate({
+                    search: { deleted: "1" },
+                    to: "/recipes",
+                  });
+                },
+              },
+            );
+          }}
+          onOpenChange={(open) => {
+            setIsDeleteDialogOpen(open);
+            if (open) {
+              setFeedback(null);
+            }
+          }}
+          open={isDeleteDialogOpen}
+          title="Delete this recipe?"
+        >
+          <Button className="rounded-md px-4" size="lg" variant="destructive">
+            Delete recipe
+          </Button>
+        </RecipeDeleteDialog>
+      </div>
 
       {feedback === null ? null : (
-        <p className="text-sm text-destructive">{feedback}</p>
+        <p className="mt-3 text-sm text-destructive">{feedback}</p>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/features/recipes/components/RecipeScalingPanel.tsx
+++ b/src/features/recipes/components/RecipeScalingPanel.tsx
@@ -24,13 +24,22 @@ export function RecipeScalingPanel({
 
   return (
     <section className="flex flex-col gap-4 border-t border-border pt-6 lg:flex-row lg:items-center lg:justify-between">
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold tracking-tight text-foreground">
-          Scale ingredients
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          {isScalable ? formatScaleLabel(scaleFactor) : getScalingPanelStatus(recipe)}
-        </p>
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            Scale ingredients
+          </h2>
+          {isScalable ? (
+            <span className="rounded-full border border-border bg-background px-3 py-1 text-sm text-muted-foreground">
+              Current: {formatScaleLabel(scaleFactor)}
+            </span>
+          ) : null}
+        </div>
+        {!isScalable ? (
+          <p className="text-sm text-muted-foreground">
+            {getScalingPanelStatus(recipe)}
+          </p>
+        ) : null}
       </div>
 
       <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- collapse the detail-page hero to a single-column layout when no cover image exists
- show the active scale state as a contextual badge instead of an orphaned line of text
- move recipe deletion into a lower-page danger zone instead of the hero area

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only layout adjustment
- no auth, storage, or schema behavior changed

Closes #67
