### PR TITLE
feat(equipment): add owner inventory management

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -25,16 +25,32 @@ export function AppShellHeader({
           </Link>
 
           <nav className="flex items-center gap-1">
-            <Button asChild className="rounded-md px-3" size="sm" variant="ghost">
-              <Link to="/recipes">
-                Recipes
-              </Link>
+            <Button
+              asChild
+              className="rounded-md px-3"
+              size="sm"
+              variant="ghost"
+            >
+              <Link to="/recipes">Recipes</Link>
+            </Button>
+            <Button
+              asChild
+              className="rounded-md px-3"
+              size="sm"
+              variant="ghost"
+            >
+              <Link to="/equipment">Equipment</Link>
             </Button>
           </nav>
         </div>
 
         <div className="flex items-center gap-2">
-          <Button asChild className="rounded-md px-3" size="sm" variant="outline">
+          <Button
+            asChild
+            className="rounded-md px-3"
+            size="sm"
+            variant="outline"
+          >
             <Link to="/account">
               <UserRound className="size-4" />
               {authActionLabel}

--- a/src/features/equipment/components/EquipmentPage.tsx
+++ b/src/features/equipment/components/EquipmentPage.tsx
@@ -1,0 +1,385 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useState, type ChangeEvent, type JSX } from "react";
+
+import { Button } from "@/components/ui/button";
+import { sessionQueryOptions } from "@/features/auth";
+import { useAppToast } from "@/hooks/useAppToast";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+import { EquipmentDataAccessError } from "../queries/equipmentApi";
+import {
+  createEquipmentMutationOptions,
+  deleteEquipmentMutationOptions,
+  updateEquipmentMutationOptions,
+} from "../queries/equipmentMutationOptions";
+import { equipmentListQueryOptions } from "../queries/equipmentQueryOptions";
+import { equipmentFormSchema } from "../schemas/equipmentSchemas";
+
+import type { EquipmentItem } from "../types/equipment";
+
+export function EquipmentPage(): JSX.Element {
+  useDocumentTitle("Equipment");
+
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery(sessionQueryOptions);
+  const ownerId =
+    sessionQuery.data?.kind === "authenticated" ? sessionQuery.data.userId : "";
+  const equipmentQuery = useQuery({
+    ...equipmentListQueryOptions(ownerId),
+    enabled: ownerId !== "",
+  });
+  const createMutation = useMutation(
+    createEquipmentMutationOptions(queryClient),
+  );
+  const updateMutation = useMutation(
+    updateEquipmentMutationOptions(queryClient),
+  );
+  const deleteMutation = useMutation(
+    deleteEquipmentMutationOptions(queryClient),
+  );
+  const { toast } = useAppToast();
+  const [newName, setNewName] = useState("");
+  const [draftNames, setDraftNames] = useState<Record<string, string>>({});
+
+  if (sessionQuery.isLoading) {
+    return (
+      <EquipmentPageState
+        description="Checking access."
+        title="Loading equipment"
+      />
+    );
+  }
+
+  if (sessionQuery.data === undefined || sessionQuery.data.kind === "guest") {
+    return (
+      <EquipmentPageState
+        description="Sign in to manage the equipment you use across recipes."
+        title="Sign in to manage equipment"
+      />
+    );
+  }
+
+  if (sessionQuery.data.kind === "unconfigured") {
+    return (
+      <EquipmentPageState
+        description="Supabase is not configured for equipment management in this environment."
+        title="Equipment management is unavailable"
+      />
+    );
+  }
+
+  const equipment = equipmentQuery.data ?? [];
+
+  return (
+    <main className="w-full max-w-4xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          Equipment
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Keep a personal equipment list ready for recipe authoring.
+        </p>
+      </section>
+
+      <div className="mt-6 space-y-6">
+        <section className="space-y-4 rounded-lg border border-border bg-background p-5">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+              Add equipment
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Recipe forms will pull from this list instead of free-text
+              equipment names.
+            </p>
+          </div>
+
+          <form
+            className="flex flex-col gap-3 sm:flex-row"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleCreateEquipment();
+            }}
+          >
+            <label className="flex-1">
+              <span className="sr-only">Equipment name</span>
+              <input
+                className="w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                onChange={(event) => {
+                  setNewName(event.target.value);
+                }}
+                placeholder="12-inch skillet"
+                value={newName}
+              />
+            </label>
+            <Button
+              className="rounded-md px-4"
+              disabled={createMutation.isPending}
+              type="submit"
+            >
+              {createMutation.isPending ? "Adding..." : "Add equipment"}
+            </Button>
+          </form>
+        </section>
+
+        {equipmentQuery.isError ? (
+          <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Equipment unavailable
+            </h2>
+            <p className="mt-1 text-sm text-amber-950/85">
+              Your equipment list could not load right now. Try again in a
+              moment.
+            </p>
+          </section>
+        ) : null}
+
+        <section className="space-y-4 rounded-lg border border-border bg-background p-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight text-foreground">
+                Your inventory
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Rename or remove equipment you no longer need.
+              </p>
+            </div>
+            <Button asChild className="rounded-md px-4" variant="outline">
+              <Link to="/recipes/new">Create recipe</Link>
+            </Button>
+          </div>
+
+          {equipment.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border px-4 py-6 text-sm text-muted-foreground">
+              No equipment saved yet. Add your common tools here so recipes can
+              reference them.
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {equipment.map((item) => {
+                const draftName = draftNames[item.id] ?? item.name;
+                const isDirty = draftName.trim() !== item.name;
+                const isDeletePending =
+                  deleteMutation.isPending &&
+                  deleteMutation.variables?.equipmentId === item.id;
+                const isUpdatePending =
+                  updateMutation.isPending &&
+                  updateMutation.variables?.equipmentId === item.id;
+
+                return (
+                  <li
+                    key={item.id}
+                    className="rounded-lg border border-border px-4 py-4"
+                  >
+                    <form
+                      className="flex flex-col gap-3 md:flex-row md:items-center"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        handleUpdateEquipment(item.id, draftName);
+                      }}
+                    >
+                      <label className="flex-1">
+                        <span className="sr-only">Equipment name</span>
+                        <input
+                          className="w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                            setDraftNames((current) => ({
+                              ...current,
+                              [item.id]: event.target.value,
+                            }));
+                          }}
+                          value={draftName}
+                        />
+                      </label>
+
+                      <div className="flex items-center gap-2">
+                        <Button
+                          className="rounded-md px-4"
+                          disabled={!isDirty || isUpdatePending}
+                          type="submit"
+                        >
+                          {isUpdatePending ? "Saving..." : "Save"}
+                        </Button>
+                        <Button
+                          className="rounded-md px-4 text-destructive hover:text-destructive"
+                          disabled={isDeletePending}
+                          onClick={() => {
+                            handleDeleteEquipment(item);
+                          }}
+                          type="button"
+                          variant="outline"
+                        >
+                          {isDeletePending ? "Removing..." : "Delete"}
+                        </Button>
+                      </div>
+                    </form>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+
+  function handleCreateEquipment(): void {
+    const parsed = equipmentFormSchema.safeParse({ name: newName });
+
+    if (!parsed.success) {
+      toast({
+        description:
+          parsed.error.issues[0]?.message ?? "Add a valid equipment item name.",
+        title: "Equipment form needs attention",
+        tone: "error",
+      });
+      return;
+    }
+
+    createMutation.mutate(
+      { name: parsed.data.name },
+      {
+        onError: (error) => {
+          toast({
+            description: getEquipmentMutationErrorMessage(error),
+            title: "Equipment could not be added",
+            tone: "error",
+          });
+        },
+        onSuccess: () => {
+          setNewName("");
+          toast({
+            description:
+              "This equipment item is now available in recipe forms.",
+            title: "Equipment added",
+            tone: "success",
+          });
+        },
+      },
+    );
+  }
+
+  function handleUpdateEquipment(equipmentId: string, name: string): void {
+    const parsed = equipmentFormSchema.safeParse({ name });
+
+    if (!parsed.success) {
+      toast({
+        description:
+          parsed.error.issues[0]?.message ?? "Add a valid equipment item name.",
+        title: "Equipment form needs attention",
+        tone: "error",
+      });
+      return;
+    }
+
+    updateMutation.mutate(
+      {
+        equipmentId,
+        name: parsed.data.name,
+      },
+      {
+        onError: (error) => {
+          toast({
+            description: getEquipmentMutationErrorMessage(error),
+            title: "Equipment could not be updated",
+            tone: "error",
+          });
+        },
+        onSuccess: (item) => {
+          setDraftNames((current) => ({
+            ...current,
+            [equipmentId]: item.name,
+          }));
+          toast({
+            description: "Recipe forms will use the updated equipment name.",
+            title: "Equipment updated",
+            tone: "success",
+          });
+        },
+      },
+    );
+  }
+
+  function handleDeleteEquipment(item: EquipmentItem): void {
+    deleteMutation.mutate(
+      { equipmentId: item.id },
+      {
+        onError: (error) => {
+          toast({
+            description: getEquipmentMutationErrorMessage(error),
+            title: "Equipment could not be removed",
+            tone: "error",
+          });
+        },
+        onSuccess: () => {
+          setDraftNames((current) => {
+            const nextDrafts = { ...current };
+            delete nextDrafts[item.id];
+            return nextDrafts;
+          });
+          void queryClient.invalidateQueries({
+            queryKey: ["recipes"],
+          });
+          toast({
+            description: "The equipment item was removed from your inventory.",
+            title: "Equipment removed",
+            tone: "success",
+          });
+        },
+      },
+    );
+  }
+}
+
+function EquipmentPageState({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}): JSX.Element {
+  return (
+    <main className="w-full max-w-4xl py-3 sm:py-4">
+      <section className="border-b border-border pb-4">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      </section>
+    </main>
+  );
+}
+
+function getEquipmentMutationErrorMessage(error: unknown): string {
+  if (error instanceof EquipmentDataAccessError) {
+    return error.message;
+  }
+
+  if (isDuplicateEquipmentError(error)) {
+    return "You already have an equipment item with that name.";
+  }
+
+  if (isEquipmentInUseError(error)) {
+    return "This equipment item is still used by one or more recipes. Remove it from those recipes first.";
+  }
+
+  return "Something went wrong while saving your equipment list.";
+}
+
+function isDuplicateEquipmentError(candidate: unknown): boolean {
+  return getDatabaseErrorCode(candidate) === "23505";
+}
+
+function isEquipmentInUseError(candidate: unknown): boolean {
+  return getDatabaseErrorCode(candidate) === "23503";
+}
+
+function getDatabaseErrorCode(candidate: unknown): string | null {
+  if (candidate === null || typeof candidate !== "object") {
+    return null;
+  }
+
+  const databaseError = candidate as Record<string, unknown>;
+
+  return typeof databaseError.code === "string" ? databaseError.code : null;
+}

