### PR TITLE
fix(recipes): simplify detail page labels

### DIFF
--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -61,14 +61,14 @@ export function RecipeCookLogSection({
     sessionState.userId === recipe.ownerId;
 
   return (
-    <section className="space-y-4 border-t border-border pt-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <section className="space-y-6 border-t border-border pt-6">
+      <div className="flex items-center gap-3">
         <h2 className="text-2xl font-semibold tracking-tight text-foreground">
           Kitchen memories
         </h2>
-        <p className="text-sm text-muted-foreground">
-          {recipe.cookLogs.length} {recipe.cookLogs.length === 1 ? "entry" : "entries"}
-        </p>
+        <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
+          {recipe.cookLogs.length}
+        </span>
       </div>
 
       {feedback === null ? null : (
@@ -87,76 +87,82 @@ export function RecipeCookLogSection({
       )}
 
       {isOwner ? (
-        <form
-          className="rounded-lg border border-border bg-background p-4"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void handleCreateCookLog();
-          }}
-        >
-          <div className="grid gap-4 md:grid-cols-2">
-            <label>
-              <span className="text-sm font-medium text-foreground">Cooked on</span>
-              <input
-                className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
-                onChange={(event) => {
-                  setCookedOn(event.target.value);
-                }}
-                type="date"
-                value={cookedOn}
-              />
-            </label>
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-foreground">Add a cook memory</h3>
+          <form
+            className="rounded-lg border border-border bg-background p-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleCreateCookLog();
+            }}
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              <label>
+                <span className="text-sm font-medium text-foreground">Cooked on</span>
+                <input
+                  className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  onChange={(event) => {
+                    setCookedOn(event.target.value);
+                  }}
+                  type="date"
+                  value={cookedOn}
+                />
+              </label>
 
-            <label>
-              <span className="text-sm font-medium text-foreground">Photo</span>
-              <input
-                accept="image/jpeg,image/png,image/webp"
-                className="mt-2 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-                disabled={isSubmitting}
-                onChange={(event) => {
-                  setSelectedPhoto(event.target.files?.[0] ?? null);
-                }}
-                type="file"
-              />
-            </label>
+              <label>
+                <span className="text-sm font-medium text-foreground">Photo</span>
+                <input
+                  accept="image/jpeg,image/png,image/webp"
+                  className="mt-2 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  disabled={isSubmitting}
+                  onChange={(event) => {
+                    setSelectedPhoto(event.target.files?.[0] ?? null);
+                  }}
+                  type="file"
+                />
+              </label>
 
-            <label className="md:col-span-2">
-              <span className="text-sm font-medium text-foreground">Notes</span>
-              <textarea
-                className="mt-2 min-h-28 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
-                onChange={(event) => {
-                  setNotes(event.target.value);
-                }}
-                placeholder="What changed, what worked, and what you want to remember next time."
-                value={notes}
-              />
-            </label>
-          </div>
+              <label className="md:col-span-2">
+                <span className="text-sm font-medium text-foreground">Notes</span>
+                <textarea
+                  className="mt-2 min-h-28 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  onChange={(event) => {
+                    setNotes(event.target.value);
+                  }}
+                  placeholder="What changed, what worked, and what you want to remember next time."
+                  value={notes}
+                />
+              </label>
+            </div>
 
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              {selectedPhoto === null
-                ? "No memory photo selected."
-                : `Selected photo: ${selectedPhoto.name}`}
-            </p>
-            <Button className="rounded-md px-5" disabled={isSubmitting} size="lg" type="submit">
-              {isSubmitting ? "Saving memory..." : "Save cook memory"}
-            </Button>
-          </div>
-        </form>
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              {selectedPhoto === null ? <span /> : (
+                <p className="text-sm text-muted-foreground">
+                  Selected photo: {selectedPhoto.name}
+                </p>
+              )}
+              <Button className="rounded-md px-5" disabled={isSubmitting} size="lg" type="submit">
+                {isSubmitting ? "Saving memory..." : "Save cook memory"}
+              </Button>
+            </div>
+          </form>
+        </div>
       ) : null}
 
-      {recipe.cookLogs.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
-          No cook memories were saved for this recipe yet.
-        </div>
-      ) : (
-        <ol className="space-y-4">
-          {recipe.cookLogs.map((cookLog) => (
-            <CookLogCard key={cookLog.id} cookLog={cookLog} />
-          ))}
-        </ol>
-      )}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">Saved memories</h3>
+        {recipe.cookLogs.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
+            No cook memories were saved for this recipe yet.
+          </div>
+        ) : (
+          <ol className="space-y-4">
+            {recipe.cookLogs.map((cookLog) => (
+              <CookLogCard key={cookLog.id} cookLog={cookLog} />
+            ))}
+          </ol>
+        )}
+      </div>
     </section>
   );
 

