### PR TITLE
fix(nav): move admin access into the header

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -7,10 +7,12 @@ import type { JSX } from "react";
 
 type AppShellHeaderProps = {
   authActionLabel: string;
+  showAdminNav: boolean;
 };
 
 export function AppShellHeader({
   authActionLabel,
+  showAdminNav,
 }: AppShellHeaderProps): JSX.Element {
   return (
     <header className="sticky top-0 z-20 border-b border-border bg-background/95 backdrop-blur">
@@ -41,6 +43,16 @@ export function AppShellHeader({
             >
               <Link to="/equipment">Equipment</Link>
             </Button>
+            {showAdminNav ? (
+              <Button
+                asChild
+                className="rounded-md px-3"
+                size="sm"
+                variant="ghost"
+              >
+                <Link to="/admin/categories">Admin</Link>
+              </Button>
+            ) : null}
           </nav>
         </div>
 

--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -1,8 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { ProfileSettingsSection } from "@/features/profiles";
 import { ThemePresetPicker, useThemePreset } from "@/features/theme";
 import { useAppToast } from "@/hooks/useAppToast";
@@ -197,22 +195,6 @@ export function AccountPage(): JSX.Element {
             </section>
           ) : null}
 
-          {sessionQuery.data?.kind === "authenticated" &&
-          sessionQuery.data.isAdmin ? (
-            <section className="space-y-3 border-t border-border pt-6">
-              <div>
-                <h2 className="text-lg font-semibold tracking-tight text-foreground">
-                  Admin
-                </h2>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Manage shared recipe categories for the shelf.
-                </p>
-              </div>
-              <Button asChild className="rounded-md px-4" variant="outline">
-                <Link to="/admin/categories">Manage categories</Link>
-              </Button>
-            </section>
-          ) : null}
         </div>
 
         <section className="space-y-4 border-t border-border pt-6">

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -37,11 +37,16 @@ function RootShell(): JSX.Element {
     sessionQuery.isLoading,
     sessionQuery.data,
   );
+  const showAdminNav =
+    sessionQuery.data?.kind === "authenticated" && sessionQuery.data.isAdmin;
 
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto flex min-h-screen w-full max-w-[96rem] flex-col px-4 sm:px-6 lg:px-8">
-        <AppShellHeader authActionLabel={authActionLabel} />
+        <AppShellHeader
+          authActionLabel={authActionLabel}
+          showAdminNav={showAdminNav}
+        />
 
         <div className="flex-1 py-5 sm:py-6">
           <Outlet />


### PR DESCRIPTION
## Summary
- add an admin nav tab to the main header for authenticated admins only
- remove the duplicate category management entry from the account page
- keep admin route authorization unchanged

## Validation
- npm run test
- npm run lint
- npm run build

Closes #146