### PR TITLE
fix(ui): add route page titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web application template</title>
+    <title>Recipe Book</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { ThemePresetPicker, useThemePreset } from "@/features/theme";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 import {
   signInMutationOptions,
@@ -56,6 +57,8 @@ function getHeadlineDescription(
 }
 
 export function AccountPage(): JSX.Element {
+  useDocumentTitle("Account");
+
   const queryClient = useQueryClient();
   const sessionQuery = useQuery(sessionQueryOptions);
   const signInMutation = useMutation(signInMutationOptions(queryClient));

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { sessionQueryOptions } from "@/features/auth";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 import { RecipeDataAccessError } from "../queries/recipeApi";
 import { isRecipeMutationAuthError } from "../queries/recipeAuth";
@@ -27,6 +28,8 @@ type FormFeedback = {
 };
 
 export function CreateRecipePage(): JSX.Element {
+  useDocumentTitle("Create Recipe");
+
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const sessionQuery = useQuery(sessionQueryOptions);

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { sessionQueryOptions } from "@/features/auth";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 import { recipeDetailQueryOptions } from "../queries/recipeQueryOptions";
 
@@ -21,6 +22,12 @@ export function RecipeDetailPage({
   const recipeDetailQuery = useQuery(recipeDetailQueryOptions(recipeId));
   const sessionQuery = useQuery(sessionQueryOptions);
   const [scaleFactor, setScaleFactor] = useState(1);
+
+  useDocumentTitle(
+    recipeDetailQuery.data === undefined
+      ? "Loading Recipe"
+      : recipeDetailQuery.data.title,
+  );
 
   if (recipeDetailQuery.data === undefined) {
     return <RecipeDetailPageLoading />;

--- a/src/features/recipes/components/RecipeDetailPageErrorState.tsx
+++ b/src/features/recipes/components/RecipeDetailPageErrorState.tsx
@@ -1,6 +1,7 @@
 import { Link, type ErrorComponentProps } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 import { getRecipeLoadErrorCopy } from "../utils/recipePresentation";
 
@@ -11,6 +12,8 @@ export function RecipeDetailPageErrorState({
   reset,
 }: ErrorComponentProps): JSX.Element {
   const copy = getRecipeLoadErrorCopy(error, "detail");
+
+  useDocumentTitle(copy.title);
 
   return (
     <main className="flex w-full max-w-6xl flex-col gap-6 py-3 sm:py-4">

--- a/src/features/recipes/components/RecipeDetailPageLoading.tsx
+++ b/src/features/recipes/components/RecipeDetailPageLoading.tsx
@@ -1,6 +1,10 @@
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
 import type { JSX } from "react";
 
 export function RecipeDetailPageLoading(): JSX.Element {
+  useDocumentTitle("Loading Recipe");
+
   return (
     <main className="flex w-full flex-col gap-8 py-3 sm:py-4">
       <div aria-hidden="true" className="animate-pulse space-y-6">

--- a/src/features/recipes/components/RecipesPage.tsx
+++ b/src/features/recipes/components/RecipesPage.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
 import { recipeListQueryOptions } from "../queries/recipeQueryOptions";
 
 import { RecipeDeleteSuccessBanner } from "./RecipeDeleteSuccessBanner";
@@ -16,6 +18,8 @@ type RecipesPageProps = {
 export function RecipesPage({
   showDeletedBanner = false,
 }: RecipesPageProps): JSX.Element {
+  useDocumentTitle("Recipes");
+
   const recipeListQuery = useQuery(recipeListQueryOptions());
 
   if (recipeListQuery.data === undefined) {

--- a/src/features/recipes/components/RecipesPageErrorState.tsx
+++ b/src/features/recipes/components/RecipesPageErrorState.tsx
@@ -1,6 +1,7 @@
 import { type ErrorComponentProps } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 import { getRecipeLoadErrorCopy } from "../utils/recipePresentation";
 
@@ -13,6 +14,8 @@ export function RecipesPageErrorState({
   reset,
 }: ErrorComponentProps): JSX.Element {
   const copy = getRecipeLoadErrorCopy(error, "list");
+
+  useDocumentTitle("Recipes Unavailable");
 
   return (
     <main className="mx-auto flex w-full max-w-[92rem] flex-col gap-6 py-6">

--- a/src/features/recipes/components/RecipesPageLoading.tsx
+++ b/src/features/recipes/components/RecipesPageLoading.tsx
@@ -1,8 +1,12 @@
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
 import { RecipesPageHeader } from "./RecipesPageHeader";
 
 import type { JSX } from "react";
 
 export function RecipesPageLoading(): JSX.Element {
+  useDocumentTitle("Recipes");
+
   return (
     <main className="flex w-full flex-col gap-6 py-3 sm:py-4">
       <RecipesPageHeader />

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+import { buildDocumentTitle } from "@/lib/documentTitle";
+
+export function useDocumentTitle(pageTitle?: string): void {
+  useEffect(() => {
+    document.title = buildDocumentTitle(pageTitle);
+  }, [pageTitle]);
+}

--- a/src/lib/documentTitle.test.ts
+++ b/src/lib/documentTitle.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDocumentTitle } from "./documentTitle";
+
+describe("buildDocumentTitle", () => {
+  it("returns the app name when no page title is provided", () => {
+    expect(buildDocumentTitle()).toBe("Recipe Book");
+    expect(buildDocumentTitle("")).toBe("Recipe Book");
+    expect(buildDocumentTitle("   ")).toBe("Recipe Book");
+  });
+
+  it("appends the app name when a page title is provided", () => {
+    expect(buildDocumentTitle("Recipes")).toBe("Recipes - Recipe Book");
+    expect(buildDocumentTitle("Beef Stroganoff")).toBe(
+      "Beef Stroganoff - Recipe Book",
+    );
+  });
+});

--- a/src/lib/documentTitle.ts
+++ b/src/lib/documentTitle.ts
@@ -1,0 +1,9 @@
+const appName = "Recipe Book";
+
+export function buildDocumentTitle(pageTitle?: string): string {
+  if (pageTitle === undefined || pageTitle.trim().length === 0) {
+    return appName;
+  }
+
+  return `${pageTitle} - ${appName}`;
+}


### PR DESCRIPTION
## Summary
- replace the starter document title with a Recipe Book default
- add a shared document-title hook for route-visible screens
- set meaningful titles for recipe list, create, account, detail, and error/loading states

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only metadata change
- no auth, storage, or schema behavior changed

Closes #70