--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -3,7 +3,6 @@ import {
   formatCountdownClock,
   formatIngredientText,
   formatStepTimer,
-  getRecipeCountLabel,
 } from "../utils/recipePresentation";
 
 import { RecipeStepTimerControl } from "./RecipeStepTimerControl";
@@ -40,11 +39,13 @@ export function RecipeDetailCollectionSection(
 
   return (
     <section className="space-y-4 border-t border-border pt-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-3">
         <h2 className="text-2xl font-semibold tracking-tight text-foreground">
           {props.title}
         </h2>
-        <p className="text-sm text-muted-foreground">{getCountText(props.kind, props.items.length)}</p>
+        <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
+          {props.items.length}
+        </span>
       </div>
 
       {props.items.length === 0 ? (
@@ -165,20 +166,6 @@ export function RecipeDetailCollectionSection(
       ) : null}
     </section>
   );
-}
-
-function getCountText(
-  kind: RecipeDetailCollectionSectionProps["kind"],
-  count: number,
-): string {
-  switch (kind) {
-    case "ingredients":
-      return getRecipeCountLabel(count, "ingredient");
-    case "equipment":
-      return getRecipeCountLabel(count, "piece", "pieces");
-    case "steps":
-      return getRecipeCountLabel(count, "step");
-  }
 }
 
 function getEmptyText(kind: RecipeDetailCollectionSectionProps["kind"]): string {

--- a/src/features/recipes/components/RecipeDetailPageErrorState.tsx
+++ b/src/features/recipes/components/RecipeDetailPageErrorState.tsx
@@ -13,24 +13,21 @@ export function RecipeDetailPageErrorState({
   const copy = getRecipeLoadErrorCopy(error, "detail");
 
   return (
-    <main className="mx-auto flex w-full max-w-[84rem] flex-col gap-6 py-6">
+    <main className="flex w-full max-w-6xl flex-col gap-6 py-3 sm:py-4">
       <div className="flex flex-wrap items-center gap-3">
-        <Button asChild variant="ghost" size="lg" className="rounded-full px-4">
-          <Link to="/recipes">Back to recipe shelf</Link>
+        <Button asChild className="rounded-md px-4" size="lg" variant="ghost">
+          <Link to="/recipes">Back to recipes</Link>
         </Button>
-        <Button onClick={reset} size="lg" className="rounded-full px-4">
+        <Button className="rounded-md px-4" onClick={reset} size="lg">
           Try again
         </Button>
       </div>
 
-      <section className="rounded-[2rem] border border-destructive/20 bg-destructive/5 px-6 py-8 shadow-[0_20px_60px_-48px_rgba(120,53,15,0.45)] sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-destructive">
-          Recipe Detail Unavailable
-        </p>
-        <h1 className="mt-3 font-display text-4xl tracking-[-0.04em] text-foreground sm:text-5xl">
+      <section className="rounded-lg border border-destructive/20 bg-destructive/5 px-6 py-6 sm:px-8">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           {copy.title}
         </h1>
-        <p className="mt-3 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
           {copy.description}
         </p>
       </section>

--- a/src/features/recipes/components/RecipeStepTimerControl.tsx
+++ b/src/features/recipes/components/RecipeStepTimerControl.tsx
@@ -24,17 +24,17 @@ export function RecipeStepTimerControl({
   const displaySeconds = isActive ? (remainingSeconds ?? timerSeconds) : timerSeconds;
 
   return (
-    <div className="mt-3 rounded-[1.2rem] border border-amber-300/60 bg-amber-50/75 px-3 py-3 shadow-[0_12px_28px_-24px_rgba(146,104,28,0.45)]">
+    <div className="mt-3 rounded-lg border border-border bg-muted/40 px-3 py-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <span className="flex size-8 items-center justify-center rounded-full bg-amber-100 text-amber-950">
+          <span className="flex size-8 items-center justify-center rounded-full bg-background text-muted-foreground">
             <BellRing className="size-4" />
           </span>
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-950/80">
-              Step timer
+            <p className="text-sm font-medium text-foreground">
+              Timer
             </p>
-            <p className="text-sm font-medium text-amber-950">
+            <p className="text-sm text-muted-foreground">
               {isActive ? `${formatCountdownClock(displaySeconds)} left` : formatCountdownClock(displaySeconds)}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- restyle the detail error state to match the newer plain-heading direction
- simplify the step timer header and quiet the section-count presentation
- separate the cook memory form from saved-memory content and remove redundant photo-status copy

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only cleanup
- no auth, storage, or schema behavior changed

Closes #68
