### PR TITLE
fix(ui): remove redundant uploader file copy

### DIFF
--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -134,11 +134,6 @@ export function CreateRecipePage(): JSX.Element {
             </Button>
           }
           coverPhotoInputResetKey={coverPhotoInputResetKey}
-          coverPhotoStatusMessage={
-            selectedCoverPhoto === null
-              ? "No cover photo selected."
-              : `Selected file: ${selectedCoverPhoto.name}`
-          }
           hasCoverPhoto={selectedCoverPhoto !== null}
           isPending={isSubmitting}
           onCoverPhotoChange={(file) => {

--- a/src/features/recipes/components/EditRecipePage.tsx
+++ b/src/features/recipes/components/EditRecipePage.tsx
@@ -149,10 +149,6 @@ export function EditRecipePage({
             </Button>
           }
           coverPhotoInputResetKey={coverPhotoInputResetKey}
-          coverPhotoStatusMessage={getCoverPhotoStatusMessage(
-            currentCoverPhotoPath,
-            selectedCoverPhoto,
-          )}
           hasCoverPhoto={
             currentCoverPhotoPath !== null || selectedCoverPhoto !== null
           }
@@ -285,21 +281,6 @@ function RecipeEditAccessState({
       </section>
     </main>
   );
-}
-
-function getCoverPhotoStatusMessage(
-  currentCoverPhotoPath: string | null,
-  selectedCoverPhoto: File | null,
-): string {
-  if (selectedCoverPhoto !== null) {
-    return `Selected file: ${selectedCoverPhoto.name}`;
-  }
-
-  if (currentCoverPhotoPath !== null) {
-    return "Current cover photo will be kept unless you remove it.";
-  }
-
-  return "No cover photo selected.";
 }
 
 function getUpdateRecipeErrorMessage(error: unknown): string {

--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -125,12 +125,7 @@ export function RecipeCookLogSection({
               </label>
             </div>
 
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-              {selectedPhoto === null ? <span /> : (
-                <p className="text-sm text-muted-foreground">
-                  Selected photo: {selectedPhoto.name}
-                </p>
-              )}
+            <div className="mt-4 flex flex-wrap items-center justify-end gap-3">
               <Button className="rounded-md px-5" disabled={isSubmitting} size="lg" type="submit">
                 {isSubmitting ? "Saving memory..." : "Save cook memory"}
               </Button>

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -20,7 +20,6 @@ const checkboxClassName =
 type RecipeCreateFormProps = {
   cancelButton: JSX.Element;
   coverPhotoInputResetKey: number;
-  coverPhotoStatusMessage: string;
   hasCoverPhoto: boolean;
   isPending: boolean;
   onCoverPhotoChange: (file: File | null) => void;
@@ -38,7 +37,6 @@ type RecipeCreateFormProps = {
 export function RecipeCreateForm({
   cancelButton,
   coverPhotoInputResetKey,
-  coverPhotoStatusMessage,
   hasCoverPhoto,
   isPending,
   onCoverPhotoChange,
@@ -204,8 +202,6 @@ export function RecipeCreateForm({
             }}
             type="file"
           />
-
-          <p className="text-sm text-muted-foreground">{coverPhotoStatusMessage}</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the extra selected-file helper line from the shared recipe cover-photo uploader
- remove the matching selected-photo helper line from the cook-memory uploader
- keep the native file input as the only selected-file indicator in both places

## Why
Both uploaders were repeating information the browser already shows inside the file input, which added clutter without helping the user.

## Validation
- `npm run test`
- `npm run lint`
- `npm run build`

## Security
- UI-only copy cleanup
- no auth, storage, routing, or schema behavior changed

Closes #90
