### PR TITLE
fix(recipes): keep equipment optional by default

### DIFF
--- a/src/features/recipes/utils/recipeFormValues.test.ts
+++ b/src/features/recipes/utils/recipeFormValues.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyRecipeCreateFormValues } from "./recipeFormValues";
+
+describe("createEmptyRecipeCreateFormValues", () => {
+  it("starts equipment empty while keeping required collections seeded", () => {
+    expect(createEmptyRecipeCreateFormValues()).toMatchObject({
+      equipment: [],
+      ingredients: [expect.any(Object)],
+      steps: [expect.any(Object)],
+    });
+  });
+});

--- a/src/features/recipes/utils/recipeFormValues.ts
+++ b/src/features/recipes/utils/recipeFormValues.ts
@@ -64,7 +64,7 @@ export function createEmptyRecipeCreateFormValues(): RecipeCreateFormValues {
   return {
     cookMinutes: "",
     description: "",
-    equipment: [createEmptyRecipeEquipmentFormValue()],
+    equipment: [],
     ingredients: [createEmptyRecipeIngredientFormValue()],
     isScalable: true,
     prepMinutes: "",


### PR DESCRIPTION
## Summary
- stop preloading the create recipe form with a blank equipment row
- keep ingredients and steps seeded so their required behavior stays unchanged
- add a focused default-state test for the create form values

## Testing
- npm run test
- npm run lint
- npm run build

## Security
- form-defaults-only change
- no auth, storage, or schema behavior changed

Closes #81