### PR TITLE
fix(recipes): render the edit route

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecipesIndexRouteImport } from './routes/recipes.index'
 import { Route as RecipesNewRouteImport } from './routes/recipes.new'
 import { Route as RecipesRecipeIdRouteImport } from './routes/recipes.$recipeId'
+import { Route as RecipesRecipeIdIndexRouteImport } from './routes/recipes.$recipeId.index'
 import { Route as RecipesRecipeIdEditRouteImport } from './routes/recipes.$recipeId.edit'
 
 const RecipesRoute = RecipesRouteImport.update({
@@ -47,6 +48,11 @@ const RecipesRecipeIdRoute = RecipesRecipeIdRouteImport.update({
   path: '/$recipeId',
   getParentRoute: () => RecipesRoute,
 } as any)
+const RecipesRecipeIdIndexRoute = RecipesRecipeIdIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => RecipesRecipeIdRoute,
+} as any)
 const RecipesRecipeIdEditRoute = RecipesRecipeIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -61,14 +67,15 @@ export interface FileRoutesByFullPath {
   '/recipes/new': typeof RecipesNewRoute
   '/recipes/': typeof RecipesIndexRoute
   '/recipes/$recipeId/edit': typeof RecipesRecipeIdEditRoute
+  '/recipes/$recipeId/': typeof RecipesRecipeIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
-  '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
   '/recipes/new': typeof RecipesNewRoute
   '/recipes': typeof RecipesIndexRoute
   '/recipes/$recipeId/edit': typeof RecipesRecipeIdEditRoute
+  '/recipes/$recipeId': typeof RecipesRecipeIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -79,6 +86,7 @@ export interface FileRoutesById {
   '/recipes/new': typeof RecipesNewRoute
   '/recipes/': typeof RecipesIndexRoute
   '/recipes/$recipeId/edit': typeof RecipesRecipeIdEditRoute
+  '/recipes/$recipeId/': typeof RecipesRecipeIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -90,14 +98,15 @@ export interface FileRouteTypes {
     | '/recipes/new'
     | '/recipes/'
     | '/recipes/$recipeId/edit'
+    | '/recipes/$recipeId/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/account'
-    | '/recipes/$recipeId'
     | '/recipes/new'
     | '/recipes'
     | '/recipes/$recipeId/edit'
+    | '/recipes/$recipeId'
   id:
     | '__root__'
     | '/'
@@ -107,6 +116,7 @@ export interface FileRouteTypes {
     | '/recipes/new'
     | '/recipes/'
     | '/recipes/$recipeId/edit'
+    | '/recipes/$recipeId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -159,6 +169,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecipesRecipeIdRouteImport
       parentRoute: typeof RecipesRoute
     }
+    '/recipes/$recipeId/': {
+      id: '/recipes/$recipeId/'
+      path: '/'
+      fullPath: '/recipes/$recipeId/'
+      preLoaderRoute: typeof RecipesRecipeIdIndexRouteImport
+      parentRoute: typeof RecipesRecipeIdRoute
+    }
     '/recipes/$recipeId/edit': {
       id: '/recipes/$recipeId/edit'
       path: '/edit'
@@ -171,10 +188,12 @@ declare module '@tanstack/react-router' {
 
 interface RecipesRecipeIdRouteChildren {
   RecipesRecipeIdEditRoute: typeof RecipesRecipeIdEditRoute
+  RecipesRecipeIdIndexRoute: typeof RecipesRecipeIdIndexRoute
 }
 
 const RecipesRecipeIdRouteChildren: RecipesRecipeIdRouteChildren = {
   RecipesRecipeIdEditRoute: RecipesRecipeIdEditRoute,
+  RecipesRecipeIdIndexRoute: RecipesRecipeIdIndexRoute,
 }
 
 const RecipesRecipeIdRouteWithChildren = RecipesRecipeIdRoute._addFileChildren(

--- a/src/routes/recipes.$recipeId.index.tsx
+++ b/src/routes/recipes.$recipeId.index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { RecipeDetailPage } from "@/features/recipes";
+
+import type { JSX } from "react";
+
+function RecipeDetailIndexRoute(): JSX.Element {
+  const { recipeId } = Route.useParams();
+
+  return <RecipeDetailPage recipeId={recipeId} />;
+}
+
+export const Route = createFileRoute("/recipes/$recipeId/")({
+  component: RecipeDetailIndexRoute,
+});

--- a/src/routes/recipes.$recipeId.tsx
+++ b/src/routes/recipes.$recipeId.tsx
@@ -1,8 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 import {
   preloadRecipeDetail,
-  RecipeDetailPage,
   RecipeDetailPageErrorState,
   RecipeDetailPageLoading,
 } from "@/features/recipes";
@@ -10,9 +9,7 @@ import {
 import type { JSX } from "react";
 
 function RecipeDetailRoute(): JSX.Element {
-  const { recipeId } = Route.useParams();
-
-  return <RecipeDetailPage recipeId={recipeId} />;
+  return <Outlet />;
 }
 
 export const Route = createFileRoute("/recipes/$recipeId")({


### PR DESCRIPTION
## Summary
The edit route now renders correctly when navigating to `/recipes/<id>/edit`. The detail route is now a layout route, and the detail screen itself lives in a nested index route so the edit page has a real outlet to mount into.

## Problem
The `Edit recipe` button changed the URL correctly, but the edit page never appeared. The route existed in the generated tree, yet the page stayed on the detail screen because the parent route rendered the detail page directly.

## Root cause
`src/routes/recipes.$recipeId.tsx` returned `<RecipeDetailPage />` instead of an `<Outlet />`. That meant the nested `/edit` child route had nowhere to render, even though the route path itself was registered.

## Fix
This change turns `/recipes/$recipeId` into a layout route that renders an outlet, adds a new index child route for the normal recipe detail page, and refreshes the generated router output. That keeps the detail and edit pages as proper sibling children under the same recipe route boundary.

## Validation
I ran `npm run test`, `npm run lint`, and `npm run build` locally after regenerating the route tree.
