### PR TITLE
fix(recipes): stabilize detail error titles

### DIFF
--- a/src/features/recipes/components/RecipeDetailPageErrorState.tsx
+++ b/src/features/recipes/components/RecipeDetailPageErrorState.tsx
@@ -3,7 +3,10 @@ import { Link, type ErrorComponentProps } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
-import { getRecipeLoadErrorCopy } from "../utils/recipePresentation";
+import {
+  getRecipeLoadDocumentTitle,
+  getRecipeLoadErrorCopy,
+} from "../utils/recipePresentation";
 
 import type { JSX } from "react";
 
@@ -12,8 +15,9 @@ export function RecipeDetailPageErrorState({
   reset,
 }: ErrorComponentProps): JSX.Element {
   const copy = getRecipeLoadErrorCopy(error, "detail");
+  const documentTitle = getRecipeLoadDocumentTitle(error, "detail");
 
-  useDocumentTitle(copy.title);
+  useDocumentTitle(documentTitle);
 
   return (
     <main className="flex w-full max-w-6xl flex-col gap-6 py-3 sm:py-4">

--- a/src/features/recipes/utils/recipePresentation.test.ts
+++ b/src/features/recipes/utils/recipePresentation.test.ts
@@ -8,6 +8,7 @@ import {
   formatRecipeTime,
   formatRecipeYield,
   formatStepTimer,
+  getRecipeLoadDocumentTitle,
   getRecipeLoadErrorCopy,
   getRecipeSummary,
 } from "./recipePresentation";
@@ -158,6 +159,32 @@ describe("getRecipeLoadErrorCopy", () => {
         "This recipe may have been removed, or the link may no longer point to a public entry.",
       title: "That recipe could not be found.",
     });
+  });
+});
+
+describe("getRecipeLoadDocumentTitle", () => {
+  it("uses a stable not-found title for missing recipe detail routes", () => {
+    expect(
+      getRecipeLoadDocumentTitle(
+        new RecipeDataAccessError("not-found", "Recipe not found."),
+        "detail",
+      ),
+    ).toBe("Recipe Not Found");
+  });
+
+  it("uses a stable unavailable title for other detail failures", () => {
+    expect(getRecipeLoadDocumentTitle(new Error("Network"), "detail")).toBe(
+      "Recipe Unavailable",
+    );
+    expect(
+      getRecipeLoadDocumentTitle(
+        new RecipeDataAccessError(
+          "supabase-unconfigured",
+          "Supabase is not configured.",
+        ),
+        "detail",
+      ),
+    ).toBe("Recipe Unavailable");
   });
 });
 

--- a/src/features/recipes/utils/recipePresentation.ts
+++ b/src/features/recipes/utils/recipePresentation.ts
@@ -9,6 +9,26 @@ type RecipeLoadErrorCopy = {
   title: string;
 };
 
+export function getRecipeLoadDocumentTitle(
+  error: unknown,
+  surface: RecipeLoadSurface,
+): string {
+  if (surface === "detail" && error instanceof RecipeDataAccessError) {
+    switch (error.code) {
+      case "not-found":
+        return "Recipe Not Found";
+      case "supabase-unconfigured":
+        return "Recipe Unavailable";
+    }
+  }
+
+  if (surface === "detail") {
+    return "Recipe Unavailable";
+  }
+
+  return "Recipes Unavailable";
+}
+
 export function formatRecipeTime(recipe: {
   cookMinutes: number | null;
   prepMinutes: number | null;


### PR DESCRIPTION
## Summary
- stop using the rendered detail error heading as the browser tab title
- add a stable detail error title helper for not-found and generic failure states
- cover the new title behavior with focused presentation tests

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only document title cleanup
- no auth, storage, or schema behavior changed

Closes #77