--- a/src/features/equipment/index.ts
+++ b/src/features/equipment/index.ts
@@ -1,0 +1,36 @@
+export { EquipmentPage } from "./components/EquipmentPage";
+export {
+  createEquipment,
+  deleteEquipment,
+  EquipmentDataAccessError,
+  listEquipmentByIdsForOwner,
+  listEquipmentForOwner,
+  updateEquipment,
+  type EquipmentDataAccessErrorCode,
+} from "./queries/equipmentApi";
+export {
+  equipmentMutationKeys,
+  equipmentQueryKeys,
+} from "./queries/equipmentKeys";
+export {
+  createEquipmentMutationOptions,
+  deleteEquipmentMutationOptions,
+  updateEquipmentMutationOptions,
+} from "./queries/equipmentMutationOptions";
+export {
+  equipmentListQueryOptions,
+  preloadEquipmentList,
+} from "./queries/equipmentQueryOptions";
+export {
+  equipmentFormSchema,
+  equipmentNameSchema,
+  type EquipmentFormInput,
+  type EquipmentFormOutput,
+} from "./schemas/equipmentSchemas";
+export type {
+  CreateEquipmentInput,
+  DeleteEquipmentInput,
+  DeleteEquipmentResult,
+  EquipmentItem,
+  UpdateEquipmentInput,
+} from "./types/equipment";

--- a/src/features/equipment/queries/equipmentApi.ts
+++ b/src/features/equipment/queries/equipmentApi.ts
@@ -1,0 +1,221 @@
+import { supabase } from "@/lib/supabase";
+
+import type {
+  CreateEquipmentInput,
+  DeleteEquipmentInput,
+  DeleteEquipmentResult,
+  EquipmentItem,
+  UpdateEquipmentInput,
+} from "../types/equipment";
+
+type EquipmentApiClient = NonNullable<typeof supabase>;
+type EquipmentRecord = {
+  created_at: string;
+  id: string;
+  name: string;
+  owner_id: string;
+  updated_at: string;
+};
+type DeletedEquipmentRecord = {
+  id: string;
+};
+
+export type EquipmentDataAccessErrorCode =
+  | "authentication-required"
+  | "not-found"
+  | "supabase-unconfigured";
+
+export class EquipmentDataAccessError extends Error {
+  readonly code: EquipmentDataAccessErrorCode;
+
+  constructor(
+    code: EquipmentDataAccessErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.code = code;
+    this.name = "EquipmentDataAccessError";
+  }
+}
+
+const equipmentSelect = `
+  id,
+  owner_id,
+  name,
+  created_at,
+  updated_at
+`;
+
+export async function listEquipmentForOwner(
+  ownerId: string,
+  client: EquipmentApiClient | null = supabase,
+): Promise<EquipmentItem[]> {
+  const equipmentClient = getEquipmentApiClient(client);
+  const { data, error } = await equipmentClient
+    .from("user_equipment")
+    .select(equipmentSelect)
+    .eq("owner_id", ownerId.trim())
+    .order("name", { ascending: true })
+    .overrideTypes<EquipmentRecord[], { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return (data ?? []).map(mapEquipmentRecord);
+}
+
+export async function listEquipmentByIdsForOwner(
+  ownerId: string,
+  equipmentIds: readonly string[],
+  client: EquipmentApiClient | null = supabase,
+): Promise<EquipmentItem[]> {
+  if (equipmentIds.length === 0) {
+    return [];
+  }
+
+  const equipmentClient = getEquipmentApiClient(client);
+  const { data, error } = await equipmentClient
+    .from("user_equipment")
+    .select(equipmentSelect)
+    .eq("owner_id", ownerId.trim())
+    .in("id", [...equipmentIds])
+    .overrideTypes<EquipmentRecord[], { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return (data ?? []).map(mapEquipmentRecord);
+}
+
+export async function createEquipment(
+  input: CreateEquipmentInput,
+  client: EquipmentApiClient | null = supabase,
+): Promise<EquipmentItem> {
+  const equipmentClient = getEquipmentApiClient(client);
+  const ownerId = await getAuthenticatedEquipmentUserId(equipmentClient);
+  const { data, error } = await equipmentClient
+    .from("user_equipment")
+    .insert({
+      name: input.name.trim(),
+      owner_id: ownerId,
+    })
+    .select(equipmentSelect)
+    .maybeSingle()
+    .overrideTypes<EquipmentRecord, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data === null) {
+    throw new EquipmentDataAccessError(
+      "not-found",
+      "The equipment item could not be created.",
+    );
+  }
+
+  return mapEquipmentRecord(data);
+}
+
+export async function updateEquipment(
+  input: UpdateEquipmentInput,
+  client: EquipmentApiClient | null = supabase,
+): Promise<EquipmentItem> {
+  const equipmentClient = getEquipmentApiClient(client);
+  await getAuthenticatedEquipmentUserId(equipmentClient);
+  const { data, error } = await equipmentClient
+    .from("user_equipment")
+    .update({
+      name: input.name.trim(),
+    })
+    .eq("id", input.equipmentId.trim())
+    .select(equipmentSelect)
+    .maybeSingle()
+    .overrideTypes<EquipmentRecord, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data === null) {
+    throw new EquipmentDataAccessError(
+      "not-found",
+      `Equipment item ${input.equipmentId} could not be updated.`,
+    );
+  }
+
+  return mapEquipmentRecord(data);
+}
+
+export async function deleteEquipment(
+  input: DeleteEquipmentInput,
+  client: EquipmentApiClient | null = supabase,
+): Promise<DeleteEquipmentResult> {
+  const equipmentClient = getEquipmentApiClient(client);
+  await getAuthenticatedEquipmentUserId(equipmentClient);
+  const equipmentId = input.equipmentId.trim();
+  const { data, error } = await equipmentClient
+    .from("user_equipment")
+    .delete()
+    .eq("id", equipmentId)
+    .select("id")
+    .maybeSingle()
+    .overrideTypes<DeletedEquipmentRecord, { merge: false }>();
+
+  if (error !== null) {
+    throw error;
+  }
+
+  if (data === null) {
+    throw new EquipmentDataAccessError(
+      "not-found",
+      `Equipment item ${equipmentId} could not be deleted.`,
+    );
+  }
+
+  return {
+    equipmentId: data.id,
+  };
+}
+
+function getEquipmentApiClient(
+  client: EquipmentApiClient | null,
+): EquipmentApiClient {
+  if (client === null) {
+    throw new EquipmentDataAccessError(
+      "supabase-unconfigured",
+      "Supabase is not configured for equipment data access.",
+    );
+  }
+
+  return client;
+}
+
+async function getAuthenticatedEquipmentUserId(
+  client: EquipmentApiClient,
+): Promise<string> {
+  const { data, error } = await client.auth.getUser();
+
+  if (error !== null || data.user === null) {
+    throw new EquipmentDataAccessError(
+      "authentication-required",
+      "Sign in before managing equipment.",
+      { cause: error ?? undefined },
+    );
+  }
+
+  return data.user.id;
+}
+
+function mapEquipmentRecord(record: EquipmentRecord): EquipmentItem {
+  return {
+    createdAt: record.created_at,
+    id: record.id,
+    name: record.name,
+    ownerId: record.owner_id,
+    updatedAt: record.updated_at,
+  };
+}

