### PR TITLE
fix(recipes): harden ownership checks

### DIFF
--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -14,6 +14,7 @@ import {
   RecipeCookLogPhotoError,
   uploadRecipeCookLogPhoto,
 } from "../queries/recipeCookLogPhotoApi";
+import { RecipeDataAccessError } from "../queries/recipeDataErrors";
 import { recipeQueryKeys } from "../queries/recipeKeys";
 
 import type {
@@ -88,96 +89,114 @@ export function RecipeCookLogSection({
         </Button>
       </div>
 
-      <div className={isExpanded ? "space-y-6" : "hidden"} hidden={!isExpanded} id={contentId}>
-          {isOwner ? (
-            <section className="space-y-4" aria-labelledby="cook-memory-create-heading">
-              <div className="border-b border-border/70 pb-2">
-                <h3
-                  className="text-base font-semibold tracking-tight text-foreground"
-                  id="cook-memory-create-heading"
-                >
-                  Add a cook memory
-                </h3>
-              </div>
-              <form
-                className="rounded-lg border border-border bg-background p-4"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  void handleCreateCookLog();
-                }}
-              >
-                <div className="grid gap-4 md:grid-cols-2">
-                  <label>
-                    <span className="text-sm font-medium text-foreground">Cooked on</span>
-                    <input
-                      className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
-                      onChange={(event) => {
-                        setCookedOn(event.target.value);
-                      }}
-                      type="date"
-                      value={cookedOn}
-                    />
-                  </label>
-
-                  <label>
-                    <span className="text-sm font-medium text-foreground">Photo</span>
-                    <input
-                      accept="image/jpeg,image/png,image/webp"
-                      className="mt-2 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-                      disabled={isSubmitting}
-                      onChange={(event) => {
-                        setSelectedPhoto(event.target.files?.[0] ?? null);
-                      }}
-                      type="file"
-                    />
-                  </label>
-
-                  <label className="md:col-span-2">
-                    <span className="text-sm font-medium text-foreground">Notes</span>
-                    <textarea
-                      className="mt-2 min-h-28 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
-                      onChange={(event) => {
-                        setNotes(event.target.value);
-                      }}
-                      placeholder="What changed, what worked, and what you want to remember next time."
-                      value={notes}
-                    />
-                  </label>
-                </div>
-
-                <div className="mt-4 flex flex-wrap items-center justify-end gap-3">
-                  <Button className="rounded-md px-5" disabled={isSubmitting} size="lg" type="submit">
-                    {isSubmitting ? "Saving memory..." : "Save cook memory"}
-                  </Button>
-                </div>
-              </form>
-            </section>
-          ) : null}
-
+      <div
+        className={isExpanded ? "space-y-6" : "hidden"}
+        hidden={!isExpanded}
+        id={contentId}
+      >
+        {isOwner ? (
           <section
-            aria-labelledby="cook-memory-history-heading"
-            className={savedMemoriesSectionClassName}
+            className="space-y-4"
+            aria-labelledby="cook-memory-create-heading"
           >
             <div className="border-b border-border/70 pb-2">
               <h3
                 className="text-base font-semibold tracking-tight text-foreground"
-                id="cook-memory-history-heading"
+                id="cook-memory-create-heading"
               >
-                Saved memories
+                Add a cook memory
               </h3>
             </div>
-            {recipe.cookLogs.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
-                No cook memories were saved for this recipe yet.
+            <form
+              className="rounded-lg border border-border bg-background p-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleCreateCookLog();
+              }}
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <label>
+                  <span className="text-sm font-medium text-foreground">
+                    Cooked on
+                  </span>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                    onChange={(event) => {
+                      setCookedOn(event.target.value);
+                    }}
+                    type="date"
+                    value={cookedOn}
+                  />
+                </label>
+
+                <label>
+                  <span className="text-sm font-medium text-foreground">
+                    Photo
+                  </span>
+                  <input
+                    accept="image/jpeg,image/png,image/webp"
+                    className="mt-2 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                    disabled={isSubmitting}
+                    onChange={(event) => {
+                      setSelectedPhoto(event.target.files?.[0] ?? null);
+                    }}
+                    type="file"
+                  />
+                </label>
+
+                <label className="md:col-span-2">
+                  <span className="text-sm font-medium text-foreground">
+                    Notes
+                  </span>
+                  <textarea
+                    className="mt-2 min-h-28 w-full rounded-xl border border-input bg-background/90 px-4 py-3 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                    onChange={(event) => {
+                      setNotes(event.target.value);
+                    }}
+                    placeholder="What changed, what worked, and what you want to remember next time."
+                    value={notes}
+                  />
+                </label>
               </div>
