### PR TITLE
fix(recipes): toast after recipe creation

### DIFF
--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -91,6 +91,12 @@ export function CreateRecipePage(): JSX.Element {
         coverImagePath: uploadedCoverPhotoPath,
       });
 
+      toast({
+        description: "Your recipe is live on the recipe page.",
+        title: "Recipe created",
+        tone: "success",
+      });
+
       void navigate({
         params: { recipeId: recipe.id },
         to: "/recipes/$recipeId",


### PR DESCRIPTION
## Summary
- show a success toast after a recipe is created
- keep the message consistent with the existing recipe update and cook-memory toasts
- trigger the toast before navigating to the new recipe detail page

## Testing
- npm run test
- npm run lint
- npm run build