### PR TITLE
feat(recipes): add recipe edit flow

### DIFF
--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
 import { useAppToast } from "@/hooks/useAppToast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -122,10 +123,24 @@ export function CreateRecipePage(): JSX.Element {
 
       <div className="mt-6">
         <RecipeCreateForm
-          coverPhotoName={selectedCoverPhoto?.name ?? null}
+          cancelButton={
+            <Button
+              asChild
+              className="rounded-md px-5"
+              size="lg"
+              variant="outline"
+            >
+              <Link to="/recipes">Cancel</Link>
+            </Button>
+          }
           coverPhotoInputResetKey={coverPhotoInputResetKey}
+          coverPhotoStatusMessage={
+            selectedCoverPhoto === null
+              ? "No cover photo selected."
+              : `Selected file: ${selectedCoverPhoto.name}`
+          }
+          hasCoverPhoto={selectedCoverPhoto !== null}
           isPending={isSubmitting}
-          isPhotoAttached={selectedCoverPhoto !== null}
           onCoverPhotoChange={(file) => {
             setSelectedCoverPhoto(file);
           }}
@@ -137,7 +152,10 @@ export function CreateRecipePage(): JSX.Element {
             event.preventDefault();
             handleSubmitRecipe();
           }}
+          removeCoverPhotoLabel="Remove photo"
           setValues={setValues}
+          submitLabel="Create recipe"
+          submitPendingLabel="Saving recipe..."
           values={values}
         />
       </div>

