### PR TITLE
fix(auth): clarify header session state

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -5,13 +5,24 @@ import { Button } from "@/components/ui/button";
 
 import type { JSX } from "react";
 
+type AuthActionState =
+  | {
+      kind: "authenticated";
+      avatarUrl: string | null;
+      label: string;
+    }
+  | {
+      kind: "guest" | "loading" | "unconfigured";
+      label: string;
+    };
+
 type AppShellHeaderProps = {
-  authActionLabel: string;
+  authAction: AuthActionState;
   showAdminNav: boolean;
 };
 
 export function AppShellHeader({
-  authActionLabel,
+  authAction,
   showAdminNav,
 }: AppShellHeaderProps): JSX.Element {
   return (
@@ -57,19 +68,76 @@ export function AppShellHeader({
         </div>
 
         <div className="flex items-center gap-2">
-          <Button
-            asChild
-            className="rounded-md px-3"
-            size="sm"
-            variant="outline"
-          >
-            <Link to="/account">
-              <UserRound className="size-4" />
-              {authActionLabel}
-            </Link>
-          </Button>
+          {authAction.kind === "authenticated" ? (
+            <Button
+              asChild
+              className="max-w-56 rounded-md px-2.5 sm:px-3"
+              size="sm"
+              variant="outline"
+            >
+              <Link to="/account">
+                <HeaderAvatar
+                  avatarUrl={authAction.avatarUrl}
+                  label={authAction.label}
+                />
+                <span className="truncate">{authAction.label}</span>
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              asChild
+              className="rounded-md px-3"
+              size="sm"
+              variant="outline"
+            >
+              <Link to="/account">
+                <UserRound className="size-4" />
+                {authAction.label}
+              </Link>
+            </Button>
+          )}
         </div>
       </div>
     </header>
   );
+}
+
+type HeaderAvatarProps = {
+  avatarUrl: string | null;
+  label: string;
+};
+
+function HeaderAvatar({
+  avatarUrl,
+  label,
+}: HeaderAvatarProps): JSX.Element {
+  if (avatarUrl !== null) {
+    return (
+      <img
+        alt={`${label} profile`}
+        className="size-5 rounded-full border border-border object-cover"
+        src={avatarUrl}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-label={`${label} profile`}
+      className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-muted text-[0.65rem] font-semibold text-foreground"
+      role="img"
+    >
+      {getHeaderAvatarFallback(label)}
+    </span>
+  );
+}
+
+function getHeaderAvatarFallback(label: string): string {
+  const trimmedLabel = label.trim();
+
+  if (trimmedLabel === "") {
+    return "?";
+  }
+
+  return trimmedLabel.slice(0, 1).toUpperCase();
 }

--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -2,10 +2,11 @@ import { Link } from "@tanstack/react-router";
 import { BookOpenText, UserRound } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
 
 import type { JSX } from "react";
 
-type AuthActionState =
+export type AuthActionState =
   | {
       kind: "authenticated";
       avatarUrl: string | null;
@@ -114,7 +115,8 @@ function HeaderAvatar({
   if (avatarUrl !== null) {
     return (
       <img
-        alt={`${label} profile`}
+        alt=""
+        aria-hidden="true"
         className="size-5 rounded-full border border-border object-cover"
         src={avatarUrl}
       />
@@ -123,21 +125,10 @@ function HeaderAvatar({
 
   return (
     <span
-      aria-label={`${label} profile`}
+      aria-hidden="true"
       className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-muted text-[0.65rem] font-semibold text-foreground"
-      role="img"
     >
-      {getHeaderAvatarFallback(label)}
+      {getProfileAvatarFallbackLabel(label)}
     </span>
   );
-}
-
-function getHeaderAvatarFallback(label: string): string {
-  const trimmedLabel = label.trim();
-
-  if (trimmedLabel === "") {
-    return "?";
-  }
-
-  return trimmedLabel.slice(0, 1).toUpperCase();
 }

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -1,2 +1,3 @@
 export { AppToasterProvider } from "./AppToaster";
 export { AppShellHeader } from "./AppShellHeader";
+export type { AuthActionState } from "./AppShellHeader";

--- a/src/features/profiles/utils/profilePresentation.ts
+++ b/src/features/profiles/utils/profilePresentation.ts
@@ -1,3 +1,5 @@
+import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
+
 import { ProfileDataAccessError } from "../queries/profileApi";
 
 type ProfileLoadErrorCopy = {
@@ -51,19 +53,4 @@ export function getProfileLoadErrorCopy(error: unknown): ProfileLoadErrorCopy {
   };
 }
 
-export function getProfileAvatarFallbackLabel(displayName: string): string {
-  const trimmedName = displayName.trim();
-
-  if (trimmedName === "") {
-    return "RB";
-  }
-
-  const initials = trimmedName
-    .split(/\s+/)
-    .filter((token) => token !== "")
-    .slice(0, 2)
-    .map((token) => token[0]?.toUpperCase() ?? "")
-    .join("");
-
-  return initials === "" ? "RB" : initials;
-}
+export { getProfileAvatarFallbackLabel };

--- a/src/lib/profilePresentation.ts
+++ b/src/lib/profilePresentation.ts
@@ -1,0 +1,16 @@
+export function getProfileAvatarFallbackLabel(displayName: string): string {
+  const trimmedName = displayName.trim();
+
+  if (trimmedName === "") {
+    return "RB";
+  }
+
+  const initials = trimmedName
+    .split(/\s+/)
+    .filter((token) => token !== "")
+    .slice(0, 2)
+    .map((token) => token[0]?.toUpperCase() ?? "")
+    .join("");
+
+  return initials === "" ? "RB" : initials;
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
 import { lazy, Suspense, type JSX } from "react";
 
 import { AppShellHeader, AppToasterProvider } from "@/components/app";
+import type { AuthActionState } from "@/components/app";
 import {
   preloadSessionState,
   sessionQueryOptions,
@@ -77,16 +78,7 @@ function getAuthAction(
         displayName: string;
       }
     | undefined,
-):
-  | {
-      kind: "authenticated";
-      avatarUrl: string | null;
-      label: string;
-    }
-  | {
-      kind: "guest" | "loading" | "unconfigured";
-      label: string;
-    } {
+): AuthActionState {
   if (isLoading) {
     return {
       kind: "loading",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,6 +9,10 @@ import {
   type AuthSessionState,
 } from "@/features/auth";
 import {
+  getProfilePhotoUrl,
+  profileDetailQueryOptions,
+} from "@/features/profiles";
+import {
   ThemePresetProvider,
 } from "@/features/theme";
 import { type AppRouterContext } from "@/lib/queryClient";
@@ -33,18 +37,26 @@ const ReactQueryDevtools = isDev
 
 function RootShell(): JSX.Element {
   const sessionQuery = useQuery(sessionQueryOptions);
-  const authActionLabel = getAuthActionLabel(
+  const sessionState = sessionQuery.data;
+  const currentUserId =
+    sessionState?.kind === "authenticated" ? sessionState.userId : "";
+  const profileQuery = useQuery({
+    ...profileDetailQueryOptions(currentUserId),
+    enabled: currentUserId !== "",
+  });
+  const authAction = getAuthAction(
     sessionQuery.isLoading,
-    sessionQuery.data,
+    sessionState,
+    profileQuery.data,
   );
   const showAdminNav =
-    sessionQuery.data?.kind === "authenticated" && sessionQuery.data.isAdmin;
+    sessionState?.kind === "authenticated" && sessionState.isAdmin;
 
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto flex min-h-screen w-full max-w-[96rem] flex-col px-4 sm:px-6 lg:px-8">
         <AppShellHeader
-          authActionLabel={authActionLabel}
+          authAction={authAction}
           showAdminNav={showAdminNav}
         />
 
@@ -56,25 +68,56 @@ function RootShell(): JSX.Element {
   );
 }
 
-function getAuthActionLabel(
+function getAuthAction(
   isLoading: boolean,
   sessionState: AuthSessionState | undefined,
-): string {
+  profile:
+    | {
+        avatarPath: string | null;
+        displayName: string;
+      }
+    | undefined,
+):
+  | {
+      kind: "authenticated";
+      avatarUrl: string | null;
+      label: string;
+    }
+  | {
+      kind: "guest" | "loading" | "unconfigured";
+      label: string;
+    } {
   if (isLoading) {
-    return "Account";
+    return {
+      kind: "loading",
+      label: "Account",
+    };
   }
 
   if (sessionState === undefined) {
-    return "Sign in";
+    return {
+      kind: "guest",
+      label: "Sign in",
+    };
   }
 
   switch (sessionState.kind) {
     case "authenticated":
-      return "Account";
+      return {
+        kind: "authenticated",
+        avatarUrl: getProfilePhotoUrl(profile?.avatarPath ?? null),
+        label: profile?.displayName ?? sessionState.email ?? "Account",
+      };
     case "guest":
-      return "Sign in";
+      return {
+        kind: "guest",
+        label: "Sign in",
+      };
     case "unconfigured":
-      return "Account";
+      return {
+        kind: "unconfigured",
+        label: "Account",
+      };
   }
 }
 


### PR DESCRIPTION
## Summary
- make signed-out header state explicitly read as Sign in
- show a signed-in identity affordance in the header with avatar/name fallback
- keep the data fetch in the route layer so app shell boundaries stay clean

## Validation
- npm run test
- npm run lint
- npm run build

Closes #147