### PR TITLE
fix(recipes): simplify danger zone styling

### DIFF
--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -41,16 +41,15 @@ export function RecipeOwnerActionsPanel({
   }
 
   return (
-    <section className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="max-w-2xl">
-          <h2 className="text-sm font-semibold text-foreground">Danger zone</h2>
-          <p className="mt-1 text-sm leading-6 text-muted-foreground">
-            Delete this recipe if you no longer want it on the shelf. This
-            removes the detail, ingredients, equipment, and method steps.
-          </p>
-        </div>
-
+    <section className="border-t border-destructive/25 pt-6">
+      <div className="max-w-2xl">
+        <h3 className="text-sm font-semibold tracking-tight text-destructive/85">
+          Danger zone
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          Delete this recipe if you no longer want it on the shelf. This removes
+          the detail, ingredients, equipment, and method steps.
+        </p>
         <RecipeDeleteDialog
           description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
           isPending={deleteRecipeMutation.isPending}
@@ -81,7 +80,11 @@ export function RecipeOwnerActionsPanel({
           open={isDeleteDialogOpen}
           title="Delete this recipe?"
         >
-          <Button className="rounded-md px-4" size="lg" variant="destructive">
+          <Button
+            className="mt-3 h-auto px-0 py-0 text-destructive hover:text-destructive/80"
+            size="sm"
+            variant="link"
+          >
             Delete recipe
           </Button>
         </RecipeDeleteDialog>


### PR DESCRIPTION
## Summary
- replace the heavy danger-zone card with a lighter divider-based section
- restyle the destructive action as a small link-style trigger instead of a full button
- keep the existing delete confirmation flow and error handling intact

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- UI-only detail-page styling change
- no auth, storage, or schema behavior changed

Closes #80