### PR TITLE
fix(ui): streamline browse navigation

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -26,12 +26,7 @@ export function AppShellHeader({
 
           <nav className="flex items-center gap-1">
             <Button asChild className="rounded-md px-3" size="sm" variant="ghost">
-              <Link
-                activeProps={{
-                  className: "bg-accent text-accent-foreground",
-                }}
-                to="/recipes"
-              >
+              <Link to="/recipes">
                 Recipes
               </Link>
             </Button>

--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -1,8 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { ThemePresetPicker, useThemePreset } from "@/features/theme";
 
 import {
@@ -226,12 +224,6 @@ export function AccountPage(): JSX.Element {
             variant="compact"
           />
         </section>
-
-        <div className="border-t border-border pt-6">
-          <Button asChild className="rounded-md px-4" size="lg" variant="outline">
-            <Link to="/recipes">Browse recipes</Link>
-          </Button>
-        </div>
       </div>
     </main>
   );

--- a/src/features/recipes/components/RecipesPageContent.tsx
+++ b/src/features/recipes/components/RecipesPageContent.tsx
@@ -16,7 +16,7 @@ export function RecipesPageContent({
   }
 
   return (
-    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <section className="grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
       {recipes.map((recipe) => (
         <RecipePreviewCard key={recipe.id} recipe={recipe} />
       ))}

--- a/src/features/recipes/components/RecipesPageLoading.tsx
+++ b/src/features/recipes/components/RecipesPageLoading.tsx
@@ -6,7 +6,7 @@ export function RecipesPageLoading(): JSX.Element {
   return (
     <main className="flex w-full flex-col gap-6 py-3 sm:py-4">
       <RecipesPageHeader />
-      <section aria-hidden="true" className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      <section aria-hidden="true" className="grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
         {Array.from({ length: 6 }, (_, index) => (
           <div
             key={`loading-recipe-${index}`}


### PR DESCRIPTION
## Summary
- make the `Recipes` nav item use a consistent visual treatment across pages
- remove the redundant browse-recipes button from the account page
- keep the recipe shelf in a two-column grid for longer before switching to three columns

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only cleanup
- no auth, storage, or schema behavior changed

Closes #69