-            ) : (
-              <ol className="space-y-4">
-                {recipe.cookLogs.map((cookLog) => (
-                  <CookLogCard key={cookLog.id} cookLog={cookLog} />
-                ))}
-              </ol>
-            )}
+
+              <div className="mt-4 flex flex-wrap items-center justify-end gap-3">
+                <Button
+                  className="rounded-md px-5"
+                  disabled={isSubmitting}
+                  size="lg"
+                  type="submit"
+                >
+                  {isSubmitting ? "Saving memory..." : "Save cook memory"}
+                </Button>
+              </div>
+            </form>
           </section>
+        ) : null}
+
+        <section
+          aria-labelledby="cook-memory-history-heading"
+          className={savedMemoriesSectionClassName}
+        >
+          <div className="border-b border-border/70 pb-2">
+            <h3
+              className="text-base font-semibold tracking-tight text-foreground"
+              id="cook-memory-history-heading"
+            >
+              Saved memories
+            </h3>
+          </div>
+          {recipe.cookLogs.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">
+              No cook memories were saved for this recipe yet.
+            </div>
+          ) : (
+            <ol className="space-y-4">
+              {recipe.cookLogs.map((cookLog) => (
+                <CookLogCard key={cookLog.id} cookLog={cookLog} />
+              ))}
+            </ol>
+          )}
+        </section>
       </div>
     </section>
   );