--- a/src/features/equipment/queries/equipmentKeys.ts
+++ b/src/features/equipment/queries/equipmentKeys.ts
@@ -1,0 +1,11 @@
+export const equipmentQueryKeys = {
+  all: ["equipment"] as const,
+  list: (ownerId: string) => [...equipmentQueryKeys.lists(), ownerId] as const,
+  lists: () => [...equipmentQueryKeys.all, "list"] as const,
+};
+
+export const equipmentMutationKeys = {
+  create: () => [...equipmentQueryKeys.all, "create"] as const,
+  delete: () => [...equipmentQueryKeys.all, "delete"] as const,
+  update: () => [...equipmentQueryKeys.all, "update"] as const,
+};

--- a/src/features/equipment/queries/equipmentMutationOptions.ts
+++ b/src/features/equipment/queries/equipmentMutationOptions.ts
@@ -1,0 +1,75 @@
+import { mutationOptions } from "@tanstack/react-query";
+
+import {
+  createEquipment,
+  deleteEquipment,
+  updateEquipment,
+} from "./equipmentApi";
+import { equipmentMutationKeys, equipmentQueryKeys } from "./equipmentKeys";
+
+import type {
+  CreateEquipmentInput,
+  DeleteEquipmentInput,
+  DeleteEquipmentResult,
+  EquipmentItem,
+  UpdateEquipmentInput,
+} from "../types/equipment";
+import type { QueryClient } from "@tanstack/react-query";
+
+type CreateEquipmentMutationOptions = ReturnType<
+  typeof mutationOptions<EquipmentItem, Error, CreateEquipmentInput>
+>;
+type UpdateEquipmentMutationOptions = ReturnType<
+  typeof mutationOptions<EquipmentItem, Error, UpdateEquipmentInput>
+>;
+type DeleteEquipmentMutationOptions = ReturnType<
+  typeof mutationOptions<DeleteEquipmentResult, Error, DeleteEquipmentInput>
+>;
+
+export function createEquipmentMutationOptions(
+  queryClient: QueryClient,
+): CreateEquipmentMutationOptions {
+  return mutationOptions({
+    mutationFn: (input): Promise<EquipmentItem> => createEquipment(input),
+    mutationKey: equipmentMutationKeys.create(),
+    onSuccess: async (): Promise<void> => {
+      await invalidateEquipmentRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function updateEquipmentMutationOptions(
+  queryClient: QueryClient,
+): UpdateEquipmentMutationOptions {
+  return mutationOptions({
+    mutationFn: (input): Promise<EquipmentItem> => updateEquipment(input),
+    mutationKey: equipmentMutationKeys.update(),
+    onSuccess: async (): Promise<void> => {
+      await invalidateEquipmentRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function deleteEquipmentMutationOptions(
+  queryClient: QueryClient,
+): DeleteEquipmentMutationOptions {
+  return mutationOptions({
+    mutationFn: (input): Promise<DeleteEquipmentResult> =>
+      deleteEquipment(input),
+    mutationKey: equipmentMutationKeys.delete(),
+    onSuccess: async (): Promise<void> => {
+      await invalidateEquipmentRelatedQueries(queryClient);
+    },
+  });
+}
+
+async function invalidateEquipmentRelatedQueries(
+  queryClient: QueryClient,
+): Promise<void> {
+  await queryClient.invalidateQueries({
+    queryKey: equipmentQueryKeys.all,
+  });
+  await queryClient.invalidateQueries({
+    queryKey: ["recipes"],
+  });
+}

--- a/src/features/equipment/queries/equipmentQueryOptions.ts
+++ b/src/features/equipment/queries/equipmentQueryOptions.ts
@@ -1,0 +1,33 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { listEquipmentForOwner } from "./equipmentApi";
+import { equipmentQueryKeys } from "./equipmentKeys";
+
+import type { EquipmentItem } from "../types/equipment";
+import type { QueryClient } from "@tanstack/react-query";
+
+type EquipmentListQueryOptions = ReturnType<
+  typeof queryOptions<
+    EquipmentItem[],
+    Error,
+    EquipmentItem[],
+    ReturnType<typeof equipmentQueryKeys.list>
+  >
+>;
+
+export function equipmentListQueryOptions(
+  ownerId: string,
+): EquipmentListQueryOptions {
+  return queryOptions({
+    queryFn: (): Promise<EquipmentItem[]> => listEquipmentForOwner(ownerId),
+    queryKey: equipmentQueryKeys.list(ownerId),
+    staleTime: 30_000,
+  });
+}
+
+export async function preloadEquipmentList(
+  queryClient: QueryClient,
+  ownerId: string,
+): Promise<void> {
+  await queryClient.ensureQueryData(equipmentListQueryOptions(ownerId));
+}

--- a/src/features/equipment/schemas/equipmentSchemas.test.ts
+++ b/src/features/equipment/schemas/equipmentSchemas.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { equipmentFormSchema } from "./equipmentSchemas";
+
+describe("equipmentFormSchema", () => {
+  it("trims valid equipment names", () => {
+    const result = equipmentFormSchema.parse({
+      name: "  12-inch skillet  ",
+    });
+
+    expect(result).toEqual({
+      name: "12-inch skillet",
+    });
+  });
+
+  it("rejects blank equipment names", () => {
+    const result = equipmentFormSchema.safeParse({
+      name: "   ",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues[0]?.message).toBe("Add an equipment item name.");
+  });
+});

--- a/src/features/equipment/schemas/equipmentSchemas.ts
+++ b/src/features/equipment/schemas/equipmentSchemas.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const equipmentNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Add an equipment item name.")
+  .max(200, "Equipment item names must be 200 characters or fewer.");
+
+export const equipmentFormSchema = z.object({
+  name: equipmentNameSchema,
+});
+
+export type EquipmentFormInput = z.input<typeof equipmentFormSchema>;
+export type EquipmentFormOutput = z.output<typeof equipmentFormSchema>;

--- a/src/features/equipment/types/equipment.ts
+++ b/src/features/equipment/types/equipment.ts
@@ -1,0 +1,24 @@
+export type EquipmentItem = {
+  createdAt: string;
+  id: string;
+  name: string;
+  ownerId: string;
+  updatedAt: string;
+};
+
+export type CreateEquipmentInput = {
+  name: string;
+};
+
+export type UpdateEquipmentInput = {
+  equipmentId: string;
+  name: string;
+};
+
+export type DeleteEquipmentInput = {
+  equipmentId: string;
+};
+
+export type DeleteEquipmentResult = {
+  equipmentId: string;
+};

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -160,6 +160,7 @@ export function CreateRecipePage(): JSX.Element {
           coverPhotoInputResetKey={coverPhotoInputResetKey}
           currentCoverPhotoPath={null}
           hasCoverPhoto={selectedCoverPhoto !== null}
+          isEquipmentLoading={equipmentListQuery.isLoading}
           isPending={isSubmitting}
           onCoverPhotoChange={(file) => {
             setSelectedCoverPhoto(file);

--- a/src/features/recipes/components/CreateRecipePage.tsx
+++ b/src/features/recipes/components/CreateRecipePage.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
 import { publicRecipeCategoryListQueryOptions } from "@/features/categories";
+import { equipmentListQueryOptions } from "@/features/equipment";
 import { useAppToast } from "@/hooks/useAppToast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
@@ -30,7 +31,13 @@ export function CreateRecipePage(): JSX.Element {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const sessionQuery = useQuery(sessionQueryOptions);
+  const equipmentOwnerId =
+    sessionQuery.data?.kind === "authenticated" ? sessionQuery.data.userId : "";
   const categoryListQuery = useQuery(publicRecipeCategoryListQueryOptions());
+  const equipmentListQuery = useQuery({
+    ...equipmentListQueryOptions(equipmentOwnerId),
+    enabled: equipmentOwnerId !== "",
+  });
   const createRecipeMutation = useMutation(
     createRecipeMutationOptions(queryClient),
   );
@@ -139,6 +146,7 @@ export function CreateRecipePage(): JSX.Element {
       <div className="mt-6">
         <RecipeCreateForm
           availableCategories={categoryListQuery.data ?? []}
+          availableEquipment={equipmentListQuery.data ?? []}
           cancelButton={
             <Button
               asChild
@@ -167,6 +175,7 @@ export function CreateRecipePage(): JSX.Element {
           removeCoverPhotoLabel="Remove photo"
           selectedCoverPhoto={selectedCoverPhoto}
           setValues={setValues}
+          showManageEquipmentLink
           submitLabel="Create recipe"
           submitPendingLabel="Saving recipe..."
           values={values}
@@ -180,6 +189,18 @@ export function CreateRecipePage(): JSX.Element {
             <p className="mt-1 text-sm text-amber-950/85">
               The category list could not load right now. You can still save the
               recipe without category tags.
+            </p>
+          </section>
+        ) : null}
+
+        {equipmentListQuery.isError ? (
+          <section className="mt-4 rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Equipment unavailable
+            </h2>
+            <p className="mt-1 text-sm text-amber-950/85">
+              Your equipment list could not load right now. Add equipment later
+              if you need it for this recipe.
             </p>
           </section>
         ) : null}

--- a/src/features/recipes/components/EditRecipePage.tsx
+++ b/src/features/recipes/components/EditRecipePage.tsx
@@ -275,6 +275,7 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
           hasCoverPhoto={
             currentCoverPhotoPath !== null || selectedCoverPhoto !== null
           }
+          isEquipmentLoading={equipmentListQuery.isLoading}
           isPending={isSubmitting}
           onCoverPhotoChange={(file) => {
             setSelectedCoverPhoto(file);

--- a/src/features/recipes/components/EditRecipePage.tsx
+++ b/src/features/recipes/components/EditRecipePage.tsx
@@ -5,6 +5,10 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
 import { publicRecipeCategoryListQueryOptions } from "@/features/categories";
+import {
+  equipmentListQueryOptions,
+  type EquipmentItem,
+} from "@/features/equipment";
 import { profileListQueryOptions } from "@/features/profiles";
 import { useAppToast } from "@/hooks/useAppToast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -62,6 +66,17 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedOwnerId, setSelectedOwnerId] = useState("");
   const [values, setValues] = useState(createEmptyRecipeCreateFormValues);
+  const equipmentOwnerId =
+    recipeDetailQuery.data === undefined
+      ? ""
+      : selectedOwnerId.trim() !== ""
+        ? selectedOwnerId
+        : recipeDetailQuery.data.ownerId;
+  const equipmentListQuery = useQuery({
+    ...equipmentListQueryOptions(equipmentOwnerId),
+    enabled:
+      sessionQuery.data?.kind === "authenticated" && equipmentOwnerId !== "",
+  });
 
   useDocumentTitle(
     recipeDetailQuery.data === undefined
@@ -84,6 +99,30 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
     setInitializedRecipeId(recipeDetailQuery.data.id);
     setCoverPhotoInputResetKey((current) => current + 1);
   }, [initializedRecipeId, recipeDetailQuery.data]);
+
+  useEffect(() => {
+    if (equipmentListQuery.data === undefined) {
+      return;
+    }
+
+    const validEquipmentIds = new Set(
+      equipmentListQuery.data.map((item) => item.id),
+    );
+
+    setValues((current) => {
+      const nextEquipment = current.equipment.map((item) =>
+        item.equipmentId === "" || validEquipmentIds.has(item.equipmentId)
+          ? item
+          : { ...item, equipmentId: "" },
+      );
+      const hasChanges = nextEquipment.some(
+        (item, index) =>
+          item.equipmentId !== current.equipment[index]?.equipmentId,
+      );
+
+      return hasChanges ? { ...current, equipment: nextEquipment } : current;
+    });
+  }, [equipmentListQuery.data]);
 
   if (
     recipeDetailQuery.data === undefined ||
@@ -176,6 +215,11 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
     categoryListQuery.data ?? [],
     recipe.categories,
   );
+  const availableEquipment =
+    nextOwnerId === recipe.ownerId
+      ? mergeEquipmentOptions(equipmentListQuery.data ?? [], recipe.equipment)
+      : (equipmentListQuery.data ?? []);
+  const showManageEquipmentLink = sessionState.userId === nextOwnerId;
 
   return (
     <main className="w-full max-w-6xl py-3 sm:py-4">
@@ -213,6 +257,7 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
 
         <RecipeCreateForm
           availableCategories={availableCategories}
+          availableEquipment={availableEquipment}
           cancelButton={
             <Button
               asChild
@@ -260,6 +305,7 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
           }
           selectedCoverPhoto={selectedCoverPhoto}
           setValues={setValues}
+          showManageEquipmentLink={showManageEquipmentLink}
           submitLabel="Save changes"
           submitPendingLabel="Saving changes..."
           values={values}
@@ -273,6 +319,18 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
             <p className="mt-1 text-sm text-amber-950/85">
               The category list could not load right now. Existing category
               assignments are still preserved when you save.
+            </p>
+          </section>
+        ) : null}
+
+        {equipmentListQuery.isError ? (
+          <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
+            <h2 className="text-sm font-semibold text-amber-950">
+              Equipment unavailable
+            </h2>
+            <p className="mt-1 text-sm text-amber-950/85">
+              The equipment inventory for this recipe owner could not load right
+              now. Existing selections are still shown where possible.
             </p>
           </section>
         ) : null}
@@ -368,6 +426,38 @@ export function EditRecipePage({ recipeId }: EditRecipePageProps): JSX.Element {
       setIsSubmitting(false);
     }
   }
+}
+
+function mergeEquipmentOptions(
+  availableEquipment: readonly EquipmentItem[],
+  recipeEquipment: {
+    equipmentId: string;
+    name: string;
+  }[],
+): EquipmentItem[] {
+  const equipmentMap = new Map<string, EquipmentItem>();
+
+  for (const item of availableEquipment) {
+    equipmentMap.set(item.id, item);
+  }
+
+  for (const item of recipeEquipment) {
+    if (equipmentMap.has(item.equipmentId)) {
+      continue;
+    }
+
+    equipmentMap.set(item.equipmentId, {
+      createdAt: "",
+      id: item.equipmentId,
+      name: item.name,
+      ownerId: "",
+      updatedAt: "",
+    });
+  }
+
+  return [...equipmentMap.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
 }
 
 type RecipeEditAccessStateProps = {

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -38,6 +38,7 @@ type RecipeCreateFormProps = {
   coverPhotoInputResetKey: number;
   currentCoverPhotoPath: string | null;
   hasCoverPhoto: boolean;
+  isEquipmentLoading: boolean;
   isPending: boolean;
   onCoverPhotoChange: (file: File | null) => void;
   onRemoveCoverPhoto: () => void;
@@ -60,6 +61,7 @@ export function RecipeCreateForm({
   coverPhotoInputResetKey,
   currentCoverPhotoPath,
   hasCoverPhoto,
+  isEquipmentLoading,
   isPending,
   onCoverPhotoChange,
   onRemoveCoverPhoto,
@@ -323,7 +325,13 @@ export function RecipeCreateForm({
       <RecipeCreateCollectionSection
         addLabel="Add equipment"
         description={
-          availableEquipment.length === 0 ? (
+          isEquipmentLoading ? (
+            <p className="text-sm text-muted-foreground">
+              {showManageEquipmentLink
+                ? "Loading your equipment inventory."
+                : "Loading the selected owner's equipment inventory."}
+            </p>
+          ) : availableEquipment.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               {showManageEquipmentLink ? (
                 <>
@@ -360,7 +368,7 @@ export function RecipeCreateForm({
             </p>
           )
         }
-        isAddDisabled={availableEquipment.length === 0}
+        isAddDisabled={isEquipmentLoading || availableEquipment.length === 0}
         items={values.equipment}
         onAdd={() => {
           setValues((current) => ({

--- a/src/features/recipes/components/RecipeCreateForm.tsx
+++ b/src/features/recipes/components/RecipeCreateForm.tsx
@@ -1,5 +1,8 @@
+import { Link } from "@tanstack/react-router";
+
 import { Button } from "@/components/ui/button";
 import type { RecipeCategorySummary } from "@/features/categories";
+import type { EquipmentItem } from "@/features/equipment";
 
 import { getIngredientUnitGroups } from "../utils/ingredientUnits";
 import {
@@ -30,6 +33,7 @@ const checkboxClassName =
 
 type RecipeCreateFormProps = {
   availableCategories: RecipeCategorySummary[];
+  availableEquipment: EquipmentItem[];
   cancelButton: JSX.Element;
   coverPhotoInputResetKey: number;
   currentCoverPhotoPath: string | null;
@@ -43,6 +47,7 @@ type RecipeCreateFormProps = {
   setValues: (
     updater: (current: RecipeCreateFormValues) => RecipeCreateFormValues,
   ) => void;
+  showManageEquipmentLink: boolean;
   submitLabel: string;
   submitPendingLabel: string;
   values: RecipeCreateFormValues;
@@ -50,6 +55,7 @@ type RecipeCreateFormProps = {
 
 export function RecipeCreateForm({
   availableCategories,
+  availableEquipment,
   cancelButton,
   coverPhotoInputResetKey,
   currentCoverPhotoPath,
@@ -61,6 +67,7 @@ export function RecipeCreateForm({
   removeCoverPhotoLabel,
   selectedCoverPhoto,
   setValues,
+  showManageEquipmentLink,
   submitLabel,
   submitPendingLabel,
   values,
@@ -315,6 +322,45 @@ export function RecipeCreateForm({
 
       <RecipeCreateCollectionSection
         addLabel="Add equipment"
+        description={
+          availableEquipment.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {showManageEquipmentLink ? (
+                <>
+                  No equipment is saved yet. Add equipment on the{" "}
+                  <Link
+                    className="font-medium text-foreground underline underline-offset-4"
+                    to="/equipment"
+                  >
+                    Equipment
+                  </Link>{" "}
+                  page first.
+                </>
+              ) : (
+                "No equipment is available in the selected owner's inventory yet."
+              )}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {showManageEquipmentLink ? (
+                <>
+                  Select from your saved equipment. You can update the list on
+                  the{" "}
+                  <Link
+                    className="font-medium text-foreground underline underline-offset-4"
+                    to="/equipment"
+                  >
+                    Equipment
+                  </Link>{" "}
+                  page.
+                </>
+              ) : (
+                "Select from the selected owner's saved equipment."
+              )}
+            </p>
+          )
+        }
+        isAddDisabled={availableEquipment.length === 0}
         items={values.equipment}
         onAdd={() => {
           setValues((current) => ({
@@ -335,6 +381,7 @@ export function RecipeCreateForm({
         }}
         renderItem={(equipment, index) => (
           <EquipmentFields
+            availableEquipment={availableEquipment}
             equipment={equipment}
             onChange={(nextEquipment) => {
               setValues((current) => ({
@@ -445,7 +492,9 @@ function CoverPhotoPreviewCard({
 
 type RecipeCreateCollectionSectionProps<TItem> = {
   addLabel: string;
+  description?: JSX.Element;
   getItemHeading?: (index: number) => string | null;
+  isAddDisabled?: boolean;
   items: TItem[];
   onAdd: () => void;
   onRemove: (index: number) => void;
@@ -455,7 +504,9 @@ type RecipeCreateCollectionSectionProps<TItem> = {
 
 function RecipeCreateCollectionSection<TItem>({
   addLabel,
+  description,
   getItemHeading,
+  isAddDisabled = false,
   items,
   onAdd,
   onRemove,
@@ -465,11 +516,15 @@ function RecipeCreateCollectionSection<TItem>({
   return (
     <section className="space-y-4 border-b border-border pb-8">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold tracking-tight text-foreground">
-          {title}
-        </h2>
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold tracking-tight text-foreground">
+            {title}
+          </h2>
+          {description ?? null}
+        </div>
         <Button
           className="rounded-md px-4"
+          disabled={isAddDisabled}
           onClick={onAdd}
           type="button"
           variant="outline"
@@ -620,26 +675,34 @@ function IngredientFields({
 }
 
 type EquipmentFieldsProps = {
+  availableEquipment: EquipmentItem[];
   equipment: RecipeCreateEquipmentFormValue;
   onChange: (equipment: RecipeCreateEquipmentFormValue) => void;
 };
 
 function EquipmentFields({
+  availableEquipment,
   equipment,
   onChange,
 }: EquipmentFieldsProps): JSX.Element {
   return (
     <div className="grid gap-4 md:grid-cols-2">
-      <label>
+      <label className="md:col-span-2">
         <span className="text-sm font-medium text-foreground">Equipment</span>
-        <input
+        <select
           className={inputClassName}
           onChange={(event) => {
-            onChange({ ...equipment, name: event.target.value });
+            onChange({ ...equipment, equipmentId: event.target.value });
           }}
-          placeholder="Chef's knife"
-          value={equipment.name}
-        />
+          value={equipment.equipmentId}
+        >
+          <option value="">Choose equipment</option>
+          {availableEquipment.map((item) => (
+            <option key={item.id} value={item.id}>
+              {item.name}
+            </option>
+          ))}
+        </select>
       </label>
 
       <label>

--- a/src/features/recipes/queries/recipeAdapters.ts
+++ b/src/features/recipes/queries/recipeAdapters.ts
@@ -71,14 +71,24 @@ export function buildRecipeEquipmentInsertRows(
   equipment: CreateRecipeEquipmentInput[] | undefined,
   inventoryItemsById: ReadonlyMap<string, EquipmentItem>,
 ): RecipeEquipmentInsert[] {
-  return (equipment ?? []).map((item, index) => ({
-    details: normalizeOptionalText(item.details),
-    equipment_id: item.equipmentId,
-    is_optional: item.isOptional ?? false,
-    name: inventoryItemsById.get(item.equipmentId)?.name.trim() ?? "",
-    position: index + 1,
-    recipe_id: recipeId,
-  }));
+  return (equipment ?? []).map((item, index) => {
+    const inventoryItem = inventoryItemsById.get(item.equipmentId);
+
+    if (inventoryItem === undefined) {
+      throw new Error(
+        `Equipment inventory item ${item.equipmentId} is missing from the recipe owner inventory map.`,
+      );
+    }
+
+    return {
+      details: normalizeOptionalText(item.details),
+      equipment_id: item.equipmentId,
+      is_optional: item.isOptional ?? false,
+      name: inventoryItem.name.trim(),
+      position: index + 1,
+      recipe_id: recipeId,
+    };
+  });
 }
 
 export function buildRecipeIngredientInsertRows(

--- a/src/features/recipes/queries/recipeAdapters.ts
+++ b/src/features/recipes/queries/recipeAdapters.ts
@@ -1,4 +1,5 @@
 import type { RecipeCategorySummary } from "@/features/categories";
+import type { EquipmentItem } from "@/features/equipment";
 import type { Database } from "@/types/supabase";
 
 import {
@@ -68,11 +69,13 @@ export function buildRecipeInsert(
 export function buildRecipeEquipmentInsertRows(
   recipeId: string,
   equipment: CreateRecipeEquipmentInput[] | undefined,
+  inventoryItemsById: ReadonlyMap<string, EquipmentItem>,
 ): RecipeEquipmentInsert[] {
   return (equipment ?? []).map((item, index) => ({
     details: normalizeOptionalText(item.details),
+    equipment_id: item.equipmentId,
     is_optional: item.isOptional ?? false,
-    name: item.name.trim(),
+    name: inventoryItemsById.get(item.equipmentId)?.name.trim() ?? "",
     position: index + 1,
     recipe_id: recipeId,
   }));
@@ -176,6 +179,7 @@ function getTotalMinutes(
 function mapRecipeEquipmentRow(row: RecipeEquipmentRow): RecipeEquipment {
   return {
     details: row.details,
+    equipmentId: row.equipment_id,
     id: row.id,
     isOptional: row.is_optional,
     name: row.name,

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -2,6 +2,8 @@ import {
   listRecipeCategoriesByRecipeIds,
   replaceRecipeCategoryAssignments,
 } from "@/features/categories";
+import { listEquipmentByIdsForOwner } from "@/features/equipment";
+import type { EquipmentItem } from "@/features/equipment";
 import { supabase } from "@/lib/supabase";
 
 import {
@@ -33,7 +35,10 @@ type CreatedRecipeRecord = {
   id: string;
 };
 
-export type RecipeDataAccessErrorCode = "not-found" | "supabase-unconfigured";
+export type RecipeDataAccessErrorCode =
+  | "invalid-equipment"
+  | "not-found"
+  | "supabase-unconfigured";
 
 export class RecipeDataAccessError extends Error {
   readonly code: RecipeDataAccessErrorCode;
@@ -93,6 +98,7 @@ const recipeDetailSelect = `
   ),
   recipe_equipment (
     id,
+    equipment_id,
     position,
     name,
     details,
@@ -118,9 +124,12 @@ export async function createRecipe(
     const { data, error } = await recipeClient
       .from("recipes")
       .insert(buildRecipeInsert(input))
-      .select("id")
+      .select("id, owner_id")
       .single()
-      .overrideTypes<CreatedRecipeRecord, { merge: false }>();
+      .overrideTypes<
+        CreatedRecipeRecord & { owner_id: string },
+        { merge: false }
+      >();
 
     if (error !== null) {
       throw error;
@@ -128,7 +137,12 @@ export async function createRecipe(
 
     createdRecipeId = data.id;
 
-    await insertRecipeRelations(recipeClient, createdRecipeId, input);
+    await insertRecipeRelations(
+      recipeClient,
+      createdRecipeId,
+      data.owner_id,
+      input,
+    );
 
     return getRecipeDetail(createdRecipeId, recipeClient);
   } catch (error) {
@@ -150,9 +164,12 @@ export async function deleteRecipe(
     .from("recipes")
     .delete()
     .eq("id", recipeId)
-    .select("id")
+    .select("id, owner_id")
     .maybeSingle()
-    .overrideTypes<CreatedRecipeRecord, { merge: false }>();
+    .overrideTypes<
+      CreatedRecipeRecord & { owner_id: string },
+      { merge: false }
+    >();
 
   if (error !== null) {
     throw error;
@@ -180,9 +197,12 @@ export async function updateRecipe(
     .from("recipes")
     .update(buildRecipeInsert(input))
     .eq("id", recipeId)
-    .select("id")
+    .select("id, owner_id")
     .maybeSingle()
-    .overrideTypes<CreatedRecipeRecord, { merge: false }>();
+    .overrideTypes<
+      CreatedRecipeRecord & { owner_id: string },
+      { merge: false }
+    >();
 
   if (error !== null) {
     throw error;
@@ -195,7 +215,7 @@ export async function updateRecipe(
     );
   }
 
-  await replaceRecipeRelations(recipeClient, recipeId, input);
+  await replaceRecipeRelations(recipeClient, recipeId, data.owner_id, input);
 
   return getRecipeDetail(recipeId, recipeClient);
 }
@@ -299,8 +319,14 @@ function getRecipeApiClient(client: RecipeApiClient | null): RecipeApiClient {
 async function insertRecipeRelations(
   client: RecipeApiClient,
   recipeId: string,
+  recipeOwnerId: string,
   input: CreateRecipeInput,
 ): Promise<void> {
+  const inventoryItemsById = await getEquipmentInventoryItemsById(
+    recipeOwnerId,
+    input.equipment,
+    client,
+  );
   const ingredientRows = buildRecipeIngredientInsertRows(
     recipeId,
     input.ingredients,
@@ -308,6 +334,7 @@ async function insertRecipeRelations(
   const equipmentRows = buildRecipeEquipmentInsertRows(
     recipeId,
     input.equipment,
+    inventoryItemsById,
   );
   const stepRows = buildRecipeStepInsertRows(recipeId, input.steps);
   await replaceRecipeCategoryAssignments(recipeId, input.categoryIds, client);
@@ -344,6 +371,7 @@ async function insertRecipeRelations(
 async function replaceRecipeRelations(
   client: RecipeApiClient,
   recipeId: string,
+  recipeOwnerId: string,
   input: CreateRecipeInput,
 ): Promise<void> {
   const ingredientDelete = await client
@@ -373,5 +401,29 @@ async function replaceRecipeRelations(
     throw stepDelete.error;
   }
 
-  await insertRecipeRelations(client, recipeId, input);
+  await insertRecipeRelations(client, recipeId, recipeOwnerId, input);
+}
+
+async function getEquipmentInventoryItemsById(
+  ownerId: string,
+  equipment: CreateRecipeInput["equipment"],
+  client: RecipeApiClient,
+): Promise<ReadonlyMap<string, EquipmentItem>> {
+  const equipmentIds = [
+    ...new Set((equipment ?? []).map((item) => item.equipmentId)),
+  ];
+  const inventoryItems = await listEquipmentByIdsForOwner(
+    ownerId,
+    equipmentIds,
+    client,
+  );
+
+  if (inventoryItems.length !== equipmentIds.length) {
+    throw new RecipeDataAccessError(
+      "invalid-equipment",
+      "One or more selected equipment items are unavailable for this recipe owner.",
+    );
+  }
+
+  return new Map(inventoryItems.map((item) => [item.id, item]));
 }

--- a/src/features/recipes/queries/recipeData.test.ts
+++ b/src/features/recipes/queries/recipeData.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildRecipeInsert,
   buildRecipeCookLogInsert,
+  buildRecipeEquipmentInsertRows,
   buildRecipeIngredientInsertRows,
   buildRecipeStepInsertRows,
   mapRecipeDetailRecord,
@@ -26,6 +27,7 @@ describe("mapRecipeDetailRecord", () => {
           {
             created_at: "2026-03-26T10:00:00.000Z",
             details: null,
+            equipment_id: "inventory-2",
             id: "equipment-2",
             is_optional: false,
             name: "Mixing bowl",
@@ -36,6 +38,7 @@ describe("mapRecipeDetailRecord", () => {
           {
             created_at: "2026-03-26T10:00:00.000Z",
             details: "for finishing",
+            equipment_id: "inventory-1",
             id: "equipment-1",
             is_optional: true,
             name: "Microplane",
@@ -150,6 +153,10 @@ describe("mapRecipeDetailRecord", () => {
     ]);
     expect(recipe.ingredients.map((item) => item.position)).toEqual([1, 2]);
     expect(recipe.equipment.map((item) => item.position)).toEqual([1, 2]);
+    expect(recipe.equipment.map((item) => item.equipmentId)).toEqual([
+      "inventory-1",
+      "inventory-2",
+    ]);
     expect(recipe.steps.map((item) => item.position)).toEqual([1, 2]);
     expect(recipe.creatorName).toBe("Dylan Logan");
     expect(recipe.allergens).toEqual(["milk", "wheat"]);
@@ -179,6 +186,28 @@ describe("recipe insert builders", () => {
         unit: " ",
       },
     ]);
+    const equipment = buildRecipeEquipmentInsertRows(
+      "recipe-1",
+      [
+        {
+          details: " heavy duty ",
+          equipmentId: "inventory-1",
+          isOptional: true,
+        },
+      ],
+      new Map([
+        [
+          "inventory-1",
+          {
+            createdAt: "",
+            id: "inventory-1",
+            name: " Dutch oven ",
+            ownerId: "owner-1",
+            updatedAt: "",
+          },
+        ],
+      ]),
+    );
     const steps = buildRecipeStepInsertRows("recipe-1", [
       {
         instruction: " Toast the spices ",
@@ -209,6 +238,16 @@ describe("recipe insert builders", () => {
         preparation: "finely grated",
         recipe_id: "recipe-1",
         unit: null,
+      },
+    ]);
+    expect(equipment).toEqual([
+      {
+        details: "heavy duty",
+        equipment_id: "inventory-1",
+        is_optional: true,
+        name: "Dutch oven",
+        position: 1,
+        recipe_id: "recipe-1",
       },
     ]);
     expect(steps).toEqual([

--- a/src/features/recipes/schemas/recipeFormSchema.test.ts
+++ b/src/features/recipes/schemas/recipeFormSchema.test.ts
@@ -12,8 +12,8 @@ describe("recipeCreateFormSchema", () => {
       equipment: [
         {
           details: "Large mixing bowl",
+          equipmentId: "22222222-2222-4222-8222-222222222222",
           isOptional: false,
-          name: "Bowl",
         },
       ],
       ingredients: [
@@ -50,8 +50,8 @@ describe("recipeCreateFormSchema", () => {
       equipment: [
         {
           details: "Large mixing bowl",
+          equipmentId: "22222222-2222-4222-8222-222222222222",
           isOptional: false,
-          name: "Bowl",
         },
       ],
       ingredients: [
@@ -109,6 +109,56 @@ describe("recipeCreateFormSchema", () => {
         "Add at least one ingredient.",
         "Add at least one step.",
       ]),
+    );
+  });
+
+  it("requires equipment selections to come from the inventory list", () => {
+    const result = recipeCreateFormSchema.safeParse({
+      allergens: [],
+      categoryIds: [],
+      cookMinutes: "",
+      description: "",
+      equipment: [
+        {
+          details: "",
+          equipmentId: "",
+          isOptional: false,
+        },
+      ],
+      ingredients: [
+        {
+          amount: "1",
+          isOptional: false,
+          item: "Flour",
+          notes: "",
+          preparation: "",
+          unit: "cups",
+        },
+      ],
+      isScalable: true,
+      prepMinutes: "",
+      steps: [
+        {
+          instruction: "Mix the flour.",
+          notes: "",
+          timerUnit: "minutes",
+          timerValue: "",
+        },
+      ],
+      summary: "",
+      title: "Bread",
+      yieldQuantity: "",
+      yieldUnit: "",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues.map((issue) => issue.message)).toContain(
+      "Choose an equipment item.",
     );
   });
 

--- a/src/features/recipes/schemas/recipeFormSchema.ts
+++ b/src/features/recipes/schemas/recipeFormSchema.ts
@@ -65,8 +65,8 @@ const recipeIngredientSchema = z.object({
 
 const recipeEquipmentSchema = z.object({
   details: optionalTrimmedTextSchema,
+  equipmentId: z.string().uuid("Choose an equipment item."),
   isOptional: z.boolean(),
-  name: z.string().trim().min(1, "Add an equipment item."),
 });
 
 const recipeStepSchema = z.object({
@@ -116,8 +116,8 @@ export const recipeCreateFormSchema = z
       description,
       equipment: equipment.map((item) => ({
         details: normalizeOptionalText(item.details),
+        equipmentId: item.equipmentId,
         isOptional: item.isOptional,
-        name: item.name,
       })),
       ingredients: ingredients.map((ingredient) => ({
         amount: ingredient.amount,

--- a/src/features/recipes/types/recipes.ts
+++ b/src/features/recipes/types/recipes.ts
@@ -43,6 +43,7 @@ export type RecipeIngredient = {
 
 export type RecipeEquipment = {
   details: string | null;
+  equipmentId: string;
   id: string;
   isOptional: boolean;
   name: string;
@@ -87,8 +88,8 @@ export type CreateRecipeIngredientInput = {
 
 export type CreateRecipeEquipmentInput = {
   details?: string | null;
+  equipmentId: string;
   isOptional?: boolean;
-  name: string;
 };
 
 export type CreateRecipeStepInput = {

--- a/src/features/recipes/utils/recipeFormValues.test.ts
+++ b/src/features/recipes/utils/recipeFormValues.test.ts
@@ -41,6 +41,7 @@ describe("createRecipeFormValuesFromRecipe", () => {
       equipment: [
         {
           details: "large pot",
+          equipmentId: "inventory-1",
           id: "equipment-1",
           isOptional: false,
           name: "Dutch oven",
@@ -88,8 +89,8 @@ describe("createRecipeFormValuesFromRecipe", () => {
       equipment: [
         {
           details: "large pot",
+          equipmentId: "inventory-1",
           isOptional: false,
-          name: "Dutch oven",
         },
       ],
       ingredients: [

--- a/src/features/recipes/utils/recipeFormValues.ts
+++ b/src/features/recipes/utils/recipeFormValues.ts
@@ -18,8 +18,8 @@ export type RecipeCreateIngredientFormValue = {
 
 export type RecipeCreateEquipmentFormValue = {
   details: string;
+  equipmentId: string;
   isOptional: boolean;
-  name: string;
 };
 
 export type RecipeCreateStepFormValue = {
@@ -59,8 +59,8 @@ export function createEmptyRecipeIngredientFormValue(): RecipeCreateIngredientFo
 export function createEmptyRecipeEquipmentFormValue(): RecipeCreateEquipmentFormValue {
   return {
     details: "",
+    equipmentId: "",
     isOptional: false,
-    name: "",
   };
 }
 
@@ -101,8 +101,8 @@ export function createRecipeFormValuesFromRecipe(
     description: recipe.description,
     equipment: recipe.equipment.map((item) => ({
       details: item.details ?? "",
+      equipmentId: item.equipmentId,
       isOptional: item.isOptional,
-      name: item.name,
     })),
     ingredients: recipe.ingredients.map((ingredient) => ({
       amount: formatOptionalNumber(ingredient.amount),

--- a/src/features/recipes/utils/recipePresentation.ts
+++ b/src/features/recipes/utils/recipePresentation.ts
@@ -20,6 +20,8 @@ export function getRecipeLoadDocumentTitle(
 ): string {
   if (surface === "detail" && error instanceof RecipeDataAccessError) {
     switch (error.code) {
+      case "invalid-equipment":
+        return "Recipe Unavailable";
       case "not-found":
         return "Recipe Not Found";
       case "supabase-unconfigured":
@@ -175,6 +177,12 @@ export function getRecipeLoadErrorCopy(
 ): RecipeLoadErrorCopy {
   if (error instanceof RecipeDataAccessError) {
     switch (error.code) {
+      case "invalid-equipment":
+        return {
+          description:
+            "One or more selected equipment items are no longer available for this recipe owner.",
+          title: "This recipe could not be loaded right now.",
+        };
       case "not-found":
         return {
           description:

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as RecipesRouteImport } from './routes/recipes'
+import { Route as EquipmentRouteImport } from './routes/equipment'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecipesIndexRouteImport } from './routes/recipes.index'
@@ -23,6 +24,11 @@ import { Route as RecipesRecipeIdEditRouteImport } from './routes/recipes.$recip
 const RecipesRoute = RecipesRouteImport.update({
   id: '/recipes',
   path: '/recipes',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EquipmentRoute = EquipmentRouteImport.update({
+  id: '/equipment',
+  path: '/equipment',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AccountRoute = AccountRouteImport.update({
@@ -74,6 +80,7 @@ const RecipesRecipeIdEditRoute = RecipesRecipeIdEditRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
+  '/equipment': typeof EquipmentRoute
   '/recipes': typeof RecipesRouteWithChildren
   '/admin/categories': typeof AdminCategoriesRoute
   '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
@@ -86,6 +93,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
+  '/equipment': typeof EquipmentRoute
   '/admin/categories': typeof AdminCategoriesRoute
   '/recipes/new': typeof RecipesNewRoute
   '/users/$userId': typeof UsersUserIdRoute
@@ -97,6 +105,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/account': typeof AccountRoute
+  '/equipment': typeof EquipmentRoute
   '/recipes': typeof RecipesRouteWithChildren
   '/admin/categories': typeof AdminCategoriesRoute
   '/recipes/$recipeId': typeof RecipesRecipeIdRouteWithChildren
@@ -111,6 +120,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/account'
+    | '/equipment'
     | '/recipes'
     | '/admin/categories'
     | '/recipes/$recipeId'
@@ -123,6 +133,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/account'
+    | '/equipment'
     | '/admin/categories'
     | '/recipes/new'
     | '/users/$userId'
@@ -133,6 +144,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/account'
+    | '/equipment'
     | '/recipes'
     | '/admin/categories'
     | '/recipes/$recipeId'
@@ -146,6 +158,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccountRoute: typeof AccountRoute
+  EquipmentRoute: typeof EquipmentRoute
   RecipesRoute: typeof RecipesRouteWithChildren
   AdminCategoriesRoute: typeof AdminCategoriesRoute
   UsersUserIdRoute: typeof UsersUserIdRoute
@@ -158,6 +171,13 @@ declare module '@tanstack/react-router' {
       path: '/recipes'
       fullPath: '/recipes'
       preLoaderRoute: typeof RecipesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/equipment': {
+      id: '/equipment'
+      path: '/equipment'
+      fullPath: '/equipment'
+      preLoaderRoute: typeof EquipmentRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/account': {
@@ -258,6 +278,7 @@ const RecipesRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccountRoute: AccountRoute,
+  EquipmentRoute: EquipmentRoute,
   RecipesRoute: RecipesRouteWithChildren,
   AdminCategoriesRoute: AdminCategoriesRoute,
   UsersUserIdRoute: UsersUserIdRoute,

--- a/src/routes/equipment.tsx
+++ b/src/routes/equipment.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { EquipmentPage } from "@/features/equipment";
+
+export const Route = createFileRoute("/equipment")({
+  component: EquipmentPage,
+});

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -141,6 +141,7 @@ export type Database = {
         Row: {
           created_at: string;
           details: string | null;
+          equipment_id: string;
           id: string;
           is_optional: boolean;
           name: string;
@@ -151,6 +152,7 @@ export type Database = {
         Insert: {
           created_at?: string;
           details?: string | null;
+          equipment_id: string;
           id?: string;
           is_optional?: boolean;
           name: string;
@@ -161,6 +163,7 @@ export type Database = {
         Update: {
           created_at?: string;
           details?: string | null;
+          equipment_id?: string;
           id?: string;
           is_optional?: boolean;
           name?: string;
@@ -169,6 +172,13 @@ export type Database = {
           updated_at?: string;
         };
         Relationships: [
+          {
+            columns: ["equipment_id"];
+            foreignKeyName: "recipe_equipment_equipment_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "user_equipment";
+          },
           {
             columns: ["recipe_id"];
             foreignKeyName: "recipe_equipment_recipe_id_fkey";
@@ -317,6 +327,30 @@ export type Database = {
           updated_at?: string;
           yield_quantity?: number | null;
           yield_unit?: string | null;
+        };
+        Relationships: [];
+      };
+      user_equipment: {
+        Row: {
+          created_at: string;
+          id: string;
+          name: string;
+          owner_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          name: string;
+          owner_id?: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          name?: string;
+          owner_id?: string;
+          updated_at?: string;
         };
         Relationships: [];
       };

--- a/supabase/migrations/20260410010000_add_user_equipment_inventory.sql
+++ b/supabase/migrations/20260410010000_add_user_equipment_inventory.sql
@@ -1,0 +1,238 @@
+create table public.user_equipment (
+  id uuid primary key default extensions.gen_random_uuid (),
+  owner_id uuid not null default auth.uid () references auth.users (id) on delete cascade,
+  name text not null,
+  created_at timestamptz not null default timezone ('utc', now()),
+  updated_at timestamptz not null default timezone ('utc', now()),
+  constraint user_equipment_name_not_blank check (char_length(btrim(name)) between 1 and 200)
+);
+
+create unique index user_equipment_owner_name_key on public.user_equipment (owner_id, lower(btrim(name)));
+
+create index user_equipment_owner_id_idx on public.user_equipment (owner_id, name);
+
+create trigger set_user_equipment_updated_at before
+update on public.user_equipment for each row
+execute function public.set_updated_at ();
+
+grant
+select
+  on public.user_equipment to authenticated;
+
+grant insert,
+update,
+delete on public.user_equipment to authenticated;
+
+alter table public.user_equipment enable row level security;
+
+create policy "Users and admins can view equipment inventory" on public.user_equipment for
+select
+  to authenticated using (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+    or public.current_user_is_admin ()
+  );
+
+create policy "Users can insert their own equipment" on public.user_equipment for insert to authenticated
+with
+  check (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+  );
+
+create policy "Users can update their own equipment" on public.user_equipment
+for update
+  to authenticated using (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+  )
+with
+  check (
+    (
+      select
+        auth.uid ()
+    ) = owner_id
+  );
+
+create policy "Users can delete their own equipment" on public.user_equipment for delete to authenticated using (
+  (
+    select
+      auth.uid ()
+  ) = owner_id
+);
+
+alter table public.recipe_equipment
+add column equipment_id uuid references public.user_equipment (id) on delete restrict;
+
+create index recipe_equipment_equipment_id_idx on public.recipe_equipment (equipment_id);
+
+insert into
+  public.user_equipment (owner_id, name)
+select distinct
+  recipes.owner_id,
+  recipe_equipment.name
+from
+  public.recipe_equipment
+  inner join public.recipes on recipes.id = recipe_equipment.recipe_id
+where
+  char_length(btrim(recipe_equipment.name)) > 0
+on conflict do nothing;
+
+update public.recipe_equipment
+set
+  equipment_id = user_equipment.id
+from
+  public.recipes,
+  public.user_equipment
+where
+  recipes.id = recipe_equipment.recipe_id
+  and user_equipment.owner_id = recipes.owner_id
+  and lower(btrim(user_equipment.name)) = lower(btrim(recipe_equipment.name))
+  and recipe_equipment.equipment_id is null;
+
+alter table public.recipe_equipment
+alter column equipment_id
+set not null;
+
+create or replace function public.set_recipe_equipment_name_from_inventory () returns trigger language plpgsql
+set
+  search_path = public as $$
+declare
+  inventory_name text;
+  inventory_owner_id uuid;
+  recipe_owner_id uuid;
+begin
+  select
+    user_equipment.name,
+    user_equipment.owner_id
+  into
+    inventory_name,
+    inventory_owner_id
+  from
+    public.user_equipment
+  where
+    user_equipment.id = new.equipment_id;
+
+  if inventory_name is null then
+    raise exception 'Equipment inventory item % was not found.', new.equipment_id;
+  end if;
+
+  select
+    recipes.owner_id
+  into
+    recipe_owner_id
+  from
+    public.recipes
+  where
+    recipes.id = new.recipe_id;
+
+  if recipe_owner_id is null then
+    raise exception 'Recipe % was not found.', new.recipe_id;
+  end if;
+
+  if inventory_owner_id <> recipe_owner_id then
+    raise exception 'Equipment inventory item % does not belong to recipe owner %.', new.equipment_id, recipe_owner_id;
+  end if;
+
+  new.name := inventory_name;
+
+  return new;
+end;
+$$;
+
+create or replace function public.sync_recipe_equipment_name_from_inventory () returns trigger language plpgsql
+set
+  search_path = public as $$
+begin
+  update public.recipe_equipment
+  set name = new.name
+  where equipment_id = new.id;
+
+  return new;
+end;
+$$;
+
+create trigger set_recipe_equipment_name_from_inventory before insert
+or
+update of equipment_id,
+name on public.recipe_equipment for each row
+execute function public.set_recipe_equipment_name_from_inventory ();
+
+create trigger sync_recipe_equipment_name_from_inventory
+after
+update of name on public.user_equipment for each row
+execute function public.sync_recipe_equipment_name_from_inventory ();
+
+drop policy if exists "Recipe owners and admins can insert equipment" on public.recipe_equipment;
+
+create policy "Recipe owners and admins can insert equipment" on public.recipe_equipment for insert to authenticated
+with
+  check (
+    exists (
+      select
+        1
+      from
+        public.recipes
+        inner join public.user_equipment on user_equipment.id = recipe_equipment.equipment_id
+      where
+        recipes.id = recipe_equipment.recipe_id
+        and user_equipment.owner_id = recipes.owner_id
+        and (
+          recipes.owner_id = (
+            select
+              auth.uid ()
+          )
+          or public.current_user_is_admin ()
+        )
+    )
+  );
+
+drop policy if exists "Recipe owners and admins can update equipment" on public.recipe_equipment;
+
+create policy "Recipe owners and admins can update equipment" on public.recipe_equipment
+for update
+  to authenticated using (
+    exists (
+      select
+        1
+      from
+        public.recipes
+        inner join public.user_equipment on user_equipment.id = recipe_equipment.equipment_id
+      where
+        recipes.id = recipe_equipment.recipe_id
+        and user_equipment.owner_id = recipes.owner_id
+        and (
+          recipes.owner_id = (
+            select
+              auth.uid ()
+          )
+          or public.current_user_is_admin ()
+        )
+    )
+  )
+with
+  check (
+    exists (
+      select
+        1
+      from
+        public.recipes
+        inner join public.user_equipment on user_equipment.id = recipe_equipment.equipment_id
+      where
+        recipes.id = recipe_equipment.recipe_id
+        and user_equipment.owner_id = recipes.owner_id
+        and (
+          recipes.owner_id = (
+            select
+              auth.uid ()
+          )
+          or public.current_user_is_admin ()
+        )
+    )
+  );

--- a/supabase/migrations/20260410010000_add_user_equipment_inventory.sql
+++ b/supabase/migrations/20260410010000_add_user_equipment_inventory.sql
@@ -76,7 +76,7 @@ insert into
   public.user_equipment (owner_id, name)
 select distinct
   recipes.owner_id,
-  recipe_equipment.name
+  btrim(recipe_equipment.name)
 from
   public.recipe_equipment
   inner join public.recipes on recipes.id = recipe_equipment.recipe_id


### PR DESCRIPTION
## Summary
- add a user-owned equipment inventory table with RLS, backfill existing recipe equipment, and keep recipe equipment linked to owner inventory
- add an Equipment page and nav tab for managing personal equipment items
- switch recipe create/edit flows from free-text equipment names to owner-scoped inventory selections, including admin edit support

## Validation
- npm run test
- npm run lint
- npm run build

Closes #133