### PR TITLE
feat(recipes): add categories and shelf filters

### DIFF
--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { ProfileSettingsSection } from "@/features/profiles";
 import { ThemePresetPicker, useThemePreset } from "@/features/theme";
 import { useAppToast } from "@/hooks/useAppToast";
@@ -192,6 +194,23 @@ export function AccountPage(): JSX.Element {
               <p className="mt-1 text-sm text-amber-950/85">
                 Sign in before creating or deleting recipes.
               </p>
+            </section>
+          ) : null}
+
+          {sessionQuery.data?.kind === "authenticated" &&
+          sessionQuery.data.isAdmin ? (
+            <section className="space-y-3 border-t border-border pt-6">
+              <div>
+                <h2 className="text-lg font-semibold tracking-tight text-foreground">
+                  Admin
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Manage shared recipe categories for the shelf.
+                </p>
+              </div>
+              <Button asChild className="rounded-md px-4" variant="outline">
+                <Link to="/admin/categories">Manage categories</Link>
+              </Button>
             </section>
           ) : null}
         </div>

--- a/src/features/categories/components/CategoriesAdminPage.tsx
+++ b/src/features/categories/components/CategoriesAdminPage.tsx
@@ -1,0 +1,452 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useState, type JSX } from "react";
+
+import { Button } from "@/components/ui/button";
+import { sessionQueryOptions } from "@/features/auth";
+import { useAppToast } from "@/hooks/useAppToast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+import {
+  createRecipeCategoryMutationOptions,
+  updateRecipeCategoryMutationOptions,
+} from "../queries/categoryMutationOptions";
+import { adminRecipeCategoryListQueryOptions } from "../queries/categoryQueryOptions";
+import { recipeCategoryFormSchema } from "../schemas/categorySchemas";
+
+import type { RecipeCategory } from "../types/categories";
+
+export function CategoriesAdminPage(): JSX.Element {
+  useDocumentTitle("Manage Categories");
+
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery(sessionQueryOptions);
+  const categoriesQuery = useQuery({
+    ...adminRecipeCategoryListQueryOptions(),
+    enabled:
+      sessionQuery.data?.kind === "authenticated" && sessionQuery.data.isAdmin,
+  });
+  const createCategoryMutation = useMutation(
+    createRecipeCategoryMutationOptions(queryClient),
+  );
+  const updateCategoryMutation = useMutation(
+    updateRecipeCategoryMutationOptions(queryClient),
+  );
+  const { toast } = useAppToast();
+  const [newCategoryName, setNewCategoryName] = useState("");
+
+  if (sessionQuery.isLoading) {
+    return (
+      <CategoryAdminState
+        description="Checking access."
+        title="Loading categories"
+      />
+    );
+  }
+
+  if (sessionQuery.data === undefined || sessionQuery.data.kind === "guest") {
+    return (
+      <CategoryAdminState
+        description="Sign in with an admin account to manage recipe categories."
+        title="Sign in to manage categories"
+      />
+    );
+  }
+
+  if (sessionQuery.data.kind === "unconfigured") {
+    return (
+      <CategoryAdminState
+        description="Supabase is not configured for category management in this environment."
+        title="Category management is unavailable"
+      />
+    );
+  }
+
+  if (!sessionQuery.data.isAdmin) {
+    return (
+      <CategoryAdminState
+        description="Only admins can create, rename, or retire recipe categories."
+        title="You can’t manage categories"
+      />
+    );
+  }
+
+  const categories = categoriesQuery.data ?? [];
+  const activeCategories = categories.filter((category) => category.isActive);
+  const retiredCategories = categories.filter((category) => !category.isActive);
+
+  return (
+    <main className="w-full max-w-4xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          Manage categories
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Create, rename, and retire the shared recipe categories used across
+          the shelf.
+        </p>
+      </section>
+
+      <div className="mt-6 space-y-8">
+        <section className="space-y-4 rounded-lg border border-border bg-background p-5">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+              New category
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Add a new category to the shared list.
+            </p>
+          </div>
+
+          <form
+            className="flex flex-col gap-3 sm:flex-row"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const parsed = recipeCategoryFormSchema.safeParse({
+                name: newCategoryName,
+              });
+
+              if (!parsed.success) {
+                toast({
+                  description:
+                    parsed.error.issues[0]?.message ??
+                    "Add a valid category name.",
+                  title: "Category form needs attention",
+                  tone: "error",
+                });
+                return;
+              }
+
+              createCategoryMutation.mutate(
+                { name: parsed.data.name },
+                {
+                  onError: (error) => {
+                    toast({
+                      description: getCategoryMutationErrorMessage(error),
+                      title: "Category could not be created",
+                      tone: "error",
+                    });
+                  },
+                  onSuccess: () => {
+                    setNewCategoryName("");
+                    void queryClient.invalidateQueries({
+                      queryKey: ["recipes"],
+                    });
+                    toast({
+                      description: "The category is ready to use on recipes.",
+                      title: "Category created",
+                      tone: "success",
+                    });
+                  },
+                },
+              );
+            }}
+          >
+            <label className="flex-1">
+              <span className="sr-only">Category name</span>
+              <input
+                className="w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                onChange={(event) => {
+                  setNewCategoryName(event.target.value);
+                }}
+                placeholder="Weeknight dinners"
+                value={newCategoryName}
+              />
+            </label>
+            <Button
+              className="rounded-md px-4"
+              disabled={createCategoryMutation.isPending}
+              type="submit"
+            >
+              {createCategoryMutation.isPending
+                ? "Creating..."
+                : "Add category"}
+            </Button>
+          </form>
+        </section>
+
+        {categoriesQuery.isError ? (
+          <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Categories unavailable
+            </h2>
+            <p className="mt-1 text-sm text-amber-950/85">
+              The category list could not load right now. Try again in a moment.
+            </p>
+          </section>
+        ) : null}
+
+        <CategoryListSection
+          categories={activeCategories}
+          emptyState="No active categories yet."
+          isPending={updateCategoryMutation.isPending}
+          onToggleActive={(category) => {
+            updateCategoryMutation.mutate(
+              {
+                categoryId: category.id,
+                isActive: false,
+                name: category.name,
+              },
+              {
+                onError: (error) => {
+                  toast({
+                    description: getCategoryMutationErrorMessage(error),
+                    title: "Category could not be retired",
+                    tone: "error",
+                  });
+                },
+                onSuccess: () => {
+                  void queryClient.invalidateQueries({
+                    queryKey: ["recipes"],
+                  });
+                  toast({
+                    description:
+                      "The category remains on older recipes but is no longer offered for new tagging.",
+                    title: "Category retired",
+                    tone: "success",
+                  });
+                },
+              },
+            );
+          }}
+          onUpdate={(input) => {
+            updateCategoryMutation.mutate(input, {
+              onError: (error) => {
+                toast({
+                  description: getCategoryMutationErrorMessage(error),
+                  title: "Category could not be updated",
+                  tone: "error",
+                });
+              },
+              onSuccess: () => {
+                void queryClient.invalidateQueries({
+                  queryKey: ["recipes"],
+                });
+                toast({
+                  description: "The category name is live across the shelf.",
+                  title: "Category updated",
+                  tone: "success",
+                });
+              },
+            });
+          }}
+          toggleLabel="Retire"
+          title="Active categories"
+        />
+
+        <CategoryListSection
+          categories={retiredCategories}
+          emptyState="No retired categories."
+          isPending={updateCategoryMutation.isPending}
+          onToggleActive={(category) => {
+            updateCategoryMutation.mutate(
+              {
+                categoryId: category.id,
+                isActive: true,
+                name: category.name,
+              },
+              {
+                onError: (error) => {
+                  toast({
+                    description: getCategoryMutationErrorMessage(error),
+                    title: "Category could not be restored",
+                    tone: "error",
+                  });
+                },
+                onSuccess: () => {
+                  void queryClient.invalidateQueries({
+                    queryKey: ["recipes"],
+                  });
+                  toast({
+                    description:
+                      "The category is available for recipe tagging again.",
+                    title: "Category restored",
+                    tone: "success",
+                  });
+                },
+              },
+            );
+          }}
+          onUpdate={(input) => {
+            updateCategoryMutation.mutate(input, {
+              onError: (error) => {
+                toast({
+                  description: getCategoryMutationErrorMessage(error),
+                  title: "Category could not be updated",
+                  tone: "error",
+                });
+              },
+              onSuccess: () => {
+                void queryClient.invalidateQueries({
+                  queryKey: ["recipes"],
+                });
+                toast({
+                  description: "The category name is live across the shelf.",
+                  title: "Category updated",
+                  tone: "success",
+                });
+              },
+            });
+          }}
+          toggleLabel="Restore"
+          title="Retired categories"
+        />
+
+        <div className="border-t border-border pt-6">
+          <Button asChild className="rounded-md px-4" variant="outline">
+            <Link to="/account">Back to account</Link>
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+type CategoryAdminStateProps = {
+  description: string;
+  title: string;
+};
+
+function CategoryAdminState({
+  description,
+  title,
+}: CategoryAdminStateProps): JSX.Element {
+  return (
+    <main className="w-full max-w-4xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      </section>
+    </main>
+  );
+}
+
+type CategoryListSectionProps = {
+  categories: RecipeCategory[];
+  emptyState: string;
+  isPending: boolean;
+  onToggleActive: (category: RecipeCategory) => void;
+  onUpdate: (input: {
+    categoryId: string;
+    isActive: boolean;
+    name: string;
+  }) => void;
+  title: string;
+  toggleLabel: string;
+};
+
+function CategoryListSection({
+  categories,
+  emptyState,
+  isPending,
+  onToggleActive,
+  onUpdate,
+  title,
+  toggleLabel,
+}: CategoryListSectionProps): JSX.Element {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight text-foreground">
+          {title}
+        </h2>
+      </div>
+
+      {categories.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyState}</p>
+      ) : (
+        <div className="space-y-3">
+          {categories.map((category) => (
+            <CategoryEditorRow
+              key={`${category.id}-${category.name}-${category.isActive ? "active" : "retired"}`}
+              category={category}
+              isPending={isPending}
+              onToggleActive={onToggleActive}
+              onUpdate={(name) => {
+                onUpdate({
+                  categoryId: category.id,
+                  isActive: category.isActive,
+                  name,
+                });
+              }}
+              toggleLabel={toggleLabel}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+type CategoryEditorRowProps = {
+  category: RecipeCategory;
+  isPending: boolean;
+  onToggleActive: (category: RecipeCategory) => void;
+  onUpdate: (name: string) => void;
+  toggleLabel: string;
+};
+
+function CategoryEditorRow({
+  category,
+  isPending,
+  onToggleActive,
+  onUpdate,
+  toggleLabel,
+}: CategoryEditorRowProps): JSX.Element {
+  const [draftName, setDraftName] = useState(category.name);
+
+  return (
+    <article className="rounded-lg border border-border bg-background p-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex-1 space-y-2">
+          <label className="block">
+            <span className="text-sm font-medium text-foreground">Name</span>
+            <input
+              className="mt-2 w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+              onChange={(event) => {
+                setDraftName(event.target.value);
+              }}
+              value={draftName}
+            />
+          </label>
+          <p className="text-xs text-muted-foreground">Slug: {category.slug}</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            className="rounded-md px-4"
+            disabled={isPending}
+            onClick={() => {
+              onUpdate(draftName);
+            }}
+            type="button"
+            variant="outline"
+          >
+            Save
+          </Button>
+          <Button
+            className="rounded-md px-4"
+            disabled={isPending}
+            onClick={() => {
+              onToggleActive(category);
+            }}
+            type="button"
+            variant="outline"
+          >
+            {toggleLabel}
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function getCategoryMutationErrorMessage(error: Error): string {
+  return error.message.includes("recipe_categories_name_lower_key")
+    ? "That category name is already in use."
+    : error.message.includes("recipe_categories_slug_key")
+      ? "That category slug is already in use."
+      : error.message;
+}

--- a/src/features/categories/components/CategoriesAdminPage.tsx
+++ b/src/features/categories/components/CategoriesAdminPage.tsx
@@ -180,6 +180,13 @@ export function CategoriesAdminPage(): JSX.Element {
           categories={activeCategories}
           emptyState="No active categories yet."
           isPending={updateCategoryMutation.isPending}
+          onInvalidName={(message) => {
+            toast({
+              description: message,
+              title: "Category form needs attention",
+              tone: "error",
+            });
+          }}
           onToggleActive={(category) => {
             updateCategoryMutation.mutate(
               {
@@ -238,6 +245,13 @@ export function CategoriesAdminPage(): JSX.Element {
           categories={retiredCategories}
           emptyState="No retired categories."
           isPending={updateCategoryMutation.isPending}
+          onInvalidName={(message) => {
+            toast({
+              description: message,
+              title: "Category form needs attention",
+              tone: "error",
+            });
+          }}
           onToggleActive={(category) => {
             updateCategoryMutation.mutate(
               {
@@ -327,6 +341,7 @@ type CategoryListSectionProps = {
   categories: RecipeCategory[];
   emptyState: string;
   isPending: boolean;
+  onInvalidName: (message: string) => void;
   onToggleActive: (category: RecipeCategory) => void;
   onUpdate: (input: {
     categoryId: string;
@@ -341,6 +356,7 @@ function CategoryListSection({
   categories,
   emptyState,
   isPending,
+  onInvalidName,
   onToggleActive,
   onUpdate,
   title,
@@ -363,6 +379,7 @@ function CategoryListSection({
               key={`${category.id}-${category.name}-${category.isActive ? "active" : "retired"}`}
               category={category}
               isPending={isPending}
+              onInvalidName={onInvalidName}
               onToggleActive={onToggleActive}
               onUpdate={(name) => {
                 onUpdate({
@@ -383,6 +400,7 @@ function CategoryListSection({
 type CategoryEditorRowProps = {
   category: RecipeCategory;
   isPending: boolean;
+  onInvalidName: (message: string) => void;
   onToggleActive: (category: RecipeCategory) => void;
   onUpdate: (name: string) => void;
   toggleLabel: string;
@@ -391,6 +409,7 @@ type CategoryEditorRowProps = {
 function CategoryEditorRow({
   category,
   isPending,
+  onInvalidName,
   onToggleActive,
   onUpdate,
   toggleLabel,
@@ -419,7 +438,19 @@ function CategoryEditorRow({
             className="rounded-md px-4"
             disabled={isPending}
             onClick={() => {
-              onUpdate(draftName);
+              const parsed = recipeCategoryFormSchema.safeParse({
+                name: draftName,
+              });
+
+              if (!parsed.success) {
+                onInvalidName(
+                  parsed.error.issues[0]?.message ??
+                    "Add a valid category name.",
+                );
+                return;
+              }
+
+              onUpdate(parsed.data.name);
             }}
             type="button"
             variant="outline"

--- a/src/features/categories/index.ts
+++ b/src/features/categories/index.ts
@@ -1,0 +1,36 @@
+export { CategoriesAdminPage } from "./components/CategoriesAdminPage";
+export {
+  createRecipeCategory,
+  listAdminRecipeCategories,
+  listPublicRecipeCategories,
+  listRecipeCategoriesByRecipeIds,
+  replaceRecipeCategoryAssignments,
+  RecipeCategoryDataAccessError,
+  updateRecipeCategory,
+  type RecipeCategoryDataAccessErrorCode,
+} from "./queries/categoryApi";
+export {
+  categoryMutationKeys,
+  categoryQueryKeys,
+} from "./queries/categoryKeys";
+export {
+  createRecipeCategoryMutationOptions,
+  updateRecipeCategoryMutationOptions,
+} from "./queries/categoryMutationOptions";
+export {
+  adminRecipeCategoryListQueryOptions,
+  preloadPublicRecipeCategoryList,
+  publicRecipeCategoryListQueryOptions,
+} from "./queries/categoryQueryOptions";
+export {
+  recipeCategoryFormSchema,
+  type RecipeCategoryFormInput,
+  type RecipeCategoryFormOutput,
+} from "./schemas/categorySchemas";
+export type {
+  CreateRecipeCategoryInput,
+  RecipeCategory,
+  RecipeCategorySummary,
+  UpdateRecipeCategoryInput,
+} from "./types/categories";
+export { createRecipeCategorySlug } from "./utils/categoryPresentation";

--- a/src/features/categories/queries/categoryApi.test.ts
+++ b/src/features/categories/queries/categoryApi.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { isRecipeCategorySchemaUnavailableError } from "./categoryApi";
+
+describe("isRecipeCategorySchemaUnavailableError", () => {
+  it("detects missing category table errors", () => {
+    expect(
+      isRecipeCategorySchemaUnavailableError({
+        message: 'relation "public.recipe_categories" does not exist',
+      }),
+    ).toBe(true);
+  });
+
+  it("detects missing assignment relationship errors", () => {
+    expect(
+      isRecipeCategorySchemaUnavailableError({
+        details:
+          "Could not find a relationship for recipe_category_assignments",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(
+      isRecipeCategorySchemaUnavailableError({
+        message: "boom",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/categories/queries/categoryApi.ts
+++ b/src/features/categories/queries/categoryApi.ts
@@ -1,0 +1,319 @@
+import { supabase } from "@/lib/supabase";
+import type { Database } from "@/types/supabase";
+
+import { createRecipeCategorySlug } from "../utils/categoryPresentation";
+
+import type {
+  CreateRecipeCategoryInput,
+  RecipeCategory,
+  RecipeCategorySummary,
+  UpdateRecipeCategoryInput,
+} from "../types/categories";
+
+type CategoryApiClient = NonNullable<typeof supabase>;
+type RecipeCategoryRow =
+  Database["public"]["Tables"]["recipe_categories"]["Row"];
+type RecipeCategoryInsert =
+  Database["public"]["Tables"]["recipe_categories"]["Insert"];
+type RecipeCategoryAssignmentInsert =
+  Database["public"]["Tables"]["recipe_category_assignments"]["Insert"];
+type RecipeCategoryAssignmentRow = {
+  recipe_categories: RecipeCategoryRow | null;
+  recipe_id: string;
+};
+
+export type RecipeCategoryDataAccessErrorCode =
+  | "authentication-required"
+  | "supabase-unconfigured";
+
+export class RecipeCategoryDataAccessError extends Error {
+  readonly code: RecipeCategoryDataAccessErrorCode;
+
+  constructor(
+    code: RecipeCategoryDataAccessErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.code = code;
+    this.name = "RecipeCategoryDataAccessError";
+  }
+}
+
+const categorySelect = `
+  id,
+  slug,
+  name,
+  is_active,
+  created_at,
+  updated_at
+`;
+
+export async function listPublicRecipeCategories(
+  client: CategoryApiClient | null = supabase,
+): Promise<RecipeCategorySummary[]> {
+  const categoryClient = getCategoryApiClient(client);
+  const { data, error } = await categoryClient
+    .from("recipe_categories")
+    .select(categorySelect)
+    .eq("is_active", true)
+    .order("name", { ascending: true })
+    .overrideTypes<RecipeCategoryRow[], { merge: false }>();
+
+  if (error !== null) {
+    if (isRecipeCategorySchemaUnavailableError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+
+  return (data ?? []).map(mapRecipeCategorySummaryRow);
+}
+
+export async function listAdminRecipeCategories(
+  client: CategoryApiClient | null = supabase,
+): Promise<RecipeCategory[]> {
+  const categoryClient = getCategoryApiClient(client);
+  const { data, error } = await categoryClient
+    .from("recipe_categories")
+    .select(categorySelect)
+    .order("is_active", { ascending: false })
+    .order("name", { ascending: true })
+    .overrideTypes<RecipeCategoryRow[], { merge: false }>();
+
+  if (error !== null) {
+    if (isRecipeCategorySchemaUnavailableError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+
+  return (data ?? []).map(mapRecipeCategoryRow);
+}
+
+export async function createRecipeCategory(
+  input: CreateRecipeCategoryInput,
+  client: CategoryApiClient | null = supabase,
+): Promise<RecipeCategory> {
+  const categoryClient = await requireAuthenticatedCategoryClient(client);
+  const payload = buildRecipeCategoryInsert(input);
+  const { data, error } = await categoryClient
+    .from("recipe_categories")
+    .insert(payload)
+    .select(categorySelect)
+    .single()
+    .overrideTypes<RecipeCategoryRow, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return mapRecipeCategoryRow(data);
+}
+
+export async function updateRecipeCategory(
+  input: UpdateRecipeCategoryInput,
+  client: CategoryApiClient | null = supabase,
+): Promise<RecipeCategory> {
+  const categoryClient = await requireAuthenticatedCategoryClient(client);
+  const { data, error } = await categoryClient
+    .from("recipe_categories")
+    .update({
+      is_active: input.isActive,
+      name: input.name.trim(),
+    })
+    .eq("id", input.categoryId.trim())
+    .select(categorySelect)
+    .single()
+    .overrideTypes<RecipeCategoryRow, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return mapRecipeCategoryRow(data);
+}
+
+export async function listRecipeCategoriesByRecipeIds(
+  recipeIds: readonly string[],
+  client: CategoryApiClient | null = supabase,
+): Promise<Map<string, RecipeCategorySummary[]>> {
+  if (recipeIds.length === 0) {
+    return new Map();
+  }
+
+  const categoryClient = getCategoryApiClient(client);
+  const { data, error } = await categoryClient
+    .from("recipe_category_assignments")
+    .select(
+      `
+        recipe_id,
+        recipe_categories (
+          id,
+          slug,
+          name,
+          is_active,
+          created_at,
+          updated_at
+        )
+      `,
+    )
+    .in("recipe_id", [...recipeIds])
+    .overrideTypes<RecipeCategoryAssignmentRow[], { merge: false }>();
+
+  if (error !== null) {
+    if (isRecipeCategorySchemaUnavailableError(error)) {
+      return new Map();
+    }
+
+    throw error;
+  }
+
+  const categoryMap = new Map<string, RecipeCategorySummary[]>();
+
+  for (const assignment of data ?? []) {
+    const category = assignment.recipe_categories;
+
+    if (category === null) {
+      continue;
+    }
+
+    const recipeCategories = categoryMap.get(assignment.recipe_id) ?? [];
+    recipeCategories.push(mapRecipeCategorySummaryRow(category));
+    categoryMap.set(
+      assignment.recipe_id,
+      sortRecipeCategories(recipeCategories),
+    );
+  }
+
+  return categoryMap;
+}
+
+export async function replaceRecipeCategoryAssignments(
+  recipeId: string,
+  categoryIds: readonly string[] | undefined,
+  client: CategoryApiClient | null = supabase,
+): Promise<void> {
+  const categoryClient = getCategoryApiClient(client);
+  const normalizedCategoryIds = [...new Set(categoryIds ?? [])].filter(
+    (categoryId) => categoryId.trim() !== "",
+  );
+
+  const deleteResult = await categoryClient
+    .from("recipe_category_assignments")
+    .delete()
+    .eq("recipe_id", recipeId);
+
+  if (deleteResult.error !== null) {
+    throw deleteResult.error;
+  }
+
+  if (normalizedCategoryIds.length === 0) {
+    return;
+  }
+
+  const rows: RecipeCategoryAssignmentInsert[] = normalizedCategoryIds.map(
+    (categoryId) => ({
+      category_id: categoryId,
+      recipe_id: recipeId,
+    }),
+  );
+  const insertResult = await categoryClient
+    .from("recipe_category_assignments")
+    .insert(rows);
+
+  if (insertResult.error !== null) {
+    throw insertResult.error;
+  }
+}
+
+export function isRecipeCategorySchemaUnavailableError(
+  error: unknown,
+): boolean {
+  if (error === null || typeof error !== "object") {
+    return false;
+  }
+
+  const categoryError = error as Record<string, unknown>;
+  const message =
+    typeof categoryError.message === "string" ? categoryError.message : "";
+  const details =
+    typeof categoryError.details === "string" ? categoryError.details : "";
+  const hint = typeof categoryError.hint === "string" ? categoryError.hint : "";
+
+  return [message, details, hint].some(
+    (value) =>
+      value.includes("recipe_categories") ||
+      value.includes("recipe_category_assignments"),
+  );
+}
+
+function buildRecipeCategoryInsert(
+  input: CreateRecipeCategoryInput,
+): RecipeCategoryInsert {
+  return {
+    name: input.name.trim(),
+    slug: createRecipeCategorySlug(input.name),
+  };
+}
+
+function getCategoryApiClient(
+  client: CategoryApiClient | null,
+): CategoryApiClient {
+  if (client === null) {
+    throw new RecipeCategoryDataAccessError(
+      "supabase-unconfigured",
+      "Supabase is not configured for recipe category access.",
+    );
+  }
+
+  return client;
+}
+
+async function requireAuthenticatedCategoryClient(
+  client: CategoryApiClient | null,
+): Promise<CategoryApiClient> {
+  const categoryClient = getCategoryApiClient(client);
+  const { data, error } = await categoryClient.auth.getUser();
+
+  if (error !== null || data.user === null) {
+    throw new RecipeCategoryDataAccessError(
+      "authentication-required",
+      "Sign in before managing recipe categories.",
+      { cause: error ?? undefined },
+    );
+  }
+
+  return categoryClient;
+}
+
+function mapRecipeCategoryRow(record: RecipeCategoryRow): RecipeCategory {
+  return {
+    createdAt: record.created_at,
+    id: record.id,
+    isActive: record.is_active,
+    name: record.name,
+    slug: record.slug,
+    updatedAt: record.updated_at,
+  };
+}
+
+function mapRecipeCategorySummaryRow(
+  record: RecipeCategoryRow,
+): RecipeCategorySummary {
+  return {
+    id: record.id,
+    name: record.name,
+    slug: record.slug,
+  };
+}
+
+function sortRecipeCategories(
+  categories: readonly RecipeCategorySummary[],
+): RecipeCategorySummary[] {
+  return [...categories].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}

--- a/src/features/categories/queries/categoryKeys.ts
+++ b/src/features/categories/queries/categoryKeys.ts
@@ -1,0 +1,13 @@
+export const categoryQueryKeys = {
+  all: ["categories"] as const,
+  list: () => [...categoryQueryKeys.lists(), "public"] as const,
+  listAdmin: () => [...categoryQueryKeys.lists(), "admin"] as const,
+  lists: () => [...categoryQueryKeys.all, "list"] as const,
+  recipeAssignments: (recipeIds: readonly string[]) =>
+    [...categoryQueryKeys.all, "recipe-assignments", ...recipeIds] as const,
+};
+
+export const categoryMutationKeys = {
+  create: () => [...categoryQueryKeys.all, "create"] as const,
+  update: () => [...categoryQueryKeys.all, "update"] as const,
+};

--- a/src/features/categories/queries/categoryMutationOptions.ts
+++ b/src/features/categories/queries/categoryMutationOptions.ts
@@ -1,0 +1,46 @@
+import { mutationOptions } from "@tanstack/react-query";
+
+import { createRecipeCategory, updateRecipeCategory } from "./categoryApi";
+import { categoryMutationKeys, categoryQueryKeys } from "./categoryKeys";
+
+import type {
+  CreateRecipeCategoryInput,
+  RecipeCategory,
+  UpdateRecipeCategoryInput,
+} from "../types/categories";
+import type { QueryClient } from "@tanstack/react-query";
+
+type CreateCategoryMutationOptions = ReturnType<
+  typeof mutationOptions<RecipeCategory, Error, CreateRecipeCategoryInput>
+>;
+type UpdateCategoryMutationOptions = ReturnType<
+  typeof mutationOptions<RecipeCategory, Error, UpdateRecipeCategoryInput>
+>;
+
+export function createRecipeCategoryMutationOptions(
+  queryClient: QueryClient,
+): CreateCategoryMutationOptions {
+  return mutationOptions({
+    mutationFn: (input): Promise<RecipeCategory> => createRecipeCategory(input),
+    mutationKey: categoryMutationKeys.create(),
+    onSuccess: async (): Promise<void> => {
+      await queryClient.invalidateQueries({
+        queryKey: categoryQueryKeys.all,
+      });
+    },
+  });
+}
+
+export function updateRecipeCategoryMutationOptions(
+  queryClient: QueryClient,
+): UpdateCategoryMutationOptions {
+  return mutationOptions({
+    mutationFn: (input): Promise<RecipeCategory> => updateRecipeCategory(input),
+    mutationKey: categoryMutationKeys.update(),
+    onSuccess: async (): Promise<void> => {
+      await queryClient.invalidateQueries({
+        queryKey: categoryQueryKeys.all,
+      });
+    },
+  });
+}

--- a/src/features/categories/queries/categoryQueryOptions.ts
+++ b/src/features/categories/queries/categoryQueryOptions.ts
@@ -1,0 +1,53 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import {
+  listAdminRecipeCategories,
+  listPublicRecipeCategories,
+} from "./categoryApi";
+import { categoryQueryKeys } from "./categoryKeys";
+
+import type {
+  RecipeCategory,
+  RecipeCategorySummary,
+} from "../types/categories";
+import type { QueryClient } from "@tanstack/react-query";
+
+type PublicCategoryListQueryOptions = ReturnType<
+  typeof queryOptions<
+    RecipeCategorySummary[],
+    Error,
+    RecipeCategorySummary[],
+    ReturnType<typeof categoryQueryKeys.list>
+  >
+>;
+type AdminCategoryListQueryOptions = ReturnType<
+  typeof queryOptions<
+    RecipeCategory[],
+    Error,
+    RecipeCategory[],
+    ReturnType<typeof categoryQueryKeys.listAdmin>
+  >
+>;
+
+export function publicRecipeCategoryListQueryOptions(): PublicCategoryListQueryOptions {
+  return queryOptions({
+    queryFn: (): Promise<RecipeCategorySummary[]> =>
+      listPublicRecipeCategories(),
+    queryKey: categoryQueryKeys.list(),
+    staleTime: 30_000,
+  });
+}
+
+export function adminRecipeCategoryListQueryOptions(): AdminCategoryListQueryOptions {
+  return queryOptions({
+    queryFn: (): Promise<RecipeCategory[]> => listAdminRecipeCategories(),
+    queryKey: categoryQueryKeys.listAdmin(),
+    staleTime: 30_000,
+  });
+}
+
+export async function preloadPublicRecipeCategoryList(
+  queryClient: QueryClient,
+): Promise<void> {
+  await queryClient.ensureQueryData(publicRecipeCategoryListQueryOptions());
+}

--- a/src/features/categories/schemas/categorySchemas.test.ts
+++ b/src/features/categories/schemas/categorySchemas.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { recipeCategoryFormSchema } from "./categorySchemas";
+
+describe("recipeCategoryFormSchema", () => {
+  it("trims and accepts a non-empty category name", () => {
+    expect(recipeCategoryFormSchema.parse({ name: "  Weeknight  " })).toEqual({
+      name: "Weeknight",
+    });
+  });
+
+  it("rejects blank category names", () => {
+    expect(recipeCategoryFormSchema.safeParse({ name: "   " }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects names that cannot produce a usable slug", () => {
+    expect(recipeCategoryFormSchema.safeParse({ name: "!!!" }).success).toBe(
+      false,
+    );
+  });
+});

--- a/src/features/categories/schemas/categorySchemas.ts
+++ b/src/features/categories/schemas/categorySchemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+import { createRecipeCategorySlug } from "../utils/categoryPresentation";
+
+export const recipeCategoryFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Add a category name.")
+    .max(80)
+    .refine((value) => createRecipeCategorySlug(value) !== "", {
+      message: "Use letters or numbers in the category name.",
+    }),
+});
+
+export type RecipeCategoryFormInput = z.input<typeof recipeCategoryFormSchema>;
+export type RecipeCategoryFormOutput = z.output<
+  typeof recipeCategoryFormSchema
+>;

--- a/src/features/categories/types/categories.ts
+++ b/src/features/categories/types/categories.ts
@@ -1,0 +1,23 @@
+export type RecipeCategory = {
+  createdAt: string;
+  id: string;
+  isActive: boolean;
+  name: string;
+  slug: string;
+  updatedAt: string;
+};
+
+export type RecipeCategorySummary = Pick<
+  RecipeCategory,
+  "id" | "name" | "slug"
+>;
+
+export type CreateRecipeCategoryInput = {
+  name: string;
+};
+
+export type UpdateRecipeCategoryInput = {
+  categoryId: string;
+  isActive: boolean;
+  name: string;
+};

--- a/src/features/categories/utils/categoryPresentation.test.ts
+++ b/src/features/categories/utils/categoryPresentation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { createRecipeCategorySlug } from "./categoryPresentation";
+
+describe("createRecipeCategorySlug", () => {
+  it("normalizes a display name into a url-friendly slug", () => {
+    expect(createRecipeCategorySlug("Weeknight Dinners")).toBe(
+      "weeknight-dinners",
+    );
+  });
+
+  it("collapses punctuation and repeated separators", () => {
+    expect(createRecipeCategorySlug("Brunch / Bake-Off  Favorites")).toBe(
+      "brunch-bake-off-favorites",
+    );
+  });
+});

--- a/src/features/categories/utils/categoryPresentation.ts
+++ b/src/features/categories/utils/categoryPresentation.ts
@@ -1,0 +1,8 @@
+export function createRecipeCategorySlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
+import { publicRecipeCategoryListQueryOptions } from "@/features/categories";
 import { useAppToast } from "@/hooks/useAppToast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
@@ -29,9 +30,14 @@ export function CreateRecipePage(): JSX.Element {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const sessionQuery = useQuery(sessionQueryOptions);
-  const createRecipeMutation = useMutation(createRecipeMutationOptions(queryClient));
+  const categoryListQuery = useQuery(publicRecipeCategoryListQueryOptions());
+  const createRecipeMutation = useMutation(
+    createRecipeMutationOptions(queryClient),
+  );
   const { toast } = useAppToast();
-  const [selectedCoverPhoto, setSelectedCoverPhoto] = useState<File | null>(null);
+  const [selectedCoverPhoto, setSelectedCoverPhoto] = useState<File | null>(
+    null,
+  );
   const [coverPhotoInputResetKey, setCoverPhotoInputResetKey] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [values, setValues] = useState(createEmptyRecipeCreateFormValues);
@@ -83,7 +89,8 @@ export function CreateRecipePage(): JSX.Element {
 
     try {
       if (selectedCoverPhoto !== null) {
-        uploadedCoverPhotoPath = await uploadRecipeCoverPhoto(selectedCoverPhoto);
+        uploadedCoverPhotoPath =
+          await uploadRecipeCoverPhoto(selectedCoverPhoto);
       }
 
       const recipe = await createRecipeMutation.mutateAsync({
@@ -103,7 +110,9 @@ export function CreateRecipePage(): JSX.Element {
       });
     } catch (error) {
       if (uploadedCoverPhotoPath !== null) {
-        await deleteRecipeCoverPhoto(uploadedCoverPhotoPath).catch(() => undefined);
+        await deleteRecipeCoverPhoto(uploadedCoverPhotoPath).catch(
+          () => undefined,
+        );
       }
 
       toast({
@@ -129,6 +138,7 @@ export function CreateRecipePage(): JSX.Element {
 
       <div className="mt-6">
         <RecipeCreateForm
+          availableCategories={categoryListQuery.data ?? []}
           cancelButton={
             <Button
               asChild
@@ -161,6 +171,18 @@ export function CreateRecipePage(): JSX.Element {
           submitPendingLabel="Saving recipe..."
           values={values}
         />
+
+        {categoryListQuery.isError ? (
+          <section className="mt-4 rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Categories unavailable
+            </h2>
+            <p className="mt-1 text-sm text-amber-950/85">
+              The category list could not load right now. You can still save the
+              recipe without category tags.
+            </p>
+          </section>
+        ) : null}
       </div>
     </main>
   );

--- a/src/features/recipes/components/EditRecipePage.tsx
+++ b/src/features/recipes/components/EditRecipePage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
+import { publicRecipeCategoryListQueryOptions } from "@/features/categories";
 import { profileListQueryOptions } from "@/features/profiles";
 import { useAppToast } from "@/hooks/useAppToast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -22,6 +23,7 @@ import { recipeCreateFormSchema } from "../schemas/recipeFormSchema";
 import {
   createEmptyRecipeCreateFormValues,
   createRecipeFormValuesFromRecipe,
+  mergeRecipeCategoryOptions,
 } from "../utils/recipeFormValues";
 
 import { RecipeCreateForm } from "./RecipeCreateForm";
@@ -38,6 +40,7 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
   const queryClient = useQueryClient();
   const recipeDetailQuery = useQuery(recipeDetailQueryOptions(recipeId));
   const sessionQuery = useQuery(sessionQueryOptions);
+  const categoryListQuery = useQuery(publicRecipeCategoryListQueryOptions());
   const profileListQuery = useQuery({
     ...profileListQueryOptions(),
     enabled:
@@ -169,6 +172,10 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
     canModerateRecipe &&
     nextOwnerId.trim() !== "" &&
     nextOwnerId !== recipe.ownerId;
+  const availableCategories = mergeRecipeCategoryOptions(
+    categoryListQuery.data ?? [],
+    recipe.categories,
+  );
 
   return (
     <main className="w-full max-w-6xl py-3 sm:py-4">
@@ -205,6 +212,7 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
         ) : null}
 
         <RecipeCreateForm
+          availableCategories={availableCategories}
           cancelButton={
             <Button
               asChild
@@ -256,6 +264,18 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
           submitPendingLabel="Saving changes..."
           values={values}
         />
+
+        {categoryListQuery.isError ? (
+          <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Categories unavailable
+            </h2>
+            <p className="mt-1 text-sm text-amber-950/85">
+              The category list could not load right now. Existing category
+              assignments are still preserved when you save.
+            </p>
+          </section>
+        ) : null}
       </div>
     </main>
   );

--- a/src/features/recipes/components/RecipeCategoryFieldset.tsx
+++ b/src/features/recipes/components/RecipeCategoryFieldset.tsx
@@ -1,0 +1,61 @@
+import type { RecipeCategorySummary } from "@/features/categories";
+
+import type { JSX } from "react";
+
+type RecipeCategoryFieldsetProps = {
+  categories: RecipeCategorySummary[];
+  onToggle: (categoryId: string) => void;
+  selectedCategoryIds: string[];
+};
+
+export function RecipeCategoryFieldset({
+  categories,
+  onToggle,
+  selectedCategoryIds,
+}: RecipeCategoryFieldsetProps): JSX.Element {
+  return (
+    <section className="space-y-4 border-b border-border pb-8">
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          Categories
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Tag the recipe so it is easier to browse and filter on the shelf.
+        </p>
+      </div>
+
+      {categories.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No categories are available yet.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {categories.map((category) => {
+            const isSelected = selectedCategoryIds.includes(category.id);
+
+            return (
+              <label
+                key={category.id}
+                className={
+                  isSelected
+                    ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-primary bg-primary/10 px-3 py-2 text-sm text-foreground"
+                    : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-2 text-sm text-foreground"
+                }
+              >
+                <input
+                  checked={isSelected}
+                  className="size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20"
+                  onChange={() => {
+                    onToggle(category.id);
+                  }}
+                  type="checkbox"
+                />
+                {category.name}
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import type { RecipeCategorySummary } from "@/features/categories";
 
 import { getIngredientUnitGroups } from "../utils/ingredientUnits";
 import {
@@ -16,6 +17,7 @@ import {
 } from "../utils/recipeTimerUnits";
 
 import { RecipeAllergenFieldset } from "./RecipeAllergenFieldset";
+import { RecipeCategoryFieldset } from "./RecipeCategoryFieldset";
 import { RecipeCoverImage } from "./RecipeCoverImage";
 
 import type { FormEvent, JSX } from "react";
@@ -27,6 +29,7 @@ const checkboxClassName =
   "size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20";
 
 type RecipeCreateFormProps = {
+  availableCategories: RecipeCategorySummary[];
   cancelButton: JSX.Element;
   coverPhotoInputResetKey: number;
   currentCoverPhotoPath: string | null;
@@ -46,6 +49,7 @@ type RecipeCreateFormProps = {
 };
 
 export function RecipeCreateForm({
+  availableCategories,
   cancelButton,
   coverPhotoInputResetKey,
   currentCoverPhotoPath,
@@ -375,6 +379,19 @@ export function RecipeCreateForm({
           />
         )}
         title="Steps"
+      />
+
+      <RecipeCategoryFieldset
+        categories={availableCategories}
+        onToggle={(categoryId) => {
+          setValues((current) => ({
+            ...current,
+            categoryIds: current.categoryIds.includes(categoryId)
+              ? current.categoryIds.filter((item) => item !== categoryId)
+              : [...current.categoryIds, categoryId],
+          }));
+        }}
+        selectedCategoryIds={values.categoryIds}
       />
 
       <RecipeAllergenFieldset

--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -14,10 +14,12 @@ import type { RecipeListItem } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipePreviewCardProps = {
+  onCategoryClick?: (slug: string) => void;
   recipe: RecipeListItem;
 };
 
 export function RecipePreviewCard({
+  onCategoryClick,
   recipe,
 }: RecipePreviewCardProps): JSX.Element {
   const summary = getRecipeSummary(recipe.summary, recipe.description);
@@ -48,6 +50,32 @@ export function RecipePreviewCard({
           </h2>
           <p className="truncate text-sm text-muted-foreground">{summary}</p>
         </div>
+
+        {recipe.categories.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {recipe.categories.map((category) =>
+              onCategoryClick === undefined ? (
+                <span
+                  key={category.id}
+                  className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground"
+                >
+                  {category.name}
+                </span>
+              ) : (
+                <button
+                  key={category.id}
+                  className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground transition hover:border-primary hover:text-foreground"
+                  onClick={() => {
+                    onCategoryClick(category.slug);
+                  }}
+                  type="button"
+                >
+                  {category.name}
+                </button>
+              ),
+            )}
+          </div>
+        ) : null}
 
         <div className="flex flex-wrap gap-2">
           {metadata.map((item) => (

--- a/src/features/recipes/components/RecipeShelfFilters.tsx
+++ b/src/features/recipes/components/RecipeShelfFilters.tsx
@@ -1,0 +1,184 @@
+import type { RecipeCategorySummary } from "@/features/categories";
+
+import type { JSX } from "react";
+
+type RecipeShelfFiltersProps = {
+  availableCategories: RecipeCategorySummary[];
+  hasActiveFilters: boolean;
+  maxAvailableTotalMinutes: number;
+  maxTotalMinutes: number | null;
+  minTotalMinutes: number | null;
+  onCategoryToggle: (slug: string) => void;
+  onClearFilters: () => void;
+  onMaxTotalMinutesChange: (value: number | null) => void;
+  onMinTotalMinutesChange: (value: number | null) => void;
+  selectedCategorySlugs: string[];
+};
+
+export function RecipeShelfFilters({
+  availableCategories,
+  hasActiveFilters,
+  maxAvailableTotalMinutes,
+  maxTotalMinutes,
+  minTotalMinutes,
+  onCategoryToggle,
+  onClearFilters,
+  onMaxTotalMinutesChange,
+  onMinTotalMinutesChange,
+  selectedCategorySlugs,
+}: RecipeShelfFiltersProps): JSX.Element {
+  const maxSliderValue = Math.max(maxAvailableTotalMinutes, 5);
+  const minRangeValue = minTotalMinutes ?? 0;
+  const maxRangeValue = maxTotalMinutes ?? maxSliderValue;
+
+  return (
+    <section className="flex flex-col gap-4 border-t border-border pt-4 xl:flex-row xl:items-start xl:justify-between">
+      <details className="max-w-xl">
+        <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border px-3 py-2 text-sm text-foreground transition hover:bg-muted/40">
+          <span className="font-medium">Categories</span>
+          <span className="text-muted-foreground">
+            {selectedCategorySlugs.length === 0
+              ? "All categories"
+              : `${selectedCategorySlugs.length} selected`}
+          </span>
+        </summary>
+        <div className="mt-2 flex flex-wrap gap-2 rounded-md border border-border bg-background p-3">
+          {availableCategories.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No categories are available yet.
+            </p>
+          ) : (
+            availableCategories.map((category) => {
+              const isSelected = selectedCategorySlugs.includes(category.slug);
+
+              return (
+                <label
+                  key={category.id}
+                  className={
+                    isSelected
+                      ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-primary bg-primary/10 px-3 py-2 text-sm text-foreground"
+                      : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-2 text-sm text-foreground"
+                  }
+                >
+                  <input
+                    checked={isSelected}
+                    className="size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20"
+                    onChange={() => {
+                      onCategoryToggle(category.slug);
+                    }}
+                    type="checkbox"
+                  />
+                  {category.name}
+                </label>
+              );
+            })
+          )}
+        </div>
+      </details>
+
+      <div className="w-full max-w-xl space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium text-foreground">Total time</p>
+            <p className="text-sm text-muted-foreground">
+              Narrow the shelf by total prep + cook time.
+            </p>
+          </div>
+          {hasActiveFilters ? (
+            <button
+              className="text-sm font-medium text-primary transition hover:underline"
+              onClick={onClearFilters}
+              type="button"
+            >
+              Clear filters
+            </button>
+          ) : null}
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label>
+            <span className="text-sm font-medium text-foreground">Min</span>
+            <input
+              className="mt-2 w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+              inputMode="numeric"
+              onChange={(event) => {
+                onMinTotalMinutesChange(
+                  parseOptionalMinuteInput(event.target.value),
+                );
+              }}
+              placeholder="0"
+              value={minTotalMinutes ?? ""}
+            />
+          </label>
+
+          <label>
+            <span className="text-sm font-medium text-foreground">Max</span>
+            <input
+              className="mt-2 w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+              inputMode="numeric"
+              onChange={(event) => {
+                onMaxTotalMinutesChange(
+                  parseOptionalMinuteInput(event.target.value),
+                );
+              }}
+              placeholder={String(maxSliderValue)}
+              value={maxTotalMinutes ?? ""}
+            />
+          </label>
+        </div>
+
+        <div className="space-y-2">
+          <input
+            className="w-full accent-primary"
+            max={maxSliderValue}
+            min={0}
+            onChange={(event) => {
+              const nextValue = Number(event.target.value);
+              onMinTotalMinutesChange(nextValue);
+
+              if (maxTotalMinutes !== null && nextValue > maxTotalMinutes) {
+                onMaxTotalMinutesChange(nextValue);
+              }
+            }}
+            step={5}
+            type="range"
+            value={Math.min(minRangeValue, maxRangeValue)}
+          />
+          <input
+            className="w-full accent-primary"
+            max={maxSliderValue}
+            min={0}
+            onChange={(event) => {
+              const nextValue = Number(event.target.value);
+              onMaxTotalMinutesChange(nextValue);
+
+              if (minTotalMinutes !== null && nextValue < minTotalMinutes) {
+                onMinTotalMinutesChange(nextValue);
+              }
+            }}
+            step={5}
+            type="range"
+            value={Math.max(maxRangeValue, minRangeValue)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Range: {minRangeValue} to {maxRangeValue} minutes
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function parseOptionalMinuteInput(value: string): number | null {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue === "") {
+    return null;
+  }
+
+  const parsedValue = Number(trimmedValue);
+
+  return Number.isFinite(parsedValue) && parsedValue >= 0
+    ? Math.round(parsedValue)
+    : null;
+}

--- a/src/features/recipes/components/RecipeShelfFilters.tsx
+++ b/src/features/recipes/components/RecipeShelfFilters.tsx
@@ -27,9 +27,17 @@ export function RecipeShelfFilters({
   onMinTotalMinutesChange,
   selectedCategorySlugs,
 }: RecipeShelfFiltersProps): JSX.Element {
-  const maxSliderValue = Math.max(maxAvailableTotalMinutes, 5);
-  const minRangeValue = minTotalMinutes ?? 0;
-  const maxRangeValue = maxTotalMinutes ?? maxSliderValue;
+  const maxSliderValue = Math.max(
+    maxAvailableTotalMinutes,
+    minTotalMinutes ?? 0,
+    maxTotalMinutes ?? 0,
+    5,
+  );
+  const minRangeValue = Math.min(minTotalMinutes ?? 0, maxSliderValue);
+  const maxRangeValue = Math.min(
+    maxTotalMinutes ?? maxSliderValue,
+    maxSliderValue,
+  );
 
   return (
     <section className="flex flex-col gap-4 border-t border-border pt-4 xl:flex-row xl:items-start xl:justify-between">
@@ -161,7 +169,8 @@ export function RecipeShelfFilters({
             value={Math.max(maxRangeValue, minRangeValue)}
           />
           <p className="text-xs text-muted-foreground">
-            Range: {minRangeValue} to {maxRangeValue} minutes
+            Range: {minTotalMinutes ?? 0} to {maxTotalMinutes ?? maxSliderValue}{" "}
+            minutes
           </p>
         </div>
       </div>

--- a/src/features/recipes/components/RecipesEmptyState.tsx
+++ b/src/features/recipes/components/RecipesEmptyState.tsx
@@ -2,17 +2,25 @@ import { NotebookText } from "lucide-react";
 
 import type { JSX } from "react";
 
-export function RecipesEmptyState(): JSX.Element {
+type RecipesEmptyStateProps = {
+  isFiltered?: boolean;
+};
+
+export function RecipesEmptyState({
+  isFiltered = false,
+}: RecipesEmptyStateProps): JSX.Element {
   return (
     <section className="rounded-xl border border-dashed border-border px-6 py-12 text-center sm:px-8">
       <div className="mx-auto flex size-11 items-center justify-center rounded-lg bg-muted text-muted-foreground">
         <NotebookText className="size-6" />
       </div>
       <h2 className="mt-4 text-2xl font-semibold tracking-tight text-foreground">
-        No recipes yet.
+        {isFiltered ? "No recipes match these filters." : "No recipes yet."}
       </h2>
       <p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">
-        Recipes will show up here when they are added.
+        {isFiltered
+          ? "Try removing a category or widening the total-time range."
+          : "Recipes will show up here when they are added."}
       </p>
     </section>
   );

--- a/src/features/recipes/components/RecipesPage.tsx
+++ b/src/features/recipes/components/RecipesPage.tsx
@@ -2,10 +2,19 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 
+import { publicRecipeCategoryListQueryOptions } from "@/features/categories";
 import { useAppToast } from "@/hooks/useAppToast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 import { recipeListQueryOptions } from "../queries/recipeQueryOptions";
+import { type RecipeShelfSearch } from "../schemas/recipeShelfSearchSchema";
+import {
+  applyRecipeShelfFilters,
+  getRecipeShelfFilters,
+  getRecipeShelfHasActiveFilters,
+  serializeRecipeShelfCategorySlugs,
+  serializeRecipeShelfMinuteValue,
+} from "../utils/recipeShelfFilters";
 
 import { RecipesPageContent } from "./RecipesPageContent";
 import { RecipesPageHeader } from "./RecipesPageHeader";
@@ -14,10 +23,12 @@ import { RecipesPageLoading } from "./RecipesPageLoading";
 import type { JSX } from "react";
 
 type RecipesPageProps = {
+  search: RecipeShelfSearch;
   showDeletedBanner?: boolean;
 };
 
 export function RecipesPage({
+  search,
   showDeletedBanner = false,
 }: RecipesPageProps): JSX.Element {
   useDocumentTitle("Recipes");
@@ -25,6 +36,7 @@ export function RecipesPage({
   const { toast } = useAppToast();
   const navigate = useNavigate();
   const recipeListQuery = useQuery(recipeListQueryOptions());
+  const categoryListQuery = useQuery(publicRecipeCategoryListQueryOptions());
   const hasShownDeletedToastRef = useRef(false);
 
   useEffect(() => {
@@ -44,8 +56,11 @@ export function RecipesPage({
       tone: "success",
     });
     void navigate({
+      search: (current) => ({
+        ...current,
+        deleted: undefined,
+      }),
       replace: true,
-      search: {},
       to: "/recipes",
     });
   }, [navigate, showDeletedBanner, toast]);
@@ -55,11 +70,82 @@ export function RecipesPage({
   }
 
   const recipes = recipeListQuery.data;
+  const filters = getRecipeShelfFilters(search);
+  const filteredRecipes = applyRecipeShelfFilters(recipes, filters);
+  const hasActiveFilters = getRecipeShelfHasActiveFilters(filters);
+  const maxAvailableTotalMinutes = recipes.reduce((maxMinutes, recipe) => {
+    return Math.max(maxMinutes, recipe.totalMinutes ?? 0);
+  }, 0);
 
   return (
     <main className="flex w-full flex-col gap-6 py-3 sm:py-4">
-      <RecipesPageHeader />
-      <RecipesPageContent recipes={recipes} />
+      <RecipesPageHeader
+        availableCategories={categoryListQuery.data ?? []}
+        hasActiveFilters={hasActiveFilters}
+        maxAvailableTotalMinutes={maxAvailableTotalMinutes}
+        maxTotalMinutes={filters.maxTotalMinutes}
+        minTotalMinutes={filters.minTotalMinutes}
+        onCategoryToggle={(slug) => {
+          const nextCategorySlugs = filters.categorySlugs.includes(slug)
+            ? filters.categorySlugs.filter((item) => item !== slug)
+            : [...filters.categorySlugs, slug];
+
+          void navigate({
+            search: (current) => ({
+              ...current,
+              categories: serializeRecipeShelfCategorySlugs(nextCategorySlugs),
+            }),
+            to: "/recipes",
+          });
+        }}
+        onClearFilters={() => {
+          void navigate({
+            search: (current) => ({
+              ...current,
+              categories: undefined,
+              maxTotalMinutes: undefined,
+              minTotalMinutes: undefined,
+            }),
+            to: "/recipes",
+          });
+        }}
+        onMaxTotalMinutesChange={(value) => {
+          void navigate({
+            search: (current) => ({
+              ...current,
+              maxTotalMinutes: serializeRecipeShelfMinuteValue(value),
+            }),
+            to: "/recipes",
+          });
+        }}
+        onMinTotalMinutesChange={(value) => {
+          void navigate({
+            search: (current) => ({
+              ...current,
+              minTotalMinutes: serializeRecipeShelfMinuteValue(value),
+            }),
+            to: "/recipes",
+          });
+        }}
+        selectedCategorySlugs={filters.categorySlugs}
+      />
+      <RecipesPageContent
+        isFiltered={hasActiveFilters}
+        onCategoryClick={(slug) => {
+          const nextCategorySlugs = filters.categorySlugs.includes(slug)
+            ? filters.categorySlugs
+            : [...filters.categorySlugs, slug];
+
+          void navigate({
+            search: (current) => ({
+              ...current,
+              categories: serializeRecipeShelfCategorySlugs(nextCategorySlugs),
+            }),
+            to: "/recipes",
+          });
+        }}
+        recipes={filteredRecipes}
+      />
     </main>
   );
 }

--- a/src/features/recipes/components/RecipesPageContent.tsx
+++ b/src/features/recipes/components/RecipesPageContent.tsx
@@ -5,20 +5,28 @@ import type { RecipeListItem } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipesPageContentProps = {
+  isFiltered?: boolean;
+  onCategoryClick?: (slug: string) => void;
   recipes: RecipeListItem[];
 };
 
 export function RecipesPageContent({
+  isFiltered = false,
+  onCategoryClick,
   recipes,
 }: RecipesPageContentProps): JSX.Element {
   if (recipes.length === 0) {
-    return <RecipesEmptyState />;
+    return <RecipesEmptyState isFiltered={isFiltered} />;
   }
 
   return (
     <section className="grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
       {recipes.map((recipe) => (
-        <RecipePreviewCard key={recipe.id} recipe={recipe} />
+        <RecipePreviewCard
+          key={recipe.id}
+          onCategoryClick={onCategoryClick}
+          recipe={recipe}
+        />
       ))}
     </section>
   );

--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -1,23 +1,70 @@
 import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
+import type { RecipeCategorySummary } from "@/features/categories";
+
+import { RecipeShelfFilters } from "./RecipeShelfFilters";
 
 import type { JSX } from "react";
 
-export function RecipesPageHeader(): JSX.Element {
+type RecipesPageHeaderProps = {
+  availableCategories?: RecipeCategorySummary[];
+  hasActiveFilters?: boolean;
+  maxAvailableTotalMinutes?: number;
+  maxTotalMinutes?: number | null;
+  minTotalMinutes?: number | null;
+  onCategoryToggle?: (slug: string) => void;
+  onClearFilters?: () => void;
+  onMaxTotalMinutesChange?: (value: number | null) => void;
+  onMinTotalMinutesChange?: (value: number | null) => void;
+  selectedCategorySlugs?: string[];
+};
+
+export function RecipesPageHeader({
+  availableCategories = [],
+  hasActiveFilters = false,
+  maxAvailableTotalMinutes = 0,
+  maxTotalMinutes = null,
+  minTotalMinutes = null,
+  onCategoryToggle,
+  onClearFilters,
+  onMaxTotalMinutesChange,
+  onMinTotalMinutesChange,
+  selectedCategorySlugs = [],
+}: RecipesPageHeaderProps): JSX.Element {
   return (
-    <section className="flex flex-col gap-4 border-b border-border pb-4 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
-          Recipes
-        </h1>
+    <section className="space-y-4 border-b border-border pb-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            Recipes
+          </h1>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button asChild className="rounded-md px-4" size="lg">
+            <Link to="/recipes/new">New recipe</Link>
+          </Button>
+        </div>
       </div>
 
-      <div className="flex items-center gap-3">
-        <Button asChild className="rounded-md px-4" size="lg">
-          <Link to="/recipes/new">New recipe</Link>
-          </Button>
-      </div>
+      {onCategoryToggle !== undefined &&
+      onClearFilters !== undefined &&
+      onMaxTotalMinutesChange !== undefined &&
+      onMinTotalMinutesChange !== undefined ? (
+        <RecipeShelfFilters
+          availableCategories={availableCategories}
+          hasActiveFilters={hasActiveFilters}
+          maxAvailableTotalMinutes={maxAvailableTotalMinutes}
+          maxTotalMinutes={maxTotalMinutes}
+          minTotalMinutes={minTotalMinutes}
+          onCategoryToggle={onCategoryToggle}
+          onClearFilters={onClearFilters}
+          onMaxTotalMinutesChange={onMaxTotalMinutesChange}
+          onMinTotalMinutesChange={onMinTotalMinutesChange}
+          selectedCategorySlugs={selectedCategorySlugs}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/features/recipes/index.ts
+++ b/src/features/recipes/index.ts
@@ -2,6 +2,7 @@ export { RecipeAllergenFieldset } from "./components/RecipeAllergenFieldset";
 export { RecipeAllergenSummary } from "./components/RecipeAllergenSummary";
 export { CreateRecipePage } from "./components/CreateRecipePage";
 export { EditRecipePage } from "./components/EditRecipePage";
+export { RecipeCategoryFieldset } from "./components/RecipeCategoryFieldset";
 export { RecipeDetailPage } from "./components/RecipeDetailPage";
 export { RecipeDetailHero } from "./components/RecipeDetailHero";
 export { RecipeDetailPageErrorState } from "./components/RecipeDetailPageErrorState";
@@ -96,6 +97,7 @@ export {
   createEmptyRecipeIngredientFormValue,
   createEmptyRecipeStepFormValue,
   createRecipeFormValuesFromRecipe,
+  mergeRecipeCategoryOptions,
   type RecipeCreateEquipmentFormValue,
   type RecipeCreateFormValues,
   type RecipeCreateIngredientFormValue,

--- a/src/features/recipes/queries/recipeAdapters.ts
+++ b/src/features/recipes/queries/recipeAdapters.ts
@@ -1,3 +1,4 @@
+import type { RecipeCategorySummary } from "@/features/categories";
 import type { Database } from "@/types/supabase";
 
 import {
@@ -120,10 +121,11 @@ export function buildRecipeCookLogInsert(
 export function mapRecipeDetailRecord(
   record: RecipeDetailRecord,
   cookLogs: RecipeCookLogRow[] = [],
+  categories: RecipeCategorySummary[] = [],
   creatorName: string | null = null,
 ): RecipeDetail {
   return {
-    ...mapRecipeListRecord(record),
+    ...mapRecipeListRecord(record, categories),
     cookLogs: sortCookLogs(cookLogs).map(mapRecipeCookLogRow),
     creatorName,
     equipment: sortByPosition(record.recipe_equipment ?? []).map(
@@ -136,9 +138,13 @@ export function mapRecipeDetailRecord(
   };
 }
 
-export function mapRecipeListRecord(record: RecipeListRecord): RecipeListItem {
+export function mapRecipeListRecord(
+  record: RecipeListRecord,
+  categories: RecipeCategorySummary[] = [],
+): RecipeListItem {
   return {
     allergens: normalizeRecipeAllergens(record.allergens),
+    categories,
     cookMinutes: record.cook_minutes,
     coverImagePath: record.cover_image_path,
     createdAt: record.created_at,

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -1,3 +1,7 @@
+import {
+  listRecipeCategoriesByRecipeIds,
+  replaceRecipeCategoryAssignments,
+} from "@/features/categories";
 import { supabase } from "@/lib/supabase";
 
 import {
@@ -223,8 +227,13 @@ export async function getRecipeDetail(
     listRecipeCookLogs(recipeId, recipeClient),
     getRecipeCreatorName(data.owner_id, recipeClient),
   ]);
+  const categoryMap = await listRecipeCategoriesByRecipeIds(
+    [recipeId],
+    recipeClient,
+  );
+  const recipeCategories = categoryMap.get(recipeId) ?? [];
 
-  return mapRecipeDetailRecord(data, cookLogs, creatorName);
+  return mapRecipeDetailRecord(data, cookLogs, recipeCategories, creatorName);
 }
 
 export async function listRecipes(
@@ -265,7 +274,15 @@ async function listRecipeRecords(
     throw error;
   }
 
-  return (data ?? []).map(mapRecipeListRecord);
+  const rows = data ?? [];
+  const categoryMap = await listRecipeCategoriesByRecipeIds(
+    rows.map((row) => row.id),
+    recipeClient,
+  );
+
+  return rows.map((row) =>
+    mapRecipeListRecord(row, categoryMap.get(row.id) ?? []),
+  );
 }
 
 function getRecipeApiClient(client: RecipeApiClient | null): RecipeApiClient {
@@ -293,6 +310,7 @@ async function insertRecipeRelations(
     input.equipment,
   );
   const stepRows = buildRecipeStepInsertRows(recipeId, input.steps);
+  await replaceRecipeCategoryAssignments(recipeId, input.categoryIds, client);
 
   if (ingredientRows.length > 0) {
     const { error } = await client

--- a/src/features/recipes/queries/recipeData.test.ts
+++ b/src/features/recipes/queries/recipeData.test.ts
@@ -132,6 +132,13 @@ describe("mapRecipeDetailRecord", () => {
           updated_at: "2026-03-25T21:30:00.000Z",
         },
       ],
+      [
+        {
+          id: "category-1",
+          name: "Weeknight",
+          slug: "weeknight",
+        },
+      ],
       "Dylan Logan",
     );
 
@@ -146,6 +153,13 @@ describe("mapRecipeDetailRecord", () => {
     expect(recipe.steps.map((item) => item.position)).toEqual([1, 2]);
     expect(recipe.creatorName).toBe("Dylan Logan");
     expect(recipe.allergens).toEqual(["milk", "wheat"]);
+    expect(recipe.categories).toEqual([
+      {
+        id: "category-1",
+        name: "Weeknight",
+        slug: "weeknight",
+      },
+    ]);
   });
 });
 

--- a/src/features/recipes/queries/recipeQueryHelpers.test.ts
+++ b/src/features/recipes/queries/recipeQueryHelpers.test.ts
@@ -67,6 +67,7 @@ function buildRecipeDetail(
 ): RecipeDetail {
   return {
     allergens: ["milk"],
+    categories: [],
     cookMinutes: 20,
     cookLogs: [],
     coverImagePath: null,
@@ -95,6 +96,7 @@ function buildRecipeListItem(
 ): RecipeListItem {
   return {
     allergens: ["milk"],
+    categories: [],
     cookMinutes: 20,
     coverImagePath: null,
     createdAt: "2026-03-27T10:00:00.000Z",

--- a/src/features/recipes/schemas/recipeFormSchema.test.ts
+++ b/src/features/recipes/schemas/recipeFormSchema.test.ts
@@ -6,6 +6,7 @@ describe("recipeCreateFormSchema", () => {
   it("parses authoring form values into create recipe input", () => {
     const result = recipeCreateFormSchema.parse({
       allergens: ["milk", "wheat"],
+      categoryIds: ["11111111-1111-4111-8111-111111111111"],
       cookMinutes: "15",
       description: "Roast until golden.",
       equipment: [
@@ -43,6 +44,7 @@ describe("recipeCreateFormSchema", () => {
 
     expect(result).toEqual({
       allergens: ["milk", "wheat"],
+      categoryIds: ["11111111-1111-4111-8111-111111111111"],
       cookMinutes: 15,
       description: "Roast until golden.",
       equipment: [
@@ -81,6 +83,7 @@ describe("recipeCreateFormSchema", () => {
   it("rejects missing title, ingredients, or steps", () => {
     const result = recipeCreateFormSchema.safeParse({
       allergens: [],
+      categoryIds: [],
       cookMinutes: "",
       description: "",
       equipment: [],
@@ -112,6 +115,7 @@ describe("recipeCreateFormSchema", () => {
   it("rejects negative and non-integer timer values", () => {
     const result = recipeCreateFormSchema.safeParse({
       allergens: [],
+      categoryIds: [],
       cookMinutes: "",
       description: "",
       equipment: [],
@@ -158,6 +162,7 @@ describe("recipeCreateFormSchema", () => {
   it("supports seconds and hours authoring units", () => {
     const result = recipeCreateFormSchema.parse({
       allergens: [],
+      categoryIds: [],
       cookMinutes: "",
       description: "",
       equipment: [],
@@ -202,6 +207,43 @@ describe("recipeCreateFormSchema", () => {
   it("rejects allergens outside the hardcoded FDA list", () => {
     const result = recipeCreateFormSchema.safeParse({
       allergens: ["dairy"],
+      categoryIds: [],
+      cookMinutes: "",
+      description: "",
+      equipment: [],
+      ingredients: [
+        {
+          amount: "1",
+          isOptional: false,
+          item: "Milk",
+          notes: "",
+          preparation: "",
+          unit: "cups",
+        },
+      ],
+      isScalable: false,
+      prepMinutes: "",
+      steps: [
+        {
+          instruction: "Pour the milk.",
+          notes: "",
+          timerUnit: "minutes",
+          timerValue: "",
+        },
+      ],
+      summary: "",
+      title: "Milk",
+      yieldQuantity: "",
+      yieldUnit: "",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed category ids", () => {
+    const result = recipeCreateFormSchema.safeParse({
+      allergens: [],
+      categoryIds: ["not-a-uuid"],
       cookMinutes: "",
       description: "",
       equipment: [],

--- a/src/features/recipes/schemas/recipeFormSchema.ts
+++ b/src/features/recipes/schemas/recipeFormSchema.ts
@@ -79,6 +79,7 @@ const recipeStepSchema = z.object({
 export const recipeCreateFormSchema = z
   .object({
     allergens: z.array(z.enum(recipeAllergens)),
+    categoryIds: z.array(z.string().uuid()),
     cookMinutes: optionalIntegerStringSchema,
     description: optionalTrimmedTextSchema,
     equipment: z.array(recipeEquipmentSchema),
@@ -96,6 +97,7 @@ export const recipeCreateFormSchema = z
   .transform(
     ({
       allergens,
+      categoryIds,
       cookMinutes,
       description,
       equipment,
@@ -109,6 +111,7 @@ export const recipeCreateFormSchema = z
       yieldUnit,
     }): CreateRecipeInput => ({
       allergens,
+      categoryIds,
       cookMinutes,
       description,
       equipment: equipment.map((item) => ({

--- a/src/features/recipes/schemas/recipeShelfSearchSchema.test.ts
+++ b/src/features/recipes/schemas/recipeShelfSearchSchema.test.ts
@@ -38,5 +38,13 @@ describe("recipeShelfSearchSchema", () => {
       recipeShelfSearchSchema.safeParse({ categories: "Brunch,weeknight" })
         .success,
     ).toBe(false);
+    expect(
+      recipeShelfSearchSchema.safeParse({ categories: "-brunch,weeknight" })
+        .success,
+    ).toBe(false);
+    expect(
+      recipeShelfSearchSchema.safeParse({ categories: "brunch--ideas" })
+        .success,
+    ).toBe(false);
   });
 });

--- a/src/features/recipes/schemas/recipeShelfSearchSchema.test.ts
+++ b/src/features/recipes/schemas/recipeShelfSearchSchema.test.ts
@@ -7,6 +7,20 @@ describe("recipeShelfSearchSchema", () => {
     expect(recipeShelfSearchSchema.parse({})).toEqual({});
   });
 
+  it("accepts category and time filter search params", () => {
+    expect(
+      recipeShelfSearchSchema.parse({
+        categories: "brunch,weeknight",
+        maxTotalMinutes: "45",
+        minTotalMinutes: "10",
+      }),
+    ).toEqual({
+      categories: "brunch,weeknight",
+      maxTotalMinutes: "45",
+      minTotalMinutes: "10",
+    });
+  });
+
   it("accepts the delete success flag", () => {
     expect(recipeShelfSearchSchema.parse({ deleted: "1" })).toEqual({
       deleted: "1",
@@ -17,5 +31,12 @@ describe("recipeShelfSearchSchema", () => {
     const result = recipeShelfSearchSchema.safeParse({ deleted: "0" });
 
     expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed category filters", () => {
+    expect(
+      recipeShelfSearchSchema.safeParse({ categories: "Brunch,weeknight" })
+        .success,
+    ).toBe(false);
   });
 });

--- a/src/features/recipes/schemas/recipeShelfSearchSchema.ts
+++ b/src/features/recipes/schemas/recipeShelfSearchSchema.ts
@@ -1,7 +1,17 @@
 import { z } from "zod";
 
+const recipeShelfCategoryCsvSchema = z
+  .string()
+  .regex(/^[a-z0-9-]+(?:,[a-z0-9-]+)*$/)
+  .optional();
+
+const recipeShelfMinuteSchema = z.string().regex(/^\d+$/).optional();
+
 export const recipeShelfSearchSchema = z.object({
+  categories: recipeShelfCategoryCsvSchema,
   deleted: z.enum(["1"]).optional(),
+  maxTotalMinutes: recipeShelfMinuteSchema,
+  minTotalMinutes: recipeShelfMinuteSchema,
 });
 
 export type RecipeShelfSearch = z.infer<typeof recipeShelfSearchSchema>;

--- a/src/features/recipes/schemas/recipeShelfSearchSchema.ts
+++ b/src/features/recipes/schemas/recipeShelfSearchSchema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 const recipeShelfCategoryCsvSchema = z
   .string()
-  .regex(/^[a-z0-9-]+(?:,[a-z0-9-]+)*$/)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*(?:,[a-z0-9]+(?:-[a-z0-9]+)*)*$/)
   .optional();
 
 const recipeShelfMinuteSchema = z.string().regex(/^\d+$/).optional();

--- a/src/features/recipes/types/recipes.ts
+++ b/src/features/recipes/types/recipes.ts
@@ -1,3 +1,5 @@
+import type { RecipeCategorySummary } from "@/features/categories";
+
 export type RecipeAllergen =
   | "milk"
   | "eggs"
@@ -11,6 +13,7 @@ export type RecipeAllergen =
 
 export type RecipeListItem = {
   allergens: RecipeAllergen[];
+  categories: RecipeCategorySummary[];
   cookMinutes: number | null;
   coverImagePath: string | null;
   createdAt: string;
@@ -96,6 +99,7 @@ export type CreateRecipeStepInput = {
 
 export type CreateRecipeInput = {
   allergens?: RecipeAllergen[];
+  categoryIds?: string[];
   cookMinutes?: number | null;
   coverImagePath?: string | null;
   description?: string | null;

--- a/src/features/recipes/utils/recipeFormValues.test.ts
+++ b/src/features/recipes/utils/recipeFormValues.test.ts
@@ -11,6 +11,7 @@ describe("createEmptyRecipeCreateFormValues", () => {
   it("starts ingredient, equipment, and step collections empty", () => {
     expect(createEmptyRecipeCreateFormValues()).toEqual({
       allergens: [],
+      categoryIds: [],
       cookMinutes: "",
       description: "",
       equipment: [],
@@ -36,6 +37,7 @@ describe("createRecipeFormValuesFromRecipe", () => {
       creatorName: "Dylan Logan",
       description: "A rich tomato sauce.",
       allergens: ["milk", "wheat"],
+      categories: [{ id: "category-1", name: "Weeknight", slug: "weeknight" }],
       equipment: [
         {
           details: "large pot",
@@ -80,6 +82,7 @@ describe("createRecipeFormValuesFromRecipe", () => {
 
     expect(createRecipeFormValuesFromRecipe(recipe)).toEqual({
       allergens: ["milk", "wheat"],
+      categoryIds: ["category-1"],
       cookMinutes: "25",
       description: "A rich tomato sauce.",
       equipment: [
@@ -125,6 +128,7 @@ describe("createRecipeFormValuesFromRecipe", () => {
       creatorName: null,
       description: "",
       allergens: [],
+      categories: [],
       equipment: [],
       id: "recipe-2",
       ingredients: [],
@@ -157,6 +161,7 @@ describe("createRecipeFormValuesFromRecipe", () => {
       creatorName: null,
       description: "",
       allergens: [],
+      categories: [],
       equipment: [],
       id: "recipe-3",
       ingredients: [],

--- a/src/features/recipes/utils/recipeFormValues.ts
+++ b/src/features/recipes/utils/recipeFormValues.ts
@@ -1,3 +1,5 @@
+import type { RecipeCategorySummary } from "@/features/categories";
+
 import {
   createRecipeTimerAuthoringValue,
   type RecipeTimerUnit,
@@ -29,6 +31,7 @@ export type RecipeCreateStepFormValue = {
 
 export type RecipeCreateFormValues = {
   allergens: RecipeAllergen[];
+  categoryIds: string[];
   cookMinutes: string;
   description: string;
   equipment: RecipeCreateEquipmentFormValue[];
@@ -73,6 +76,7 @@ export function createEmptyRecipeStepFormValue(): RecipeCreateStepFormValue {
 export function createEmptyRecipeCreateFormValues(): RecipeCreateFormValues {
   return {
     allergens: [],
+    categoryIds: [],
     cookMinutes: "",
     description: "",
     equipment: [],
@@ -92,6 +96,7 @@ export function createRecipeFormValuesFromRecipe(
 ): RecipeCreateFormValues {
   return {
     allergens: recipe.allergens,
+    categoryIds: recipe.categories.map((category) => category.id),
     cookMinutes: formatOptionalNumber(recipe.cookMinutes),
     description: recipe.description,
     equipment: recipe.equipment.map((item) => ({
@@ -119,6 +124,25 @@ export function createRecipeFormValuesFromRecipe(
     yieldQuantity: formatOptionalNumber(recipe.yieldQuantity),
     yieldUnit: recipe.yieldUnit ?? "",
   };
+}
+
+export function mergeRecipeCategoryOptions(
+  availableCategories: readonly RecipeCategorySummary[],
+  selectedCategories: readonly RecipeCategorySummary[],
+): RecipeCategorySummary[] {
+  const categoryMap = new Map<string, RecipeCategorySummary>();
+
+  for (const category of availableCategories) {
+    categoryMap.set(category.id, category);
+  }
+
+  for (const category of selectedCategories) {
+    categoryMap.set(category.id, category);
+  }
+
+  return [...categoryMap.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
 }
 
 function formatOptionalNumber(value: number | null): string {

--- a/src/features/recipes/utils/recipeShelfFilters.test.ts
+++ b/src/features/recipes/utils/recipeShelfFilters.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyRecipeShelfFilters,
+  getRecipeShelfFilters,
+  serializeRecipeShelfCategorySlugs,
+  serializeRecipeShelfMinuteValue,
+} from "./recipeShelfFilters";
+
+describe("getRecipeShelfFilters", () => {
+  it("parses category slugs and minute filters from search", () => {
+    expect(
+      getRecipeShelfFilters({
+        categories: "brunch,weeknight,brunch",
+        maxTotalMinutes: "45",
+        minTotalMinutes: "15",
+      }),
+    ).toEqual({
+      categorySlugs: ["brunch", "weeknight"],
+      maxTotalMinutes: 45,
+      minTotalMinutes: 15,
+    });
+  });
+
+  it("normalizes reversed minute ranges", () => {
+    expect(
+      getRecipeShelfFilters({
+        maxTotalMinutes: "10",
+        minTotalMinutes: "20",
+      }),
+    ).toEqual({
+      categorySlugs: [],
+      maxTotalMinutes: 20,
+      minTotalMinutes: 10,
+    });
+  });
+});
+
+describe("applyRecipeShelfFilters", () => {
+  it("requires recipes to match all selected category slugs", () => {
+    const recipes = [
+      {
+        categories: [
+          { id: "1", name: "Brunch", slug: "brunch" },
+          { id: "2", name: "Vegetarian", slug: "vegetarian" },
+        ],
+        totalMinutes: 25,
+      },
+      {
+        categories: [{ id: "1", name: "Brunch", slug: "brunch" }],
+        totalMinutes: 25,
+      },
+    ];
+
+    expect(
+      applyRecipeShelfFilters(recipes as never, {
+        categorySlugs: ["brunch", "vegetarian"],
+        maxTotalMinutes: null,
+        minTotalMinutes: null,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("filters by total time when a range is present", () => {
+    const recipes = [
+      { categories: [], totalMinutes: 10 },
+      { categories: [], totalMinutes: 35 },
+      { categories: [], totalMinutes: null },
+    ];
+
+    expect(
+      applyRecipeShelfFilters(recipes as never, {
+        categorySlugs: [],
+        maxTotalMinutes: 40,
+        minTotalMinutes: 20,
+      }),
+    ).toEqual([{ categories: [], totalMinutes: 35 }]);
+  });
+});
+
+describe("recipe shelf serialization helpers", () => {
+  it("serializes category slugs into a stable csv string", () => {
+    expect(
+      serializeRecipeShelfCategorySlugs(["weeknight", "brunch", "weeknight"]),
+    ).toBe("brunch,weeknight");
+  });
+
+  it("serializes minute values only when present", () => {
+    expect(serializeRecipeShelfMinuteValue(25)).toBe("25");
+    expect(serializeRecipeShelfMinuteValue(null)).toBeUndefined();
+  });
+});

--- a/src/features/recipes/utils/recipeShelfFilters.ts
+++ b/src/features/recipes/utils/recipeShelfFilters.ts
@@ -1,0 +1,129 @@
+import type { RecipeShelfSearch } from "../schemas/recipeShelfSearchSchema";
+import type { RecipeListItem } from "../types/recipes";
+
+export type RecipeShelfFilters = {
+  categorySlugs: string[];
+  maxTotalMinutes: number | null;
+  minTotalMinutes: number | null;
+};
+
+export function applyRecipeShelfFilters(
+  recipes: readonly RecipeListItem[],
+  filters: RecipeShelfFilters,
+): RecipeListItem[] {
+  return recipes.filter((recipe) => {
+    if (filters.categorySlugs.length > 0) {
+      const recipeCategorySlugs = new Set(
+        recipe.categories.map((item) => item.slug),
+      );
+
+      if (
+        !filters.categorySlugs.every((slug) => recipeCategorySlugs.has(slug))
+      ) {
+        return false;
+      }
+    }
+
+    if (filters.minTotalMinutes !== null || filters.maxTotalMinutes !== null) {
+      if (recipe.totalMinutes === null) {
+        return false;
+      }
+
+      if (
+        filters.minTotalMinutes !== null &&
+        recipe.totalMinutes < filters.minTotalMinutes
+      ) {
+        return false;
+      }
+
+      if (
+        filters.maxTotalMinutes !== null &&
+        recipe.totalMinutes > filters.maxTotalMinutes
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export function getRecipeShelfFilters(
+  search: RecipeShelfSearch,
+): RecipeShelfFilters {
+  const minTotalMinutes = parseOptionalMinuteSearch(search.minTotalMinutes);
+  const maxTotalMinutes = parseOptionalMinuteSearch(search.maxTotalMinutes);
+  const normalizedPair =
+    minTotalMinutes !== null &&
+    maxTotalMinutes !== null &&
+    minTotalMinutes > maxTotalMinutes
+      ? {
+          maxTotalMinutes: minTotalMinutes,
+          minTotalMinutes: maxTotalMinutes,
+        }
+      : {
+          maxTotalMinutes,
+          minTotalMinutes,
+        };
+
+  return {
+    categorySlugs: parseRecipeShelfCategorySlugs(search.categories),
+    ...normalizedPair,
+  };
+}
+
+export function getRecipeShelfHasActiveFilters(
+  filters: RecipeShelfFilters,
+): boolean {
+  return (
+    filters.categorySlugs.length > 0 ||
+    filters.minTotalMinutes !== null ||
+    filters.maxTotalMinutes !== null
+  );
+}
+
+export function parseRecipeShelfCategorySlugs(
+  value: string | undefined,
+): string[] {
+  if (value === undefined || value.trim() === "") {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      value
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+
+export function serializeRecipeShelfCategorySlugs(
+  categorySlugs: readonly string[],
+): string | undefined {
+  const normalizedCategorySlugs = [...new Set(categorySlugs)]
+    .map((slug) => slug.trim())
+    .filter((slug) => slug !== "")
+    .sort();
+
+  return normalizedCategorySlugs.length === 0
+    ? undefined
+    : normalizedCategorySlugs.join(",");
+}
+
+export function serializeRecipeShelfMinuteValue(
+  value: number | null,
+): string | undefined {
+  return value === null ? undefined : String(Math.max(0, Math.round(value)));
+}
+
+function parseOptionalMinuteSearch(value: string | undefined): number | null {
+  if (value === undefined || value.trim() === "") {
+    return null;
+  }
+
+  const parsedValue = Number(value);
+
+  return Number.isInteger(parsedValue) && parsedValue >= 0 ? parsedValue : null;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as RecipesIndexRouteImport } from './routes/recipes.index'
 import { Route as UsersUserIdRouteImport } from './routes/users.$userId'
 import { Route as RecipesNewRouteImport } from './routes/recipes.new'
 import { Route as RecipesRecipeIdRouteImport } from './routes/recipes.$recipeId'
+import { Route as AdminCategoriesRouteImport } from './routes/admin.categories'
 import { Route as RecipesRecipeIdIndexRouteImport } from './routes/recipes.$recipeId.index'
 import { Route as RecipesRecipeIdEditRouteImport } from './routes/recipes.$recipeId.edit'
 
@@ -54,6 +55,11 @@ const RecipesRecipeIdRoute = RecipesRecipeIdRouteImport.update({
   path: '/$recipeId',
   getParentRoute: () => RecipesRoute,
 } as any)
+const AdminCategoriesRoute = AdminCategoriesRouteImport.update({
+  id: '/admin/categories',
+  path: '/admin/categories',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RecipesRecipeIdIndexRoute = RecipesRecipeIdIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -69,6 +75,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
+  '/admin/categories': typeof AdminCategoriesRoute
   '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
   '/recipes/new': typeof RecipesNewRoute
   '/users/$userId': typeof UsersUserIdRoute
@@ -79,6 +86,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
+  '/admin/categories': typeof AdminCategoriesRoute
   '/recipes/new': typeof RecipesNewRoute
   '/users/$userId': typeof UsersUserIdRoute
   '/recipes': typeof RecipesIndexRoute
@@ -90,6 +98,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
   '/recipes': typeof RecipesRouteWithChildren
+  '/admin/categories': typeof AdminCategoriesRoute
   '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
   '/recipes/new': typeof RecipesNewRoute
   '/users/$userId': typeof UsersUserIdRoute
@@ -103,6 +112,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/recipes'
+    | '/admin/categories'
     | '/recipes/$recipeId'
     | '/recipes/new'
     | '/users/$userId'
@@ -113,6 +123,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/account'
+    | '/admin/categories'
     | '/recipes/new'
     | '/users/$userId'
     | '/recipes'
@@ -123,6 +134,7 @@ export interface FileRouteTypes {
     | '/'
     | '/account'
     | '/recipes'
+    | '/admin/categories'
     | '/recipes/$recipeId'
     | '/recipes/new'
     | '/users/$userId'
@@ -135,6 +147,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccountRoute: typeof AccountRoute
   RecipesRoute: typeof RecipesRouteWithChildren
+  AdminCategoriesRoute: typeof AdminCategoriesRoute
   UsersUserIdRoute: typeof UsersUserIdRoute
 }
 
@@ -189,6 +202,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecipesRecipeIdRouteImport
       parentRoute: typeof RecipesRoute
     }
+    '/admin/categories': {
+      id: '/admin/categories'
+      path: '/admin/categories'
+      fullPath: '/admin/categories'
+      preLoaderRoute: typeof AdminCategoriesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/recipes/$recipeId/': {
       id: '/recipes/$recipeId/'
       path: '/'
@@ -239,6 +259,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccountRoute: AccountRoute,
   RecipesRoute: RecipesRouteWithChildren,
+  AdminCategoriesRoute: AdminCategoriesRoute,
   UsersUserIdRoute: UsersUserIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/admin.categories.tsx
+++ b/src/routes/admin.categories.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { CategoriesAdminPage } from "@/features/categories";
+
+export const Route = createFileRoute("/admin/categories")({
+  component: CategoriesAdminPage,
+});

--- a/src/routes/recipes.index.tsx
+++ b/src/routes/recipes.index.tsx
@@ -13,7 +13,9 @@ import type { JSX } from "react";
 function RecipesIndexRouteComponent(): JSX.Element {
   const search = Route.useSearch();
 
-  return <RecipesPage showDeletedBanner={search.deleted === "1"} />;
+  return (
+    <RecipesPage search={search} showDeletedBanner={search.deleted === "1"} />
+  );
 }
 
 export const Route = createFileRoute("/recipes/")({

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -77,6 +77,66 @@ export type Database = {
           },
         ];
       };
+      recipe_categories: {
+        Row: {
+          created_at: string;
+          id: string;
+          is_active: boolean;
+          name: string;
+          slug: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          is_active?: boolean;
+          name: string;
+          slug: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          is_active?: boolean;
+          name?: string;
+          slug?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      recipe_category_assignments: {
+        Row: {
+          category_id: string;
+          created_at: string;
+          recipe_id: string;
+        };
+        Insert: {
+          category_id: string;
+          created_at?: string;
+          recipe_id: string;
+        };
+        Update: {
+          category_id?: string;
+          created_at?: string;
+          recipe_id?: string;
+        };
+        Relationships: [
+          {
+            columns: ["category_id"];
+            foreignKeyName: "recipe_category_assignments_category_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "recipe_categories";
+          },
+          {
+            columns: ["recipe_id"];
+            foreignKeyName: "recipe_category_assignments_recipe_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "recipes";
+          },
+        ];
+      };
       recipe_equipment: {
         Row: {
           created_at: string;

--- a/supabase/migrations/20260408230000_add_recipe_categories.sql
+++ b/supabase/migrations/20260408230000_add_recipe_categories.sql
@@ -1,0 +1,119 @@
+create table public.recipe_categories (
+  id uuid primary key default extensions.gen_random_uuid (),
+  slug text not null,
+  name text not null,
+  is_active boolean not null default true,
+  created_at timestamptz not null default timezone ('utc', now()),
+  updated_at timestamptz not null default timezone ('utc', now()),
+  constraint recipe_categories_slug_not_blank check (char_length(btrim(slug)) between 1 and 80),
+  constraint recipe_categories_slug_format check (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+  constraint recipe_categories_name_not_blank check (char_length(btrim(name)) between 1 and 80)
+);
+
+create unique index recipe_categories_slug_key on public.recipe_categories (slug);
+
+create unique index recipe_categories_name_lower_key on public.recipe_categories (lower(name));
+
+create trigger set_recipe_categories_updated_at before
+update on public.recipe_categories for each row
+execute function public.set_updated_at ();
+
+grant
+select
+  on public.recipe_categories to anon,
+  authenticated;
+
+grant insert,
+update on public.recipe_categories to authenticated;
+
+alter table public.recipe_categories enable row level security;
+
+create policy "Recipe categories are readable by everyone" on public.recipe_categories for
+select
+  to anon,
+  authenticated using (true);
+
+create policy "Admins can insert recipe categories" on public.recipe_categories for insert to authenticated
+with
+  check (public.current_user_is_admin ());
+
+create policy "Admins can update recipe categories" on public.recipe_categories
+for update
+  to authenticated using (public.current_user_is_admin ())
+with
+  check (public.current_user_is_admin ());
+
+create table public.recipe_category_assignments (
+  recipe_id uuid not null references public.recipes (id) on delete cascade,
+  category_id uuid not null references public.recipe_categories (id) on delete restrict,
+  created_at timestamptz not null default timezone ('utc', now()),
+  constraint recipe_category_assignments_pkey primary key (recipe_id, category_id)
+);
+
+create index recipe_category_assignments_category_id_idx on public.recipe_category_assignments (category_id, recipe_id);
+
+create trigger touch_recipe_on_category_assignment_change
+after insert
+or delete on public.recipe_category_assignments for each row
+execute function public.touch_recipe_updated_at ();
+
+grant
+select
+  on public.recipe_category_assignments to anon,
+  authenticated;
+
+grant insert,
+delete on public.recipe_category_assignments to authenticated;
+
+alter table public.recipe_category_assignments enable row level security;
+
+create policy "Recipe category assignments are readable by everyone" on public.recipe_category_assignments for
+select
+  to anon,
+  authenticated using (true);
+
+create policy "Recipe owners and admins can insert category assignments" on public.recipe_category_assignments for insert to authenticated
+with
+  check (
+    exists (
+      select
+        1
+      from
+        public.recipes
+      where
+        recipes.id = recipe_category_assignments.recipe_id
+        and (
+          recipes.owner_id = (
+            select
+              auth.uid ()
+          )
+          or public.current_user_is_admin ()
+        )
+    )
+    and exists (
+      select
+        1
+      from
+        public.recipe_categories
+      where
+        recipe_categories.id = recipe_category_assignments.category_id
+    )
+  );
+
+create policy "Recipe owners and admins can delete category assignments" on public.recipe_category_assignments for delete to authenticated using (
+  exists (
+    select
+      1
+    from
+      public.recipes
+    where
+      recipes.id = recipe_category_assignments.recipe_id
+      and (
+        recipes.owner_id = (
+          select
+            auth.uid ()
+        )
+        or public.current_user_is_admin ()
+      )
+  )
+);

--- a/supabase/migrations/20260408230000_add_recipe_categories.sql
+++ b/supabase/migrations/20260408230000_add_recipe_categories.sql
@@ -97,6 +97,10 @@ with
         public.recipe_categories
       where
         recipe_categories.id = recipe_category_assignments.category_id
+        and (
+          recipe_categories.is_active
+          or public.current_user_is_admin ()
+        )
     )
   );
 


### PR DESCRIPTION
## Summary
- add recipe category schema, assignment policies, and admin category management
- wire category selection into recipe create and edit flows
- add shelf category chips, multi-select filtering, and total-time range controls

## Validation
- npm run test
- npm run lint
- npm run build

Closes #132