@@ -203,13 +222,16 @@ export function RecipeCookLogSection({
       setNotes("");
       setSelectedPhoto(null);
       toast({
-        description: "The cook log history has been refreshed with your latest entry.",
+        description:
+          "The cook log history has been refreshed with your latest entry.",
         tone: "success",
         title: "Cook memory saved",
       });
     } catch (error) {
       if (uploadedPhotoPath !== null) {
-        await deleteRecipeCookLogPhoto(uploadedPhotoPath).catch(() => undefined);
+        await deleteRecipeCookLogPhoto(uploadedPhotoPath).catch(
+          () => undefined,
+        );
       }
 
       toast({
@@ -254,7 +276,14 @@ function CookLogCard({
 }
 
 function getCookLogErrorMessage(error: unknown): string {
-  if (isRecipeMutationAuthError(error) || error instanceof RecipeCookLogPhotoError) {
+  if (
+    isRecipeMutationAuthError(error) ||
+    error instanceof RecipeCookLogPhotoError
+  ) {
+    return error.message;
+  }
+
+  if (error instanceof RecipeDataAccessError) {
     return error.message;
   }
 

--- a/src/features/recipes/queries/recipeApi.ts
+++ b/src/features/recipes/queries/recipeApi.ts
@@ -18,6 +18,11 @@ import {
 } from "./recipeAdapters";
 import { requireRecipeMutationAuth } from "./recipeAuth";
 import { listRecipeCookLogs } from "./recipeCookLogApi";
+import { RecipeDataAccessError } from "./recipeDataErrors";
+import {
+  resolveRecipeMutationAccessError,
+  type RecipeOwnershipLookupClient,
+} from "./recipeMutationAccess";
 import { getRecipeCreatorName } from "./recipeProfileApi";
 
 import type {
@@ -34,25 +39,8 @@ type RecipeApiClient = NonNullable<typeof supabase>;
 type CreatedRecipeRecord = {
   id: string;
 };
-
-export type RecipeDataAccessErrorCode =
-  | "invalid-equipment"
-  | "not-found"
-  | "supabase-unconfigured";
-
-export class RecipeDataAccessError extends Error {
-  readonly code: RecipeDataAccessErrorCode;
-
-  constructor(
-    code: RecipeDataAccessErrorCode,
-    message: string,
-    options?: ErrorOptions,
-  ) {
-    super(message, options);
-    this.code = code;
-    this.name = "RecipeDataAccessError";
-  }
-}
+export { RecipeDataAccessError } from "./recipeDataErrors";
+export type { RecipeDataAccessErrorCode } from "./recipeDataErrors";
 
 const recipeListSelect = `
   id,
@@ -176,9 +164,10 @@ export async function deleteRecipe(
   }
 
   if (data === null) {
-    throw new RecipeDataAccessError(
-      "not-found",
-      `Recipe ${recipeId} was not found or could not be deleted.`,
+    throw await resolveRecipeMutationAccessError(
+      "delete",
+      recipeId,
+      recipeClient as unknown as RecipeOwnershipLookupClient,
     );
   }
 
@@ -209,9 +198,10 @@ export async function updateRecipe(
   }
 
   if (data === null) {
-    throw new RecipeDataAccessError(
-      "not-found",
-      `Recipe ${recipeId} was not found or could not be updated.`,
+    throw await resolveRecipeMutationAccessError(
+      "update",
+      recipeId,
+      recipeClient as unknown as RecipeOwnershipLookupClient,
     );
   }
 

--- a/src/features/recipes/queries/recipeCookLogApi.test.ts
+++ b/src/features/recipes/queries/recipeCookLogApi.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  createRecipeCookLog,
   isRecipeCookLogSchemaUnavailableError,
   listRecipeCookLogs,
 } from "./recipeCookLogApi";
@@ -33,7 +34,9 @@ describe("isRecipeCookLogSchemaUnavailableError", () => {
         message: "JSON object requested, multiple (or no) rows returned",
       }),
     ).toBe(false);
-    expect(isRecipeCookLogSchemaUnavailableError(new Error("boom"))).toBe(false);
+    expect(isRecipeCookLogSchemaUnavailableError(new Error("boom"))).toBe(
+      false,
+    );
   });
 });
 
@@ -64,7 +67,9 @@ describe("listRecipeCookLogs", () => {
       }),
     };
 
-    await expect(listRecipeCookLogs("recipe-1", client as never)).resolves.toEqual([
+    await expect(
+      listRecipeCookLogs("recipe-1", client as never),
+    ).resolves.toEqual([
       {
         cooked_on: "2026-04-03",
         created_at: "2026-04-03T10:00:00.000Z",
@@ -97,8 +102,76 @@ describe("listRecipeCookLogs", () => {
       }),
     };
 
-    await expect(listRecipeCookLogs("recipe-1", client as never)).resolves.toEqual(
-      [],
-    );
+    await expect(
+      listRecipeCookLogs("recipe-1", client as never),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("createRecipeCookLog", () => {
+  it("maps blocked cross-owner inserts to a clean ownership error", async () => {
+    const client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: "viewer-1",
+            },
+          },
+          error: null,
+        }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === "recipe_cook_logs") {
+          return {
+            insert: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockReturnValue({
+                  overrideTypes: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: {
+                      code: "42501",
+                      message:
+                        'new row violates row-level security policy for table "recipe_cook_logs"',
+                    },
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  id: "recipe-1",
+                  owner_id: "owner-1",
+                },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }),
+      rpc: vi.fn().mockResolvedValue({
+        data: false,
+        error: null,
+      }),
+    };
+
+    await expect(
+      createRecipeCookLog(
+        {
+          recipeId: "recipe-1",
+        },
+        client as never,
+      ),
+    ).rejects.toMatchObject({
+      code: "ownership-required",
+      message:
+        "Only the recipe owner or an admin can save cook memories for this recipe.",
+    });
   });
 });

--- a/src/features/recipes/queries/recipeCookLogApi.ts
+++ b/src/features/recipes/queries/recipeCookLogApi.ts
@@ -6,6 +6,11 @@ import {
   type RecipeCookLogRow,
 } from "./recipeAdapters";
 import { requireRecipeMutationAuth } from "./recipeAuth";
+import {
+  isRecipeMutationPermissionDeniedError,
+  resolveRecipeMutationAccessError,
+  type RecipeOwnershipLookupClient,
+} from "./recipeMutationAccess";
 
 import type {
   CreateRecipeCookLogInput,
@@ -28,11 +33,21 @@ export async function createRecipeCookLog(
   const { data, error } = await recipeClient
     .from("recipe_cook_logs")
     .insert(buildRecipeCookLogInsert(input))
-    .select("id, recipe_id, owner_id, cooked_on, notes, photo_path, created_at, updated_at")
+    .select(
+      "id, recipe_id, owner_id, cooked_on, notes, photo_path, created_at, updated_at",
+    )
     .single()
     .overrideTypes<RecipeCookLogRow, { merge: false }>();
 
   if (error !== null) {
+    if (isRecipeMutationPermissionDeniedError(error)) {
+      throw await resolveRecipeMutationAccessError(
+        "create-cook-log",
+        input.recipeId,
+        recipeClient as unknown as RecipeOwnershipLookupClient,
+      );
+    }
+
     throw error;
   }
 
@@ -49,7 +64,9 @@ export async function listRecipeCookLogs(
 
   const { data, error } = await client
     .from("recipe_cook_logs")
-    .select("id, recipe_id, owner_id, cooked_on, notes, photo_path, created_at, updated_at")
+    .select(
+      "id, recipe_id, owner_id, cooked_on, notes, photo_path, created_at, updated_at",
+    )
     .eq("recipe_id", recipeId)
     .overrideTypes<RecipeCookLogRow[], { merge: false }>();
 

--- a/src/features/recipes/queries/recipeDataErrors.ts
+++ b/src/features/recipes/queries/recipeDataErrors.ts
@@ -1,0 +1,20 @@
+export type RecipeDataAccessErrorCode =
+  | "invalid-equipment"
+  | "mutation-blocked"
+  | "not-found"
+  | "ownership-required"
+  | "supabase-unconfigured";
+
+export class RecipeDataAccessError extends Error {
+  readonly code: RecipeDataAccessErrorCode;
+
+  constructor(
+    code: RecipeDataAccessErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.code = code;
+    this.name = "RecipeDataAccessError";
+  }
+}

--- a/src/features/recipes/queries/recipeMutationAccess.test.ts
+++ b/src/features/recipes/queries/recipeMutationAccess.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getRecipeMutationAccessState,
+  isRecipeMutationPermissionDeniedError,
+  resolveRecipeMutationAccessError,
+  type RecipeOwnershipLookupClient,
+} from "./recipeMutationAccess";
+
+function createRecipeAccessClient(options: {
+  currentUserId: string | null;
+  isAdmin?: boolean;
+  recipeOwnerId: string | null;
+}): RecipeOwnershipLookupClient {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user:
+            options.currentUserId === null
+              ? null
+              : { id: options.currentUserId },
+        },
+        error: null,
+      }),
+    },
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data:
+              options.recipeOwnerId === null
+                ? null
+                : { id: "recipe-1", owner_id: options.recipeOwnerId },
+            error: null,
+          }),
+        }),
+      }),
+    }),
+    rpc: vi.fn().mockResolvedValue({
+      data: options.isAdmin ?? false,
+      error: null,
+    }),
+  } as unknown as RecipeOwnershipLookupClient;
+}
+
+describe("getRecipeMutationAccessState", () => {
+  it("detects missing recipes", async () => {
+    const client = createRecipeAccessClient({
+      currentUserId: "owner-1",
+      recipeOwnerId: null,
+    });
+
+    await expect(
+      getRecipeMutationAccessState("recipe-1", client),
+    ).resolves.toEqual({
+      kind: "not-found",
+    });
+  });
+
+  it("detects ownership failures for non-admin viewers", async () => {
+    const client = createRecipeAccessClient({
+      currentUserId: "viewer-1",
+      recipeOwnerId: "owner-1",
+    });
+
+    await expect(
+      getRecipeMutationAccessState("recipe-1", client),
+    ).resolves.toEqual({
+      kind: "ownership-required",
+    });
+  });
+
+  it("treats admins as mutation-capable for existing recipes", async () => {
+    const client = createRecipeAccessClient({
+      currentUserId: "admin-1",
+      isAdmin: true,
+      recipeOwnerId: "owner-1",
+    });
+
+    await expect(
+      getRecipeMutationAccessState("recipe-1", client),
+    ).resolves.toEqual({
+      kind: "mutation-blocked",
+    });
+  });
+});
+
+describe("resolveRecipeMutationAccessError", () => {
+  it("returns a clear ownership error for blocked recipe deletion", async () => {
+    const client = createRecipeAccessClient({
+      currentUserId: "viewer-1",
+      recipeOwnerId: "owner-1",
+    });
+
+    await expect(
+      resolveRecipeMutationAccessError("delete", "recipe-1", client),
+    ).resolves.toMatchObject({
+      code: "ownership-required",
+      message: "Only the recipe owner or an admin can delete this recipe.",
+    });
+  });
+
+  it("returns a cook-memory-specific not-found message", async () => {
+    const client = createRecipeAccessClient({
+      currentUserId: "owner-1",
+      recipeOwnerId: null,
+    });
+
+    await expect(
+      resolveRecipeMutationAccessError("create-cook-log", "recipe-1", client),
+    ).resolves.toMatchObject({
+      code: "not-found",
+      message: "Recipe recipe-1 was not found.",
+    });
+  });
+});
+
+describe("isRecipeMutationPermissionDeniedError", () => {
+  it("detects row-level security permission failures", () => {
+    expect(
+      isRecipeMutationPermissionDeniedError({
+        code: "42501",
+        message:
+          'new row violates row-level security policy for table "recipe_cook_logs"',
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(
+      isRecipeMutationPermissionDeniedError({
+        code: "PGRST205",
+        message: "Missing table",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/recipes/queries/recipeMutationAccess.ts
+++ b/src/features/recipes/queries/recipeMutationAccess.ts
@@ -1,0 +1,205 @@
+import { RecipeDataAccessError } from "./recipeDataErrors";
+
+import type { RecipeAuthCapableClient } from "./recipeAuth";
+
+type RecipeMutationAction = "create-cook-log" | "delete" | "update";
+
+export type RecipeOwnershipLookupClient = RecipeAuthCapableClient & {
+  from: (table: "recipes") => {
+    select: (columns: "id, owner_id") => {
+      eq: (
+        column: "id",
+        value: string,
+      ) => {
+        maybeSingle: () => PromiseLike<{
+          data: RecipeOwnershipLookupRecord | null;
+          error: unknown;
+        }>;
+      };
+    };
+  };
+  rpc: (fn: "current_user_is_admin") => PromiseLike<{
+    data: boolean | null;
+    error: unknown;
+  }>;
+};
+type RecipeOwnershipLookupRecord = {
+  id: string;
+  owner_id: string;
+};
+
+type RecipeMutationAccessState =
+  | { kind: "mutation-blocked" }
+  | { kind: "not-found" }
+  | { kind: "ownership-required" };
+
+export async function resolveRecipeMutationAccessError(
+  action: RecipeMutationAction,
+  recipeId: string,
+  client: RecipeOwnershipLookupClient,
+): Promise<RecipeDataAccessError> {
+  const state = await getRecipeMutationAccessState(recipeId, client);
+
+  switch (state.kind) {
+    case "not-found":
+      return new RecipeDataAccessError(
+        "not-found",
+        getRecipeMutationNotFoundMessage(action, recipeId),
+      );
+    case "ownership-required":
+      return new RecipeDataAccessError(
+        "ownership-required",
+        getRecipeMutationOwnershipMessage(action),
+      );
+    case "mutation-blocked":
+      return new RecipeDataAccessError(
+        "mutation-blocked",
+        getRecipeMutationBlockedMessage(action),
+      );
+  }
+}
+
+export async function getRecipeMutationAccessState(
+  recipeId: string,
+  client: RecipeOwnershipLookupClient,
+): Promise<RecipeMutationAccessState> {
+  const [{ data: recipeRecord, error }, currentUserId, isAdmin] =
+    await Promise.all([
+      client
+        .from("recipes")
+        .select("id, owner_id")
+        .eq("id", recipeId)
+        .maybeSingle(),
+      getCurrentRecipeMutationUserId(client),
+      getCurrentRecipeMutationAdminState(client),
+    ]);
+
+  if (error !== null) {
+    throw toError(error, "The recipe ownership check could not be completed.");
+  }
+
+  if (recipeRecord === null) {
+    return { kind: "not-found" };
+  }
+
+  if (recipeRecord.owner_id !== currentUserId && !isAdmin) {
+    return { kind: "ownership-required" };
+  }
+
+  return { kind: "mutation-blocked" };
+}
+
+export function isRecipeMutationPermissionDeniedError(
+  candidate: unknown,
+): boolean {
+  if (candidate === null || typeof candidate !== "object") {
+    return false;
+  }
+
+  const postgrestError = candidate as Record<string, unknown>;
+  const message =
+    typeof postgrestError.message === "string" ? postgrestError.message : "";
+
+  return (
+    postgrestError.code === "42501" ||
+    message.includes("permission denied") ||
+    message.includes("row-level security")
+  );
+}
+
+async function getCurrentRecipeMutationUserId(
+  client: RecipeAuthCapableClient,
+): Promise<string> {
+  const { data, error } = await client.auth.getUser();
+
+  if (error !== null || data.user === null) {
+    return "";
+  }
+
+  return data.user.id;
+}
+
+async function getCurrentRecipeMutationAdminState(
+  client: RecipeOwnershipLookupClient,
+): Promise<boolean> {
+  const { data, error } = await client.rpc("current_user_is_admin");
+
+  if (error !== null) {
+    if (isCurrentUserIsAdminMissingError(error)) {
+      return false;
+    }
+
+    throw toError(error, "The admin ownership check could not be completed.");
+  }
+
+  return data ?? false;
+}
+
+function getRecipeMutationBlockedMessage(action: RecipeMutationAction): string {
+  switch (action) {
+    case "create-cook-log":
+      return "This cook memory could not be saved. Refresh the page and try again.";
+    case "delete":
+      return "This recipe could not be deleted. Refresh the page and try again.";
+    case "update":
+      return "This recipe could not be updated. Refresh the page and try again.";
+  }
+}
+
+function getRecipeMutationNotFoundMessage(
+  action: RecipeMutationAction,
+  recipeId: string,
+): string {
+  switch (action) {
+    case "create-cook-log":
+      return `Recipe ${recipeId} was not found.`;
+    case "delete":
+      return `Recipe ${recipeId} was not found.`;
+    case "update":
+      return `Recipe ${recipeId} was not found.`;
+  }
+}
+
+function getRecipeMutationOwnershipMessage(
+  action: RecipeMutationAction,
+): string {
+  switch (action) {
+    case "create-cook-log":
+      return "Only the recipe owner or an admin can save cook memories for this recipe.";
+    case "delete":
+      return "Only the recipe owner or an admin can delete this recipe.";
+    case "update":
+      return "Only the recipe owner or an admin can update this recipe.";
+  }
+}
+
+function isCurrentUserIsAdminMissingError(candidate: unknown): boolean {
+  if (candidate === null || typeof candidate !== "object") {
+    return false;
+  }
+
+  const rpcError = candidate as Record<string, unknown>;
+
+  return (
+    rpcError.code === "PGRST202" &&
+    typeof rpcError.message === "string" &&
+    rpcError.message.includes("current_user_is_admin")
+  );
+}
+
+function toError(candidate: unknown, fallbackMessage: string): Error {
+  if (candidate instanceof Error) {
+    return candidate;
+  }
+
+  if (
+    candidate !== null &&
+    typeof candidate === "object" &&
+    "message" in candidate &&
+    typeof candidate.message === "string"
+  ) {
+    return new Error(candidate.message);
+  }
+
+  return new Error(fallbackMessage);
+}

--- a/src/features/recipes/utils/recipePresentation.ts
+++ b/src/features/recipes/utils/recipePresentation.ts
@@ -21,6 +21,8 @@ export function getRecipeLoadDocumentTitle(
   if (surface === "detail" && error instanceof RecipeDataAccessError) {
     switch (error.code) {
       case "invalid-equipment":
+      case "mutation-blocked":
+      case "ownership-required":
         return "Recipe Unavailable";
       case "not-found":
         return "Recipe Not Found";
@@ -181,6 +183,13 @@ export function getRecipeLoadErrorCopy(
         return {
           description:
             "One or more selected equipment items are no longer available for this recipe owner.",
+          title: "This recipe could not be loaded right now.",
+        };
+      case "mutation-blocked":
+      case "ownership-required":
+        return {
+          description:
+            "This recipe is available to read, but the current session cannot complete that management action.",
           title: "This recipe could not be loaded right now.",
         };
       case "not-found":

--- a/supabase/migrations/20260410174000_harden_recipe_memory_ownership.sql
+++ b/supabase/migrations/20260410174000_harden_recipe_memory_ownership.sql
@@ -28,7 +28,9 @@ add constraint recipe_cook_logs_photo_path_matches_owner check (
 
 drop policy if exists "Recipe owners can insert cook logs" on public.recipe_cook_logs;
 
-create policy "Recipe owners can insert cook logs" on public.recipe_cook_logs for insert to authenticated
+drop policy if exists "Recipe owners and admins can insert cook logs" on public.recipe_cook_logs;
+
+create policy "Recipe owners and admins can insert cook logs" on public.recipe_cook_logs for insert to authenticated
 with
   check (
     public.current_user_can_manage_recipe (recipe_id)
@@ -40,7 +42,9 @@ with
 
 drop policy if exists "Recipe owners can update cook logs" on public.recipe_cook_logs;
 
-create policy "Recipe owners can update cook logs" on public.recipe_cook_logs
+drop policy if exists "Recipe owners and admins can update cook logs" on public.recipe_cook_logs;
+
+create policy "Recipe owners and admins can update cook logs" on public.recipe_cook_logs
 for update
   to authenticated using (
     public.current_user_can_manage_recipe (recipe_id)
@@ -60,7 +64,9 @@ with
 
 drop policy if exists "Recipe owners can delete cook logs" on public.recipe_cook_logs;
 
-create policy "Recipe owners can delete cook logs" on public.recipe_cook_logs for delete to authenticated using (
+drop policy if exists "Recipe owners and admins can delete cook logs" on public.recipe_cook_logs;
+
+create policy "Recipe owners and admins can delete cook logs" on public.recipe_cook_logs for delete to authenticated using (
   public.current_user_can_manage_recipe (recipe_id)
   and (
     select

--- a/supabase/migrations/20260410174000_harden_recipe_memory_ownership.sql
+++ b/supabase/migrations/20260410174000_harden_recipe_memory_ownership.sql
@@ -1,0 +1,69 @@
+create or replace function public.current_user_can_manage_recipe (target_recipe_id uuid) returns boolean language sql stable security definer
+set
+  search_path = public,
+  auth as $$
+  select exists (
+    select
+      1
+    from
+      public.recipes
+    where
+      recipes.id = target_recipe_id
+      and (
+        recipes.owner_id = auth.uid ()
+        or public.current_user_is_admin ()
+      )
+  );
+$$;
+
+grant
+execute on function public.current_user_can_manage_recipe (uuid) to anon,
+authenticated;
+
+alter table public.recipe_cook_logs
+add constraint recipe_cook_logs_photo_path_matches_owner check (
+  photo_path is null
+  or split_part(photo_path, '/', 1) = owner_id::text
+);
+
+drop policy if exists "Recipe owners can insert cook logs" on public.recipe_cook_logs;
+
+create policy "Recipe owners can insert cook logs" on public.recipe_cook_logs for insert to authenticated
+with
+  check (
+    public.current_user_can_manage_recipe (recipe_id)
+    and (
+      select
+        auth.uid ()
+    ) = owner_id
+  );
+
+drop policy if exists "Recipe owners can update cook logs" on public.recipe_cook_logs;
+
+create policy "Recipe owners can update cook logs" on public.recipe_cook_logs
+for update
+  to authenticated using (
+    public.current_user_can_manage_recipe (recipe_id)
+    and (
+      select
+        auth.uid ()
+    ) = owner_id
+  )
+with
+  check (
+    public.current_user_can_manage_recipe (recipe_id)
+    and (
+      select
+        auth.uid ()
+    ) = owner_id
+  );
+
+drop policy if exists "Recipe owners can delete cook logs" on public.recipe_cook_logs;
+
+create policy "Recipe owners can delete cook logs" on public.recipe_cook_logs for delete to authenticated using (
+  public.current_user_can_manage_recipe (recipe_id)
+  and (
+    select
+      auth.uid ()
+  ) = owner_id
+);


### PR DESCRIPTION
## Summary
- harden cook log ownership policies and photo-path alignment in the database
- map blocked recipe update/delete and cook memory mutations to clearer owner/admin error messages
- add regression coverage for cross-owner mutation failures

## Testing
- npm run test
- npm run lint
- npm run build

Closes #135