### PR TITLE
feat(recipes): pause and resume step timers

### DIFF
--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -131,10 +131,7 @@ export function RecipeDetailCollectionSection(
                     </p>
                     {step.timerSeconds !== null ? (
                       <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
-                        {stepTimer.activeStepId === step.id &&
-                        stepTimer.remainingSeconds !== null
-                          ? `${formatCountdownClock(stepTimer.remainingSeconds)} left`
-                          : formatStepTimer(step.timerSeconds)}
+                        {getStepTimerBadgeText(step, stepTimer)}
                       </span>
                     ) : null}
                   </div>
@@ -145,15 +142,21 @@ export function RecipeDetailCollectionSection(
                   ) : null}
                   {step.timerSeconds !== null ? (
                     <RecipeStepTimerControl
-                      isActive={stepTimer.activeStepId === step.id}
+                      onPause={stepTimer.pauseTimer}
+                      onReset={stepTimer.resetTimer}
+                      onResume={stepTimer.resumeTimer}
                       onStart={() => {
                         stepTimer.startTimer(step.id, step.timerSeconds ?? 0);
                       }}
-                      onStop={stepTimer.stopTimer}
                       remainingSeconds={
                         stepTimer.activeStepId === step.id
                           ? stepTimer.remainingSeconds
                           : null
+                      }
+                      status={
+                        stepTimer.activeStepId === step.id
+                          ? stepTimer.status
+                          : "idle"
                       }
                       timerSeconds={step.timerSeconds}
                     />
@@ -177,4 +180,25 @@ function getEmptyText(kind: RecipeDetailCollectionSectionProps["kind"]): string 
     case "steps":
       return "No cooking steps were captured for this recipe yet.";
   }
+}
+
+function getStepTimerBadgeText(
+  step: RecipeStep,
+  stepTimer: ReturnType<typeof useStepTimer>,
+): string {
+  if (
+    step.timerSeconds === null ||
+    stepTimer.activeStepId !== step.id ||
+    stepTimer.remainingSeconds === null
+  ) {
+    return formatStepTimer(step.timerSeconds ?? 0);
+  }
+
+  const countdownClock = formatCountdownClock(stepTimer.remainingSeconds);
+
+  if (stepTimer.status === "paused") {
+    return `${countdownClock} paused`;
+  }
+
+  return `${countdownClock} left`;
 }

