### PR TITLE
fix(recipes): simplify recipe form collections

### DIFF
--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -207,9 +207,7 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add ingredient"
-        itemLabel="Ingredient"
         items={values.ingredients}
-        minimumItems={1}
         onAdd={() => {
           setValues((current) => ({
             ...current,
@@ -245,9 +243,7 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add equipment"
-        itemLabel="Equipment"
         items={values.equipment}
-        minimumItems={0}
         onAdd={() => {
           setValues((current) => ({
             ...current,
@@ -280,9 +276,8 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add step"
-        itemLabel="Step"
+        getItemHeading={(index) => `Step ${index + 1}`}
         items={values.steps}
-        minimumItems={1}
         onAdd={() => {
           setValues((current) => ({
             ...current,
@@ -326,9 +321,8 @@ export function RecipeCreateForm({
 
 type RecipeCreateCollectionSectionProps<TItem> = {
   addLabel: string;
-  itemLabel: string;
+  getItemHeading?: (index: number) => string | null;
   items: TItem[];
-  minimumItems: number;
   onAdd: () => void;
   onRemove: (index: number) => void;
   renderItem: (item: TItem, index: number) => JSX.Element;
@@ -337,9 +331,8 @@ type RecipeCreateCollectionSectionProps<TItem> = {
 
 function RecipeCreateCollectionSection<TItem>({
   addLabel,
-  itemLabel,
+  getItemHeading,
   items,
-  minimumItems,
   onAdd,
   onRemove,
   renderItem,
@@ -362,30 +355,41 @@ function RecipeCreateCollectionSection<TItem>({
       </div>
 
       <div className="space-y-4">
-        {items.map((item, index) => (
-          <article
-            key={`${title}-${index + 1}`}
-            className="rounded-lg border border-border bg-background p-4"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-sm font-semibold text-foreground">
-                {itemLabel} {index + 1}
-              </p>
-              <Button
-                disabled={items.length <= minimumItems}
-                onClick={() => {
-                  onRemove(index);
-                }}
-                size="sm"
-                type="button"
-                variant="ghost"
+        {items.map((item, index) => {
+          const itemHeading = getItemHeading?.(index) ?? null;
+
+          return (
+            <article
+              key={`${title}-${index + 1}`}
+              className="rounded-lg border border-border bg-background p-4"
+            >
+              <div
+                className={
+                  itemHeading === null
+                    ? "flex justify-end gap-3"
+                    : "flex items-center justify-between gap-3"
+                }
               >
-                Remove
-              </Button>
-            </div>
-            <div className="mt-4">{renderItem(item, index)}</div>
-          </article>
-        ))}
+                {itemHeading !== null ? (
+                  <p className="text-sm font-semibold text-foreground">
+                    {itemHeading}
+                  </p>
+                ) : null}
+                <Button
+                  onClick={() => {
+                    onRemove(index);
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  Remove
+                </Button>
+              </div>
+              <div className="mt-4">{renderItem(item, index)}</div>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/features/recipes/utils/recipeFormValues.test.ts
+++ b/src/features/recipes/utils/recipeFormValues.test.ts
@@ -8,11 +8,19 @@ import {
 import type { RecipeDetail } from "../types/recipes";
 
 describe("createEmptyRecipeCreateFormValues", () => {
-  it("starts equipment empty while keeping required collections seeded", () => {
-    expect(createEmptyRecipeCreateFormValues()).toMatchObject({
+  it("starts ingredient, equipment, and step collections empty", () => {
+    expect(createEmptyRecipeCreateFormValues()).toEqual({
+      cookMinutes: "",
+      description: "",
       equipment: [],
-      ingredients: [expect.any(Object)],
-      steps: [expect.any(Object)],
+      ingredients: [],
+      isScalable: true,
+      prepMinutes: "",
+      steps: [],
+      summary: "",
+      title: "",
+      yieldQuantity: "",
+      yieldUnit: "",
     });
   });
 });
@@ -100,6 +108,36 @@ describe("createRecipeFormValuesFromRecipe", () => {
       title: "Tomato Sauce",
       yieldQuantity: "4",
       yieldUnit: "servings",
+    });
+  });
+
+  it("preserves empty recipe collections instead of seeding placeholders", () => {
+    const recipe: RecipeDetail = {
+      cookLogs: [],
+      cookMinutes: null,
+      coverImagePath: null,
+      createdAt: "2026-04-03T00:00:00.000Z",
+      description: "",
+      equipment: [],
+      id: "recipe-2",
+      ingredients: [],
+      isScalable: false,
+      ownerId: "user-1",
+      prepMinutes: null,
+      steps: [],
+      summary: "",
+      title: "Plain Rice",
+      totalMinutes: null,
+      updatedAt: "2026-04-03T00:00:00.000Z",
+      yieldQuantity: null,
+      yieldUnit: null,
+    };
+
+    expect(createRecipeFormValuesFromRecipe(recipe)).toMatchObject({
+      equipment: [],
+      ingredients: [],
+      steps: [],
+      title: "Plain Rice",
     });
   });
 });

--- a/src/features/recipes/utils/recipeFormValues.ts
+++ b/src/features/recipes/utils/recipeFormValues.ts
@@ -67,10 +67,10 @@ export function createEmptyRecipeCreateFormValues(): RecipeCreateFormValues {
     cookMinutes: "",
     description: "",
     equipment: [],
-    ingredients: [createEmptyRecipeIngredientFormValue()],
+    ingredients: [],
     isScalable: true,
     prepMinutes: "",
-    steps: [createEmptyRecipeStepFormValue()],
+    steps: [],
     summary: "",
     title: "",
     yieldQuantity: "",
@@ -89,27 +89,21 @@ export function createRecipeFormValuesFromRecipe(
       isOptional: item.isOptional,
       name: item.name,
     })),
-    ingredients:
-      recipe.ingredients.length === 0
-        ? [createEmptyRecipeIngredientFormValue()]
-        : recipe.ingredients.map((ingredient) => ({
-            amount: formatOptionalNumber(ingredient.amount),
-            isOptional: ingredient.isOptional,
-            item: ingredient.item,
-            notes: ingredient.notes ?? "",
-            preparation: ingredient.preparation ?? "",
-            unit: ingredient.unit ?? "",
-          })),
+    ingredients: recipe.ingredients.map((ingredient) => ({
+      amount: formatOptionalNumber(ingredient.amount),
+      isOptional: ingredient.isOptional,
+      item: ingredient.item,
+      notes: ingredient.notes ?? "",
+      preparation: ingredient.preparation ?? "",
+      unit: ingredient.unit ?? "",
+    })),
     isScalable: recipe.isScalable,
     prepMinutes: formatOptionalNumber(recipe.prepMinutes),
-    steps:
-      recipe.steps.length === 0
-        ? [createEmptyRecipeStepFormValue()]
-        : recipe.steps.map((step) => ({
-            instruction: step.instruction,
-            notes: step.notes ?? "",
-            timerSeconds: formatOptionalNumber(step.timerSeconds),
-          })),
+    steps: recipe.steps.map((step) => ({
+      instruction: step.instruction,
+      notes: step.notes ?? "",
+      timerSeconds: formatOptionalNumber(step.timerSeconds),
+    })),
     summary: recipe.summary,
     title: recipe.title,
     yieldQuantity: formatOptionalNumber(recipe.yieldQuantity),


### PR DESCRIPTION
## Summary
- start new recipe ingredient and step collections empty instead of pre-seeding blank items
- keep the submit requirement for at least one ingredient and one step in schema validation rather than in the remove-button behavior
- remove numbered headings from non-ordered collection cards while keeping ordered step headings in place

## Why
The shared create/edit recipe form was carrying extra visual chrome that made the page feel busier than it needed to. Starting with empty collections and simplifying the card headings makes the form calmer without changing the underlying recipe rules.

## Validation
- `npm run test`
- `npm run lint`
- `npm run build`

## Security
- UI/form-state only change
- no auth, storage, routing, or schema access rules changed

Closes #91