--- a/src/features/recipes/components/EditRecipePage.tsx
+++ b/src/features/recipes/components/EditRecipePage.tsx
@@ -1,0 +1,319 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { sessionQueryOptions } from "@/features/auth";
+import { useAppToast } from "@/hooks/useAppToast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+import { RecipeDataAccessError } from "../queries/recipeApi";
+import { isRecipeMutationAuthError } from "../queries/recipeAuth";
+import { updateRecipeMutationOptions } from "../queries/recipeMutationOptions";
+import {
+  deleteRecipeCoverPhoto,
+  RecipePhotoUploadError,
+  uploadRecipeCoverPhoto,
+} from "../queries/recipePhotoApi";
+import { recipeDetailQueryOptions } from "../queries/recipeQueryOptions";
+import { recipeCreateFormSchema } from "../schemas/recipeFormSchema";
+import {
+  createEmptyRecipeCreateFormValues,
+  createRecipeFormValuesFromRecipe,
+} from "../utils/recipeFormValues";
+
+import { RecipeCreateForm } from "./RecipeCreateForm";
+
+import type { JSX } from "react";
+
+type EditRecipePageProps = {
+  recipeId: string;
+};
+
+export function EditRecipePage({
+  recipeId,
+}: EditRecipePageProps): JSX.Element {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const recipeDetailQuery = useQuery(recipeDetailQueryOptions(recipeId));
+  const sessionQuery = useQuery(sessionQueryOptions);
+  const updateRecipeMutation = useMutation(updateRecipeMutationOptions(queryClient));
+  const { toast } = useAppToast();
+  const [selectedCoverPhoto, setSelectedCoverPhoto] = useState<File | null>(null);
+  const [coverPhotoInputResetKey, setCoverPhotoInputResetKey] = useState(0);
+  const [hasRemovedExistingCoverPhoto, setHasRemovedExistingCoverPhoto] =
+    useState(false);
+  const [initializedRecipeId, setInitializedRecipeId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [values, setValues] = useState(createEmptyRecipeCreateFormValues);
+
+  useDocumentTitle(
+    recipeDetailQuery.data === undefined
+      ? "Edit Recipe"
+      : `Edit ${recipeDetailQuery.data.title}`,
+  );
+
+  useEffect(() => {
+    if (
+      recipeDetailQuery.data === undefined ||
+      initializedRecipeId === recipeDetailQuery.data.id
+    ) {
+      return;
+    }
+
+    setValues(createRecipeFormValuesFromRecipe(recipeDetailQuery.data));
+    setSelectedCoverPhoto(null);
+    setHasRemovedExistingCoverPhoto(false);
+    setInitializedRecipeId(recipeDetailQuery.data.id);
+    setCoverPhotoInputResetKey((current) => current + 1);
+  }, [initializedRecipeId, recipeDetailQuery.data]);
+
+  if (
+    recipeDetailQuery.data === undefined ||
+    sessionQuery.isLoading ||
+    initializedRecipeId !== recipeId
+  ) {
+    return (
+      <main className="w-full max-w-6xl py-3 sm:py-4">
+        <section className="border-b border-border pb-4">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            Loading recipe editor
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Getting the latest recipe details ready for editing.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const recipe = recipeDetailQuery.data;
+  const sessionState = sessionQuery.data;
+
+  if (sessionState === undefined || sessionState.kind === "guest") {
+    return (
+      <RecipeEditAccessState
+        description="Sign in to update ingredients, equipment, steps, and other recipe details."
+        recipeId={recipe.id}
+        title="Sign in to edit this recipe"
+      />
+    );
+  }
+
+  if (sessionState.kind === "unconfigured") {
+    return (
+      <RecipeEditAccessState
+        description="Supabase is not configured for recipe editing in this environment."
+        recipeId={recipe.id}
+        title="Recipe editing is unavailable"
+      />
+    );
+  }
+
+  if (sessionState.userId !== recipe.ownerId) {
+    return (
+      <RecipeEditAccessState
+        description="Only the recipe owner can update this recipe."
+        recipeId={recipe.id}
+        title="You can’t edit this recipe"
+      />
+    );
+  }
+
+  const currentCoverPhotoPath =
+    hasRemovedExistingCoverPhoto ? null : recipe.coverImagePath;
+
+  return (
+    <main className="w-full max-w-6xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          Edit recipe
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Update the recipe details and save when you are ready.
+        </p>
+      </section>
+
+      <div className="mt-6">
+        <RecipeCreateForm
+          cancelButton={
+            <Button
+              asChild
+              className="rounded-md px-5"
+              size="lg"
+              variant="outline"
+            >
+              <Link params={{ recipeId: recipe.id }} to="/recipes/$recipeId">
+                Cancel
+              </Link>
+            </Button>
+          }
+          coverPhotoInputResetKey={coverPhotoInputResetKey}
+          coverPhotoStatusMessage={getCoverPhotoStatusMessage(
+            currentCoverPhotoPath,
+            selectedCoverPhoto,
+          )}
+          hasCoverPhoto={
+            currentCoverPhotoPath !== null || selectedCoverPhoto !== null
+          }
+          isPending={isSubmitting}
+          onCoverPhotoChange={(file) => {
+            setSelectedCoverPhoto(file);
+
+            if (file !== null) {
+              setHasRemovedExistingCoverPhoto(false);
+            }
+          }}
+          onRemoveCoverPhoto={() => {
+            if (selectedCoverPhoto !== null) {
+              setSelectedCoverPhoto(null);
+            } else {
+              setHasRemovedExistingCoverPhoto(true);
+            }
+
+            setCoverPhotoInputResetKey((current) => current + 1);
+          }}
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submitRecipe();
+          }}
+          removeCoverPhotoLabel={
+            selectedCoverPhoto !== null && recipe.coverImagePath !== null
+              ? "Use current photo"
+              : selectedCoverPhoto !== null
+                ? "Remove photo"
+                : "Remove current photo"
+          }
+          setValues={setValues}
+          submitLabel="Save changes"
+          submitPendingLabel="Saving changes..."
+          values={values}
+        />
+      </div>
+    </main>
+  );
+
+  async function submitRecipe(): Promise<void> {
+    const parsedValues = recipeCreateFormSchema.safeParse(values);
+
+    if (!parsedValues.success) {
+      toast({
+        description:
+          parsedValues.error.issues[0]?.message ??
+          "Review the form values and try again.",
+        tone: "error",
+        title: "Recipe form needs attention",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const previousCoverPhotoPath = recipe.coverImagePath;
+    let nextCoverPhotoPath = currentCoverPhotoPath;
+    let uploadedCoverPhotoPath: string | null = null;
+
+    try {
+      if (selectedCoverPhoto !== null) {
+        uploadedCoverPhotoPath = await uploadRecipeCoverPhoto(selectedCoverPhoto);
+        nextCoverPhotoPath = uploadedCoverPhotoPath;
+      }
+
+      const updatedRecipe = await updateRecipeMutation.mutateAsync({
+        ...parsedValues.data,
+        coverImagePath: nextCoverPhotoPath,
+        recipeId: recipe.id,
+      });
+
+      if (
+        previousCoverPhotoPath !== null &&
+        previousCoverPhotoPath !== nextCoverPhotoPath
+      ) {
+        await deleteRecipeCoverPhoto(previousCoverPhotoPath).catch(() => undefined);
+      }
+
+      toast({
+        description: "Your changes are live on the recipe page.",
+        title: "Recipe updated",
+      });
+
+      void navigate({
+        params: { recipeId: updatedRecipe.id },
+        to: "/recipes/$recipeId",
+      });
+    } catch (error) {
+      if (uploadedCoverPhotoPath !== null) {
+        await deleteRecipeCoverPhoto(uploadedCoverPhotoPath).catch(() => undefined);
+      }
+
+      toast({
+        description: getUpdateRecipeErrorMessage(error),
+        tone: "error",
+        title: "Recipe could not be updated",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+}
+
+type RecipeEditAccessStateProps = {
+  description: string;
+  recipeId: string;
+  title: string;
+};
+
+function RecipeEditAccessState({
+  description,
+  recipeId,
+  title,
+}: RecipeEditAccessStateProps): JSX.Element {
+  return (
+    <main className="w-full max-w-6xl py-3 sm:py-4">
+      <section className="space-y-4 border-b border-border pb-6">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          {title}
+        </h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          {description}
+        </p>
+        <Button asChild className="rounded-md px-4" variant="outline">
+          <Link params={{ recipeId }} to="/recipes/$recipeId">
+            Back to recipe
+          </Link>
+        </Button>
+      </section>
+    </main>
+  );
+}
+
+function getCoverPhotoStatusMessage(
+  currentCoverPhotoPath: string | null,
+  selectedCoverPhoto: File | null,
+): string {
+  if (selectedCoverPhoto !== null) {
+    return `Selected file: ${selectedCoverPhoto.name}`;
+  }
+
+  if (currentCoverPhotoPath !== null) {
+    return "Current cover photo will be kept unless you remove it.";
+  }
+
+  return "No cover photo selected.";
+}
+
+function getUpdateRecipeErrorMessage(error: unknown): string {
+  if (isRecipeMutationAuthError(error)) {
+    return error.message;
+  }
+
+  if (error instanceof RecipePhotoUploadError) {
+    return error.message;
+  }
+
+  if (error instanceof RecipeDataAccessError) {
+    return error.message;
+  }
+
+  return "Something went wrong while saving the recipe. Please try again.";
+}

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -1,5 +1,3 @@
-import { Link } from "@tanstack/react-router";
-
 import { Button } from "@/components/ui/button";
 
 import {
@@ -20,28 +18,36 @@ const checkboxClassName =
   "size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20";
 
 type RecipeCreateFormProps = {
-  coverPhotoName: string | null;
+  cancelButton: JSX.Element;
   coverPhotoInputResetKey: number;
-  isPhotoAttached: boolean;
+  coverPhotoStatusMessage: string;
+  hasCoverPhoto: boolean;
   isPending: boolean;
   onCoverPhotoChange: (file: File | null) => void;
   onRemoveCoverPhoto: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  removeCoverPhotoLabel: string;
   setValues: (
     updater: (current: RecipeCreateFormValues) => RecipeCreateFormValues,
   ) => void;
+  submitLabel: string;
+  submitPendingLabel: string;
   values: RecipeCreateFormValues;
 };
 
 export function RecipeCreateForm({
-  coverPhotoName,
+  cancelButton,
   coverPhotoInputResetKey,
-  isPhotoAttached,
+  coverPhotoStatusMessage,
+  hasCoverPhoto,
   isPending,
   onCoverPhotoChange,
   onRemoveCoverPhoto,
   onSubmit,
+  removeCoverPhotoLabel,
   setValues,
+  submitLabel,
+  submitPendingLabel,
   values,
 }: RecipeCreateFormProps): JSX.Element {
   return (
@@ -175,7 +181,7 @@ export function RecipeCreateForm({
                 JPG, PNG, or WebP up to 5 MB.
               </p>
             </div>
-            {isPhotoAttached ? (
+            {hasCoverPhoto ? (
               <Button
                 className="rounded-md px-4"
                 onClick={onRemoveCoverPhoto}
@@ -183,7 +189,7 @@ export function RecipeCreateForm({
                 type="button"
                 variant="outline"
               >
-                Remove photo
+                {removeCoverPhotoLabel}
               </Button>
             ) : null}
           </div>
@@ -199,11 +205,7 @@ export function RecipeCreateForm({
             type="file"
           />
 
-          <p className="text-sm text-muted-foreground">
-            {coverPhotoName === null
-              ? "No cover photo selected."
-              : `Selected file: ${coverPhotoName}`}
-          </p>
+          <p className="text-sm text-muted-foreground">{coverPhotoStatusMessage}</p>
         </div>
       </section>
 
@@ -312,16 +314,14 @@ export function RecipeCreateForm({
       />
 
       <div className="flex flex-wrap items-center justify-end gap-3 border-t border-border pt-6">
-        <Button asChild className="rounded-md px-5" size="lg" variant="outline">
-          <Link to="/recipes">Cancel</Link>
-        </Button>
+        {cancelButton}
         <Button
           className="rounded-md px-6"
           disabled={isPending}
           size="lg"
           type="submit"
         >
-          {isPending ? "Saving recipe..." : "Create recipe"}
+          {isPending ? submitPendingLabel : submitLabel}
         </Button>
       </div>
     </form>

--- a/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
+++ b/src/features/recipes/components/RecipeOwnerActionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -42,55 +42,65 @@ export function RecipeOwnerActionsPanel({
   }
 
   return (
-    <section className="border-t border-destructive/25 pt-6">
-      <div className="max-w-2xl">
-        <h3 className="text-sm font-semibold tracking-tight text-destructive/85">
-          Danger zone
-        </h3>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          Delete this recipe if you no longer want it on the shelf. This removes
-          the detail, ingredients, equipment, and method steps.
-        </p>
-        <RecipeDeleteDialog
-          description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
-          isPending={deleteRecipeMutation.isPending}
-          onConfirm={() => {
-            deleteRecipeMutation.mutate(
-              { recipeId: recipe.id },
-              {
-                onError: (error) => {
-                  toast({
-                    description: getDeleteErrorMessage(error),
-                    tone: "error",
-                    title: "Recipe could not be deleted",
-                  });
+    <div className="space-y-8">
+      <section>
+        <Button asChild className="rounded-md px-4" size="sm" variant="outline">
+          <Link params={{ recipeId: recipe.id }} to="/recipes/$recipeId/edit">
+            Edit recipe
+          </Link>
+        </Button>
+      </section>
+
+      <section className="border-t border-destructive/25 pt-6">
+        <div className="max-w-2xl">
+          <h3 className="text-sm font-semibold tracking-tight text-destructive/85">
+            Danger zone
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Delete this recipe if you no longer want it on the shelf. This removes
+            the detail, ingredients, equipment, and method steps.
+          </p>
+          <RecipeDeleteDialog
+            description="This permanently removes the recipe detail, ingredients, equipment, and method steps from the app. The shelf will refresh after deletion so the removed entry does not linger."
+            isPending={deleteRecipeMutation.isPending}
+            onConfirm={() => {
+              deleteRecipeMutation.mutate(
+                { recipeId: recipe.id },
+                {
+                  onError: (error) => {
+                    toast({
+                      description: getDeleteErrorMessage(error),
+                      tone: "error",
+                      title: "Recipe could not be deleted",
+                    });
+                  },
+                  onSuccess: () => {
+                    setIsDeleteDialogOpen(false);
+                    void navigate({
+                      search: { deleted: "1" },
+                      to: "/recipes",
+                    });
+                  },
                 },
-                onSuccess: () => {
-                  setIsDeleteDialogOpen(false);
-                  void navigate({
-                    search: { deleted: "1" },
-                    to: "/recipes",
-                  });
-                },
-              },
-            );
-          }}
-          onOpenChange={(open) => {
-            setIsDeleteDialogOpen(open);
-          }}
-          open={isDeleteDialogOpen}
-          title="Delete this recipe?"
-        >
-          <Button
-            className="mt-3 h-auto px-0 py-0 text-destructive hover:text-destructive/80"
-            size="sm"
-            variant="link"
+              );
+            }}
+            onOpenChange={(open) => {
+              setIsDeleteDialogOpen(open);
+            }}
+            open={isDeleteDialogOpen}
+            title="Delete this recipe?"
           >
-            Delete recipe
-          </Button>
-        </RecipeDeleteDialog>
-      </div>
-    </section>
+            <Button
+              className="mt-3 h-auto px-0 py-0 text-destructive hover:text-destructive/80"
+              size="sm"
+              variant="link"
+            >
+              Delete recipe
+            </Button>
+          </RecipeDeleteDialog>
+        </div>
+      </section>
+    </div>
   );
 }
 

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -1,4 +1,5 @@
 export { CreateRecipePage } from "./components/CreateRecipePage";
+export { EditRecipePage } from "./components/EditRecipePage";
 export { RecipeDetailPage } from "./components/RecipeDetailPage";
 export { RecipeDetailHero } from "./components/RecipeDetailHero";
 export { RecipeDetailPageErrorState } from "./components/RecipeDetailPageErrorState";
@@ -21,6 +22,7 @@ export {
   getRecipeDetail,
   listRecipes,
   RecipeDataAccessError,
+  updateRecipe,
   type RecipeDataAccessErrorCode,
 } from "./queries/recipeApi";
 export {
@@ -53,6 +55,7 @@ export { recipeMutationKeys, recipeQueryKeys } from "./queries/recipeKeys";
 export {
   createRecipeMutationOptions,
   deleteRecipeMutationOptions,
+  updateRecipeMutationOptions,
 } from "./queries/recipeMutationOptions";
 export {
   preloadRecipeDetail,
@@ -79,12 +82,14 @@ export type {
   RecipeIngredient,
   RecipeListItem,
   RecipeStep,
+  UpdateRecipeInput,
 } from "./types/recipes";
 export {
   createEmptyRecipeCreateFormValues,
   createEmptyRecipeEquipmentFormValue,
   createEmptyRecipeIngredientFormValue,
   createEmptyRecipeStepFormValue,
+  createRecipeFormValuesFromRecipe,
   type RecipeCreateEquipmentFormValue,
   type RecipeCreateFormValues,
   type RecipeCreateIngredientFormValue,

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -19,6 +19,7 @@ import type {
   DeleteRecipeResult,
   RecipeDetail,
   RecipeListItem,
+  UpdateRecipeInput,
 } from "../types/recipes";
 
 type RecipeApiClient = NonNullable<typeof supabase>;
@@ -162,6 +163,36 @@ export async function deleteRecipe(
   };
 }
 
+export async function updateRecipe(
+  input: UpdateRecipeInput,
+  client: RecipeApiClient | null = supabase,
+): Promise<RecipeDetail> {
+  const recipeClient = await requireRecipeMutationAuth(client);
+  const recipeId = input.recipeId.trim();
+  const { data, error } = await recipeClient
+    .from("recipes")
+    .update(buildRecipeInsert(input))
+    .eq("id", recipeId)
+    .select("id")
+    .maybeSingle()
+    .overrideTypes<CreatedRecipeRecord, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data === null) {
+    throw new RecipeDataAccessError(
+      "not-found",
+      `Recipe ${recipeId} was not found or could not be updated.`,
+    );
+  }
+
+  await replaceRecipeRelations(recipeClient, recipeId, input);
+
+  return getRecipeDetail(recipeId, recipeClient);
+}
+
 export async function getRecipeDetail(
   recipeId: string,
   client: RecipeApiClient | null = supabase,
@@ -253,4 +284,39 @@ async function insertRecipeRelations(
       throw error;
     }
   }
+}
+
+async function replaceRecipeRelations(
+  client: RecipeApiClient,
+  recipeId: string,
+  input: CreateRecipeInput,
+): Promise<void> {
+  const ingredientDelete = await client
+    .from("recipe_ingredients")
+    .delete()
+    .eq("recipe_id", recipeId);
+
+  if (ingredientDelete.error !== null) {
+    throw ingredientDelete.error;
+  }
+
+  const equipmentDelete = await client
+    .from("recipe_equipment")
+    .delete()
+    .eq("recipe_id", recipeId);
+
+  if (equipmentDelete.error !== null) {
+    throw equipmentDelete.error;
+  }
+
+  const stepDelete = await client
+    .from("recipe_steps")
+    .delete()
+    .eq("recipe_id", recipeId);
+
+  if (stepDelete.error !== null) {
+    throw stepDelete.error;
+  }
+
+  await insertRecipeRelations(client, recipeId, input);
 }

--- a/src/features/recipes/queries/recipeKeys.ts
+++ b/src/features/recipes/queries/recipeKeys.ts
@@ -9,4 +9,5 @@ export const recipeQueryKeys = {
 export const recipeMutationKeys = {
   create: () => [...recipeQueryKeys.all, "create"] as const,
   delete: () => [...recipeQueryKeys.all, "delete"] as const,
+  update: () => [...recipeQueryKeys.all, "update"] as const,
 };

--- a/src/features/recipes/queries/recipeMutationOptions.ts
+++ b/src/features/recipes/queries/recipeMutationOptions.ts
@@ -1,6 +1,6 @@
 import { mutationOptions } from "@tanstack/react-query";
 
-import { createRecipe, deleteRecipe } from "./recipeApi";
+import { createRecipe, deleteRecipe, updateRecipe } from "./recipeApi";
 import { recipeMutationKeys, recipeQueryKeys } from "./recipeKeys";
 
 import type {
@@ -8,6 +8,7 @@ import type {
   DeleteRecipeInput,
   DeleteRecipeResult,
   RecipeDetail,
+  UpdateRecipeInput,
 } from "../types/recipes";
 import type { QueryClient } from "@tanstack/react-query";
 
@@ -16,6 +17,9 @@ type CreateRecipeMutationOptions = ReturnType<
 >;
 type DeleteRecipeMutationOptions = ReturnType<
   typeof mutationOptions<DeleteRecipeResult, Error, DeleteRecipeInput>
+>;
+type UpdateRecipeMutationOptions = ReturnType<
+  typeof mutationOptions<RecipeDetail, Error, UpdateRecipeInput>
 >;
 
 export function createRecipeMutationOptions(
@@ -39,6 +43,19 @@ export function deleteRecipeMutationOptions(
     mutationKey: recipeMutationKeys.delete(),
     onSuccess: async ({ recipeId }): Promise<void> => {
       queryClient.removeQueries({ queryKey: recipeQueryKeys.detail(recipeId) });
+      await queryClient.invalidateQueries({ queryKey: recipeQueryKeys.lists() });
+    },
+  });
+}
+
+export function updateRecipeMutationOptions(
+  queryClient: QueryClient,
+): UpdateRecipeMutationOptions {
+  return mutationOptions<RecipeDetail, Error, UpdateRecipeInput>({
+    mutationFn: (input): Promise<RecipeDetail> => updateRecipe(input),
+    mutationKey: recipeMutationKeys.update(),
+    onSuccess: async (recipe): Promise<void> => {
+      queryClient.setQueryData(recipeQueryKeys.detail(recipe.id), recipe);
       await queryClient.invalidateQueries({ queryKey: recipeQueryKeys.lists() });
     },
   });

--- a/src/features/recipes/types/recipes.ts
+++ b/src/features/recipes/types/recipes.ts
@@ -110,3 +110,7 @@ export type DeleteRecipeInput = {
 export type DeleteRecipeResult = {
   recipeId: string;
 };
+
+export type UpdateRecipeInput = CreateRecipeInput & {
+  recipeId: string;
+};

--- a/src/features/recipes/utils/recipeFormValues.test.ts
+++ b/src/features/recipes/utils/recipeFormValues.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptyRecipeCreateFormValues } from "./recipeFormValues";
+import {
+  createEmptyRecipeCreateFormValues,
+  createRecipeFormValuesFromRecipe,
+} from "./recipeFormValues";
+
+import type { RecipeDetail } from "../types/recipes";
 
 describe("createEmptyRecipeCreateFormValues", () => {
   it("starts equipment empty while keeping required collections seeded", () => {
@@ -8,6 +13,93 @@ describe("createEmptyRecipeCreateFormValues", () => {
       equipment: [],
       ingredients: [expect.any(Object)],
       steps: [expect.any(Object)],
+    });
+  });
+});
+
+describe("createRecipeFormValuesFromRecipe", () => {
+  it("maps a saved recipe detail into editable form values", () => {
+    const recipe: RecipeDetail = {
+      cookLogs: [],
+      cookMinutes: 25,
+      coverImagePath: "recipe-cover-photos/owner/cover.png",
+      createdAt: "2026-04-03T00:00:00.000Z",
+      description: "A rich tomato sauce.",
+      equipment: [
+        {
+          details: "large pot",
+          id: "equipment-1",
+          isOptional: false,
+          name: "Dutch oven",
+          position: 1,
+        },
+      ],
+      id: "recipe-1",
+      ingredients: [
+        {
+          amount: 2,
+          id: "ingredient-1",
+          isOptional: false,
+          item: "Olive oil",
+          notes: "plus more to serve",
+          position: 1,
+          preparation: "divided",
+          unit: "tbsp",
+        },
+      ],
+      isScalable: true,
+      ownerId: "user-1",
+      prepMinutes: 10,
+      steps: [
+        {
+          id: "step-1",
+          instruction: "Warm the oil.",
+          notes: "Keep the heat medium.",
+          position: 1,
+          timerSeconds: 180,
+        },
+      ],
+      summary: "Simple red sauce",
+      title: "Tomato Sauce",
+      totalMinutes: 35,
+      updatedAt: "2026-04-03T00:00:00.000Z",
+      yieldQuantity: 4,
+      yieldUnit: "servings",
+    };
+
+    expect(createRecipeFormValuesFromRecipe(recipe)).toEqual({
+      cookMinutes: "25",
+      description: "A rich tomato sauce.",
+      equipment: [
+        {
+          details: "large pot",
+          isOptional: false,
+          name: "Dutch oven",
+        },
+      ],
+      ingredients: [
+        {
+          amount: "2",
+          isOptional: false,
+          item: "Olive oil",
+          notes: "plus more to serve",
+          preparation: "divided",
+          unit: "tbsp",
+        },
+      ],
+      isScalable: true,
+      prepMinutes: "10",
+      steps: [
+        {
+          instruction: "Warm the oil.",
+          notes: "Keep the heat medium.",
+          timerSeconds: "180",
+        },
+      ],
+      summary: "Simple red sauce",
+      title: "Tomato Sauce",
+      yieldQuantity: "4",
+      yieldUnit: "servings",
     });
   });
 });

--- a/src/features/recipes/utils/recipeFormValues.ts
+++ b/src/features/recipes/utils/recipeFormValues.ts
@@ -1,3 +1,5 @@
+import type { RecipeDetail } from "../types/recipes";
+
 export type RecipeCreateIngredientFormValue = {
   amount: string;
   isOptional: boolean;
@@ -74,4 +76,47 @@ export function createEmptyRecipeCreateFormValues(): RecipeCreateFormValues {
     yieldQuantity: "",
     yieldUnit: "",
   };
+}
+
+export function createRecipeFormValuesFromRecipe(
+  recipe: RecipeDetail,
+): RecipeCreateFormValues {
+  return {
+    cookMinutes: formatOptionalNumber(recipe.cookMinutes),
+    description: recipe.description,
+    equipment: recipe.equipment.map((item) => ({
+      details: item.details ?? "",
+      isOptional: item.isOptional,
+      name: item.name,
+    })),
+    ingredients:
+      recipe.ingredients.length === 0
+        ? [createEmptyRecipeIngredientFormValue()]
+        : recipe.ingredients.map((ingredient) => ({
+            amount: formatOptionalNumber(ingredient.amount),
+            isOptional: ingredient.isOptional,
+            item: ingredient.item,
+            notes: ingredient.notes ?? "",
+            preparation: ingredient.preparation ?? "",
+            unit: ingredient.unit ?? "",
+          })),
+    isScalable: recipe.isScalable,
+    prepMinutes: formatOptionalNumber(recipe.prepMinutes),
+    steps:
+      recipe.steps.length === 0
+        ? [createEmptyRecipeStepFormValue()]
+        : recipe.steps.map((step) => ({
+            instruction: step.instruction,
+            notes: step.notes ?? "",
+            timerSeconds: formatOptionalNumber(step.timerSeconds),
+          })),
+    summary: recipe.summary,
+    title: recipe.title,
+    yieldQuantity: formatOptionalNumber(recipe.yieldQuantity),
+    yieldUnit: recipe.yieldUnit ?? "",
+  };
+}
+
+function formatOptionalNumber(value: number | null): string {
+  return value === null ? "" : String(value);
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecipesIndexRouteImport } from './routes/recipes.index'
 import { Route as RecipesNewRouteImport } from './routes/recipes.new'
 import { Route as RecipesRecipeIdRouteImport } from './routes/recipes.$recipeId'
+import { Route as RecipesRecipeIdEditRouteImport } from './routes/recipes.$recipeId.edit'
 
 const RecipesRoute = RecipesRouteImport.update({
   id: '/recipes',
@@ -46,30 +47,38 @@ const RecipesRecipeIdRoute = RecipesRecipeIdRouteImport.update({
   path: '/$recipeId',
   getParentRoute: () => RecipesRoute,
 } as any)
+const RecipesRecipeIdEditRoute = RecipesRecipeIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => RecipesRecipeIdRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
-  '/recipes/$recipeId': typeof RecipesRecipeIdRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
   '/recipes/new': typeof RecipesNewRoute
   '/recipes/': typeof RecipesIndexRoute
+  '/recipes/$recipeId/edit': typeof RecipesRecipeIdEditRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
-  '/recipes/$recipeId': typeof RecipesRecipeIdRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
   '/recipes/new': typeof RecipesNewRoute
   '/recipes': typeof RecipesIndexRoute
+  '/recipes/$recipeId/edit': typeof RecipesRecipeIdEditRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
-  '/recipes/$recipeId': typeof RecipesRecipeIdRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
   '/recipes/new': typeof RecipesNewRoute
   '/recipes/': typeof RecipesIndexRoute
+  '/recipes/$recipeId/edit': typeof RecipesRecipeIdEditRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -80,8 +89,15 @@ export interface FileRouteTypes {
     | '/recipes/$recipeId'
     | '/recipes/new'
     | '/recipes/'
+    | '/recipes/$recipeId/edit'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/account' | '/recipes/$recipeId' | '/recipes/new' | '/recipes'
+  to:
+    | '/'
+    | '/account'
+    | '/recipes/$recipeId'
+    | '/recipes/new'
+    | '/recipes'
+    | '/recipes/$recipeId/edit'
   id:
     | '__root__'
     | '/'
@@ -90,6 +106,7 @@ export interface FileRouteTypes {
     | '/recipes/$recipeId'
     | '/recipes/new'
     | '/recipes/'
+    | '/recipes/$recipeId/edit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -142,17 +159,36 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecipesRecipeIdRouteImport
       parentRoute: typeof RecipesRoute
     }
+    '/recipes/$recipeId/edit': {
+      id: '/recipes/$recipeId/edit'
+      path: '/edit'
+      fullPath: '/recipes/$recipeId/edit'
+      preLoaderRoute: typeof RecipesRecipeIdEditRouteImport
+      parentRoute: typeof RecipesRecipeIdRoute
+    }
   }
 }
 
+interface RecipesRecipeIdRouteChildren {
+  RecipesRecipeIdEditRoute: typeof RecipesRecipeIdEditRoute
+}
+
+const RecipesRecipeIdRouteChildren: RecipesRecipeIdRouteChildren = {
+  RecipesRecipeIdEditRoute: RecipesRecipeIdEditRoute,
+}
+
+const RecipesRecipeIdRouteWithChildren = RecipesRecipeIdRoute._addFileChildren(
+  RecipesRecipeIdRouteChildren,
+)
+
 interface RecipesRouteChildren {
-  RecipesRecipeIdRoute: typeof RecipesRecipeIdRoute
+  RecipesRecipeIdRoute: typeof RecipesRecipeIdRouteWithChildren
   RecipesNewRoute: typeof RecipesNewRoute
   RecipesIndexRoute: typeof RecipesIndexRoute
 }
 
 const RecipesRouteChildren: RecipesRouteChildren = {
-  RecipesRecipeIdRoute: RecipesRecipeIdRoute,
+  RecipesRecipeIdRoute: RecipesRecipeIdRouteWithChildren,
   RecipesNewRoute: RecipesNewRoute,
   RecipesIndexRoute: RecipesIndexRoute,
 }

--- a/src/routes/recipes.$recipeId.edit.tsx
+++ b/src/routes/recipes.$recipeId.edit.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { preloadSessionState } from "@/features/auth";
+import {
+  EditRecipePage,
+  preloadRecipeDetail,
+  RecipeDetailPageErrorState,
+  RecipeDetailPageLoading,
+} from "@/features/recipes";
+
+import type { JSX } from "react";
+
+function EditRecipeRoute(): JSX.Element {
+  const { recipeId } = Route.useParams();
+
+  return <EditRecipePage recipeId={recipeId} />;
+}
+
+export const Route = createFileRoute("/recipes/$recipeId/edit")({
+  loader: async ({ context, params }) => {
+    await Promise.all([
+      preloadRecipeDetail(context.queryClient, params.recipeId),
+      preloadSessionState(context.queryClient),
+    ]);
+  },
+  component: EditRecipeRoute,
+  errorComponent: RecipeDetailPageErrorState,
+  pendingComponent: RecipeDetailPageLoading,
+  pendingMs: 0,
+});


### PR DESCRIPTION
## Summary
- add an owner-only edit route for existing recipes and hydrate it from the current recipe detail query
- reuse the existing recipe form for create and edit, including keeping, replacing, or removing cover photos
- add an update mutation path plus form-value mapping coverage so recipe edits refresh the shelf and detail cache cleanly

## Why
Owners could create and delete recipes, but there was no way to edit them after saving. This adds that missing workflow without duplicating the create form or loosening owner-only mutation behavior.

## User impact
Owners can now open an edit flow from a recipe detail page, change the same core fields they use during creation, and save directly back to the recipe detail view.

## Validation
- `npm run test`
- `npm run lint`
- `npm run build`

## Security
- update mutations still go through Supabase auth/RLS via the existing recipe mutation auth guard
- non-owners can load public recipe detail pages but cannot use the edit form or update mutation path
- cover photo replacement cleans up newly uploaded files on failed saves and removes the old photo only after a successful update

Closes #83