--- a/src/features/recipes/components/RecipeStepTimerControl.tsx
+++ b/src/features/recipes/components/RecipeStepTimerControl.tsx
@@ -1,27 +1,32 @@
-import { BellRing, PauseCircle, PlayCircle } from "lucide-react";
+import { BellRing, PauseCircle, PlayCircle, RotateCcw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
 import { formatCountdownClock } from "../utils/recipePresentation";
 
+import type { StepTimerStatus } from "../hooks/useStepTimer";
 import type { JSX } from "react";
 
 type RecipeStepTimerControlProps = {
-  isActive: boolean;
+  onPause: () => void;
+  onReset: () => void;
+  onResume: () => void;
   onStart: () => void;
-  onStop: () => void;
   remainingSeconds: number | null;
+  status: StepTimerStatus;
   timerSeconds: number;
 };
 
 export function RecipeStepTimerControl({
-  isActive,
+  onPause,
+  onReset,
+  onResume,
   onStart,
-  onStop,
   remainingSeconds,
+  status,
   timerSeconds,
 }: RecipeStepTimerControlProps): JSX.Element {
-  const displaySeconds = isActive ? (remainingSeconds ?? timerSeconds) : timerSeconds;
+  const displaySeconds = status === "idle" ? timerSeconds : (remainingSeconds ?? timerSeconds);
 
   return (
     <div className="mt-3 rounded-lg border border-border bg-muted/40 px-3 py-3">
@@ -35,35 +40,81 @@ export function RecipeStepTimerControl({
               Timer
             </p>
             <p className="text-sm text-muted-foreground">
-              {isActive ? `${formatCountdownClock(displaySeconds)} left` : formatCountdownClock(displaySeconds)}
+              {getTimerStatusText(status, displaySeconds)}
             </p>
           </div>
         </div>
 
-        {isActive ? (
-          <Button
-            className="rounded-full px-4"
-            onClick={onStop}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <PauseCircle />
-            Stop timer
-          </Button>
-        ) : (
-          <Button
-            className="rounded-full px-4"
-            onClick={onStart}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <PlayCircle />
-            Start timer
-          </Button>
-        )}
+        <div className="flex flex-wrap items-center gap-2">
+          {status === "running" ? (
+            <Button
+              className="rounded-full px-4"
+              onClick={onPause}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <PauseCircle />
+              Pause timer
+            </Button>
+          ) : null}
+
+          {status === "paused" ? (
+            <Button
+              className="rounded-full px-4"
+              onClick={onResume}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <PlayCircle />
+              Resume timer
+            </Button>
+          ) : null}
+
+          {status === "idle" ? (
+            <Button
+              className="rounded-full px-4"
+              onClick={onStart}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <PlayCircle />
+              Start timer
+            </Button>
+          ) : null}
+
+          {status !== "idle" ? (
+            <Button
+              className="rounded-full px-4"
+              onClick={onReset}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <RotateCcw />
+              Reset
+            </Button>
+          ) : null}
+        </div>
       </div>
     </div>
   );
+}
+
+function getTimerStatusText(
+  status: StepTimerStatus,
+  displaySeconds: number,
+): string {
+  const countdownClock = formatCountdownClock(displaySeconds);
+
+  switch (status) {
+    case "running":
+      return `${countdownClock} left`;
+    case "paused":
+      return `Paused at ${countdownClock}`;
+    case "idle":
+      return countdownClock;
+  }
 }

--- a/src/features/recipes/hooks/useStepTimer.test.ts
+++ b/src/features/recipes/hooks/useStepTimer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createRunningStepTimerState,
+  pauseStepTimerState,
+  resetStepTimerState,
+  resumeStepTimerState,
+  tickStepTimerState,
+} from "./useStepTimer";
+
+describe("step timer state helpers", () => {
+  it("starts a running timer for a step", () => {
+    expect(createRunningStepTimerState("step-1", 90)).toEqual({
+      activeStepId: "step-1",
+      remainingSeconds: 90,
+      status: "running",
+    });
+  });
+
+  it("pauses and resumes without losing the remaining time", () => {
+    const runningState = createRunningStepTimerState("step-1", 45);
+    const pausedState = pauseStepTimerState(runningState);
+
+    expect(pausedState).toEqual({
+      activeStepId: "step-1",
+      remainingSeconds: 45,
+      status: "paused",
+    });
+
+    expect(resumeStepTimerState(pausedState)).toEqual(runningState);
+  });
+
+  it("resets to an idle timer state", () => {
+    expect(resetStepTimerState()).toEqual({
+      activeStepId: null,
+      remainingSeconds: null,
+      status: "idle",
+    });
+  });
+
+  it("ticks down while running and resets after the final second", () => {
+    expect(tickStepTimerState(createRunningStepTimerState("step-1", 3))).toEqual({
+      activeStepId: "step-1",
+      remainingSeconds: 2,
+      status: "running",
+    });
+
+    expect(tickStepTimerState(createRunningStepTimerState("step-1", 1))).toEqual(
+      resetStepTimerState(),
+    );
+  });
+
+  it("leaves idle and paused timers untouched when ticking or pausing", () => {
+    const idleState = resetStepTimerState();
+    const pausedState = pauseStepTimerState(createRunningStepTimerState("step-1", 20));
+
+    expect(pauseStepTimerState(idleState)).toEqual(idleState);
+    expect(tickStepTimerState(idleState)).toEqual(idleState);
+    expect(tickStepTimerState(pausedState)).toEqual(pausedState);
+  });
+});

--- a/src/features/recipes/hooks/useStepTimer.ts
+++ b/src/features/recipes/hooks/useStepTimer.ts
@@ -1,33 +1,104 @@
 import { useEffect, useEffectEvent, useState } from "react";
 
+export type StepTimerStatus = "idle" | "paused" | "running";
+
+type StepTimerState = {
+  activeStepId: string | null;
+  remainingSeconds: number | null;
+  status: StepTimerStatus;
+};
+
 type UseStepTimerReturn = {
   activeStepId: string | null;
   remainingSeconds: number | null;
+  pauseTimer: () => void;
+  resetTimer: () => void;
+  resumeTimer: () => void;
   startTimer: (stepId: string, seconds: number) => void;
-  stopTimer: () => void;
+  status: StepTimerStatus;
 };
 
+export function createRunningStepTimerState(
+  stepId: string,
+  seconds: number,
+): StepTimerState {
+  return {
+    activeStepId: stepId,
+    remainingSeconds: seconds,
+    status: "running",
+  };
+}
+
+export function pauseStepTimerState(state: StepTimerState): StepTimerState {
+  if (
+    state.status !== "running" ||
+    state.activeStepId === null ||
+    state.remainingSeconds === null
+  ) {
+    return state;
+  }
+
+  return {
+    ...state,
+    status: "paused",
+  };
+}
+
+export function resetStepTimerState(): StepTimerState {
+  return {
+    activeStepId: null,
+    remainingSeconds: null,
+    status: "idle",
+  };
+}
+
+export function resumeStepTimerState(state: StepTimerState): StepTimerState {
+  if (
+    state.status !== "paused" ||
+    state.activeStepId === null ||
+    state.remainingSeconds === null
+  ) {
+    return state;
+  }
+
+  return {
+    ...state,
+    status: "running",
+  };
+}
+
+export function tickStepTimerState(state: StepTimerState): StepTimerState {
+  if (
+    state.status !== "running" ||
+    state.activeStepId === null ||
+    state.remainingSeconds === null
+  ) {
+    return state;
+  }
+
+  if (state.remainingSeconds <= 1) {
+    return resetStepTimerState();
+  }
+
+  return {
+    ...state,
+    remainingSeconds: state.remainingSeconds - 1,
+  };
+}
+
 export function useStepTimer(): UseStepTimerReturn {
-  const [activeStepId, setActiveStepId] = useState<string | null>(null);
-  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+  const [timerState, setTimerState] = useState<StepTimerState>(resetStepTimerState);
 
   const tick = useEffectEvent(() => {
-    setRemainingSeconds((currentRemainingSeconds) => {
-      if (currentRemainingSeconds === null) {
-        return null;
-      }
-
-      if (currentRemainingSeconds <= 1) {
-        setActiveStepId(null);
-        return null;
-      }
-
-      return currentRemainingSeconds - 1;
-    });
+    setTimerState((currentState) => tickStepTimerState(currentState));
   });
 
   useEffect(() => {
-    if (activeStepId === null || remainingSeconds === null) {
+    if (
+      timerState.status !== "running" ||
+      timerState.activeStepId === null ||
+      timerState.remainingSeconds === null
+    ) {
       return undefined;
     }
 
@@ -38,18 +109,23 @@ export function useStepTimer(): UseStepTimerReturn {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [activeStepId, remainingSeconds]);
+  }, [timerState.activeStepId, timerState.remainingSeconds, timerState.status]);
 
   return {
-    activeStepId,
-    remainingSeconds,
+    activeStepId: timerState.activeStepId,
+    pauseTimer: () => {
+      setTimerState((currentState) => pauseStepTimerState(currentState));
+    },
+    remainingSeconds: timerState.remainingSeconds,
+    resetTimer: () => {
+      setTimerState(resetStepTimerState);
+    },
+    resumeTimer: () => {
+      setTimerState((currentState) => resumeStepTimerState(currentState));
+    },
     startTimer: (stepId: string, seconds: number) => {
-      setActiveStepId(stepId);
-      setRemainingSeconds(seconds);
+      setTimerState(createRunningStepTimerState(stepId, seconds));
     },
-    stopTimer: () => {
-      setActiveStepId(null);
-      setRemainingSeconds(null);
-    },
+    status: timerState.status,
   };
 }


### PR DESCRIPTION
## Summary
Recipe step timers now behave like normal timers instead of resetting the moment they are stopped. A running timer can be paused, a paused timer can be resumed from the remaining time, and reset is now a separate explicit action.

## Problem
The old timer behavior treated `Stop timer` as a hard reset. As soon as someone stopped a timer, the active step and remaining time were cleared, so the only next action was to start the entire timer over again.

## Root cause
The timer hook only modeled an active-or-not state. It had no paused mode, so both the timer logic and the UI collapsed `pause` and `reset` into the same action.

## Fix
This change turns the step timer into a small state machine with `idle`, `running`, and `paused` states. The hook now exposes explicit pause, resume, and reset actions, the timer control renders the correct buttons for each state, and the method-step badge text reflects paused timers instead of always showing `left`.

## Validation
I ran `npm run test -- src/features/recipes/hooks/useStepTimer.test.ts`, `npm run test`, `npm run lint`, and `npm run build` locally.
