### PR TITLE
fix(recipes): link shelf card images

### DIFF
--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 
+import { getRecipeCoverPhotoUrl } from "../queries/recipePhotoApi";
 import {
   formatRecipeTime,
   formatRecipeYield,
@@ -22,6 +23,7 @@ export function RecipePreviewCard({
   onCategoryClick,
   recipe,
 }: RecipePreviewCardProps): JSX.Element {
+  const coverImageUrl = getRecipeCoverPhotoUrl(recipe.coverImagePath);
   const summary = getRecipeSummary(recipe.summary, recipe.description);
   const metadata = [
     formatRecipeTime(recipe),
@@ -31,7 +33,7 @@ export function RecipePreviewCard({
 
   return (
     <article className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-      {recipe.coverImagePath !== null ? (
+      {coverImageUrl !== null ? (
         <Link
           aria-label={`Open ${recipe.title}`}
           className="block rounded-none outline-none transition focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background"

--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -31,11 +31,20 @@ export function RecipePreviewCard({
 
   return (
     <article className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-      <RecipeCoverImage
-        coverImagePath={recipe.coverImagePath}
-        title={recipe.title}
-        variant="list"
-      />
+      {recipe.coverImagePath !== null ? (
+        <Link
+          aria-label={`Open ${recipe.title}`}
+          className="block rounded-none outline-none transition focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          params={{ recipeId: recipe.id }}
+          to="/recipes/$recipeId"
+        >
+          <RecipeCoverImage
+            coverImagePath={recipe.coverImagePath}
+            title={recipe.title}
+            variant="list"
+          />
+        </Link>
+      ) : null}
 
       <div className="flex h-full flex-col gap-4 p-5">
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- make recipe cover images on shelf cards open the detail page
- keep the image link accessible with its own focus treatment
- avoid rendering an empty interactive element when a recipe has no cover photo

## Validation
- npm run test
- npm run lint
- npm run build

Closes #134