### PR TITLE
fix(recipes): redesign batch size controls

### DIFF
--- a/src/features/recipes/components/RecipeScalingPanel.tsx
+++ b/src/features/recipes/components/RecipeScalingPanel.tsx
@@ -1,8 +1,12 @@
+import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 
 import {
   canScaleRecipe,
   formatScaleLabel,
+  isScaleFactorSelected,
+  parseScaleFactorInput,
   recipeScaleOptions,
 } from "../utils/recipeScaling";
 
@@ -21,13 +25,35 @@ export function RecipeScalingPanel({
   scaleFactor,
 }: RecipeScalingPanelProps): JSX.Element {
   const isScalable = canScaleRecipe(recipe);
+  const [customBatchSize, setCustomBatchSize] = useState("");
+  const [customBatchSizeError, setCustomBatchSizeError] = useState<string | null>(
+    null,
+  );
+  const customBatchSizeInputId = `recipe-batch-size-${recipe.id}`;
+
+  function applyScaleFactor(nextScaleFactor: number): void {
+    onScaleChange(nextScaleFactor);
+    setCustomBatchSize(formatScaleLabel(nextScaleFactor));
+    setCustomBatchSizeError(null);
+  }
+
+  function handleCustomBatchSizeSubmit(): void {
+    const parsedScaleFactor = parseScaleFactorInput(customBatchSize);
+
+    if (parsedScaleFactor === null) {
+      setCustomBatchSizeError("Enter a batch size like 1/3, 1/2, 2x, or 4.");
+      return;
+    }
+
+    applyScaleFactor(parsedScaleFactor);
+  }
 
   return (
-    <section className="flex flex-col gap-4 border-t border-border pt-6 lg:flex-row lg:items-center lg:justify-between">
+    <section className="flex flex-col gap-4 border-t border-border pt-6 lg:flex-row lg:items-start lg:justify-between">
       <div className="space-y-2">
         <div className="flex flex-wrap items-center gap-3">
           <h2 className="text-lg font-semibold tracking-tight text-foreground">
-            Scale ingredients
+            Batch size
           </h2>
           {isScalable ? (
             <span className="rounded-full border border-border bg-background px-3 py-1 text-sm text-muted-foreground">
@@ -42,23 +68,70 @@ export function RecipeScalingPanel({
         ) : null}
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {recipeScaleOptions.map((option) => (
-          <Button
-            key={option.label}
-            className="rounded-md px-4"
-            disabled={!isScalable}
-            onClick={() => {
-              onScaleChange(option.value);
+      {isScalable ? (
+        <div className="space-y-3 lg:max-w-xl lg:text-right">
+          <div className="flex flex-wrap gap-2 lg:justify-end">
+            {recipeScaleOptions.map((option) => (
+              <Button
+                key={option.label}
+                className="rounded-md px-4"
+                onClick={() => {
+                  applyScaleFactor(option.value);
+                }}
+                size="sm"
+                type="button"
+                variant={
+                  isScaleFactorSelected(scaleFactor, option.value)
+                    ? "default"
+                    : "outline"
+                }
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+
+          <form
+            className="flex flex-col gap-2 sm:flex-row sm:justify-end"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleCustomBatchSizeSubmit();
             }}
-            size="sm"
-            type="button"
-            variant={scaleFactor === option.value ? "default" : "outline"}
           >
-            {option.label}
-          </Button>
-        ))}
-      </div>
+            <label className="sr-only" htmlFor={customBatchSizeInputId}>
+              Custom batch size
+            </label>
+            <input
+              aria-describedby={`${customBatchSizeInputId}-message`}
+              aria-invalid={customBatchSizeError !== null}
+              className={batchSizeInputClassName}
+              id={customBatchSizeInputId}
+              inputMode="decimal"
+              onChange={(event) => {
+                setCustomBatchSize(event.target.value);
+                setCustomBatchSizeError(null);
+              }}
+              placeholder="1/3, 1/2, 2x, or 4"
+              value={customBatchSize}
+            />
+            <Button className="rounded-md px-4" size="sm" type="submit" variant="outline">
+              Apply
+            </Button>
+          </form>
+
+          <p
+            aria-live="polite"
+            className={
+              customBatchSizeError === null
+                ? "text-sm text-muted-foreground lg:text-right"
+                : "text-sm text-destructive lg:text-right"
+            }
+            id={`${customBatchSizeInputId}-message`}
+          >
+            {customBatchSizeError ?? "Use fractions or multipliers for custom batch sizes."}
+          </p>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -72,3 +145,6 @@ function getScalingPanelStatus(
 
   return "Add a numeric yield to enable scaling.";
 }
+
+const batchSizeInputClassName =
+  "h-9 min-w-40 rounded-md border border-border bg-background px-3 text-sm text-foreground shadow-xs outline-none transition focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/20";

--- a/src/features/recipes/utils/recipeScaling.test.ts
+++ b/src/features/recipes/utils/recipeScaling.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   canScaleRecipe,
   formatScaleLabel,
+  isScaleFactorSelected,
+  parseScaleFactorInput,
   scaleIngredientAmount,
   scaleRecipeYield,
 } from "./recipeScaling";
@@ -35,9 +37,36 @@ describe("scaleRecipeYield", () => {
 
 describe("formatScaleLabel", () => {
   it("formats the supported shortcuts and custom multipliers", () => {
-    expect(formatScaleLabel(1)).toBe("Base");
-    expect(formatScaleLabel(0.5)).toBe("Half batch");
-    expect(formatScaleLabel(2)).toBe("Double batch");
-    expect(formatScaleLabel(1.25)).toBe("1.25x batch");
+    expect(formatScaleLabel(1)).toBe("1x");
+    expect(formatScaleLabel(1 / 3)).toBe("1/3");
+    expect(formatScaleLabel(0.5)).toBe("1/2");
+    expect(formatScaleLabel(2)).toBe("2x");
+    expect(formatScaleLabel(1.25)).toBe("1.25x");
+  });
+});
+
+describe("isScaleFactorSelected", () => {
+  it("matches preset options with a small tolerance", () => {
+    expect(isScaleFactorSelected(1 / 3, 1 / 3)).toBe(true);
+    expect(isScaleFactorSelected(0.333, 1 / 3)).toBe(true);
+    expect(isScaleFactorSelected(0.4, 1 / 3)).toBe(false);
+  });
+});
+
+describe("parseScaleFactorInput", () => {
+  it("accepts common multiplier and fraction formats", () => {
+    expect(parseScaleFactorInput("1/3")).toBeCloseTo(1 / 3);
+    expect(parseScaleFactorInput(" 1 / 2 ")).toBe(0.5);
+    expect(parseScaleFactorInput("2x")).toBe(2);
+    expect(parseScaleFactorInput("4")).toBe(4);
+    expect(parseScaleFactorInput("1.25x")).toBe(1.25);
+  });
+
+  it("rejects empty and invalid batch sizes", () => {
+    expect(parseScaleFactorInput("")).toBeNull();
+    expect(parseScaleFactorInput("0")).toBeNull();
+    expect(parseScaleFactorInput("-2")).toBeNull();
+    expect(parseScaleFactorInput("three")).toBeNull();
+    expect(parseScaleFactorInput("1/0")).toBeNull();
   });
 });

--- a/src/features/recipes/utils/recipeScaling.ts
+++ b/src/features/recipes/utils/recipeScaling.ts
@@ -1,10 +1,27 @@
 import type { RecipeDetail } from "../types/recipes";
 
 export const recipeScaleOptions = [
-  { label: "Half", value: 0.5 },
-  { label: "Base", value: 1 },
-  { label: "Double", value: 2 },
+  { label: "1/3", value: 1 / 3 },
+  { label: "1/2", value: 0.5 },
+  { label: "1x", value: 1 },
+  { label: "2x", value: 2 },
+  { label: "4x", value: 4 },
 ] as const;
+
+const commonScaleLabels = [
+  { label: "1/4", value: 1 / 4 },
+  { label: "1/3", value: 1 / 3 },
+  { label: "1/2", value: 0.5 },
+  { label: "3/4", value: 3 / 4 },
+  { label: "1x", value: 1 },
+  { label: "1.5x", value: 1.5 },
+  { label: "2x", value: 2 },
+  { label: "3x", value: 3 },
+  { label: "4x", value: 4 },
+  { label: "8x", value: 8 },
+] as const;
+
+const scaleFactorTolerance = 0.01;
 
 export function canScaleRecipe(
   recipe: Pick<RecipeDetail, "isScalable" | "yieldQuantity">,
@@ -35,19 +52,63 @@ export function scaleRecipeYield(
 }
 
 export function formatScaleLabel(scaleFactor: number): string {
-  if (scaleFactor === 1) {
-    return "Base";
+  const matchedLabel = commonScaleLabels.find((option) =>
+    isScaleFactorSelected(scaleFactor, option.value),
+  );
+
+  if (matchedLabel !== undefined) {
+    return matchedLabel.label;
   }
 
-  if (scaleFactor === 0.5) {
-    return "Half batch";
+  return `${normalizeScaledNumber(scaleFactor)}x`;
+}
+
+export function isScaleFactorSelected(
+  currentScaleFactor: number,
+  expectedScaleFactor: number,
+): boolean {
+  return Math.abs(currentScaleFactor - expectedScaleFactor) < scaleFactorTolerance;
+}
+
+export function parseScaleFactorInput(value: string): number | null {
+  const trimmedValue = value.trim().toLowerCase();
+
+  if (trimmedValue === "") {
+    return null;
   }
 
-  if (scaleFactor === 2) {
-    return "Double batch";
+  const multiplierValue = trimmedValue.endsWith("x")
+    ? trimmedValue.slice(0, -1).trim()
+    : trimmedValue;
+
+  const fractionMatch = multiplierValue.match(
+    /^(?<numerator>\d+(?:\.\d+)?)\s*\/\s*(?<denominator>\d+(?:\.\d+)?)$/,
+  );
+
+  if (fractionMatch?.groups !== undefined) {
+    const numerator = Number(fractionMatch.groups.numerator);
+    const denominator = Number(fractionMatch.groups.denominator);
+
+    if (
+      !Number.isFinite(numerator) ||
+      !Number.isFinite(denominator) ||
+      denominator <= 0
+    ) {
+      return null;
+    }
+
+    const parsedFraction = numerator / denominator;
+
+    return parsedFraction > 0 ? parsedFraction : null;
   }
 
-  return `${normalizeScaledNumber(scaleFactor)}x batch`;
+  const parsedValue = Number(multiplierValue);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    return null;
+  }
+
+  return parsedValue;
 }
 
 function normalizeScaledNumber(value: number): number {


### PR DESCRIPTION
## Summary
The recipe detail page now uses a cleaner batch-size control instead of the old preset-only scaling toggle. Users can still tap quick presets, but they can also enter custom values like `1/3`, `1/2`, `2x`, or `4` when they need a less common batch size.

## Problem
The previous scaling UI was still framed like an implementation detail. It was labeled `Scale ingredients`, only offered a tiny fixed set of buttons, and did not let people express the kinds of batch sizes they commonly use when cooking from the web.

## Root cause
The scaling feature only exposed hard-coded shortcut buttons and the supporting utilities only understood that narrow set of values. That kept the interface functional, but it made the experience feel constrained and technical.

## Fix
This change renames the control to `Batch size`, expands the preset list to more useful recipe-style shortcuts, and adds a compact custom entry field that accepts fractions and multipliers. The scaling helpers now parse custom values, format friendly labels for common fractions, and keep preset highlighting tolerant enough for fraction-based inputs.

## Validation
I ran `npm run test -- src/features/recipes/utils/recipeScaling.test.ts`, `npm run test`, `npm run lint`, and `npm run build` locally.
