### PR TITLE
feat(equipment): persist inventory ordering

### DIFF
--- a/src/features/equipment/components/EquipmentPage.tsx
+++ b/src/features/equipment/components/EquipmentPage.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { ArrowDown, ArrowUp } from "lucide-react";
 import { useState, type ChangeEvent, type JSX } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -11,10 +12,12 @@ import { EquipmentDataAccessError } from "../queries/equipmentApi";
 import {
   createEquipmentMutationOptions,
   deleteEquipmentMutationOptions,
+  reorderEquipmentMutationOptions,
   updateEquipmentMutationOptions,
 } from "../queries/equipmentMutationOptions";
 import { equipmentListQueryOptions } from "../queries/equipmentQueryOptions";
 import { equipmentFormSchema } from "../schemas/equipmentSchemas";
+import { moveEquipmentItemIds } from "../utils/equipmentOrdering";
 
 import type { EquipmentItem } from "../types/equipment";
 
@@ -34,6 +37,9 @@ export function EquipmentPage(): JSX.Element {
   );
   const updateMutation = useMutation(
     updateEquipmentMutationOptions(queryClient),
+  );
+  const reorderMutation = useMutation(
+    reorderEquipmentMutationOptions(queryClient),
   );
   const deleteMutation = useMutation(
     deleteEquipmentMutationOptions(queryClient),
@@ -141,7 +147,7 @@ export function EquipmentPage(): JSX.Element {
                 Your inventory
               </h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                Rename or remove equipment you no longer need.
+                Reorder, rename, or remove equipment you no longer need.
               </p>
             </div>
             <Button asChild className="rounded-md px-4" variant="outline">
@@ -156,12 +162,15 @@ export function EquipmentPage(): JSX.Element {
             </div>
           ) : (
             <ul className="space-y-3">
-              {equipment.map((item) => {
+              {equipment.map((item, index) => {
                 const draftName = draftNames[item.id] ?? item.name;
                 const isDirty = draftName.trim() !== item.name;
                 const isDeletePending =
                   deleteMutation.isPending &&
                   deleteMutation.variables?.equipmentId === item.id;
+                const isFirstItem = index === 0;
+                const isLastItem = index === equipment.length - 1;
+                const isReorderPending = reorderMutation.isPending;
                 const isUpdatePending =
                   updateMutation.isPending &&
                   updateMutation.variables?.equipmentId === item.id;
@@ -178,6 +187,35 @@ export function EquipmentPage(): JSX.Element {
                         handleUpdateEquipment(item.id, draftName);
                       }}
                     >
+                      <div className="flex items-center gap-2">
+                        <Button
+                          aria-label={`Move ${item.name} up`}
+                          className="rounded-md px-3"
+                          disabled={isFirstItem || isReorderPending}
+                          onClick={() => {
+                            handleMoveEquipment(item.id, "up");
+                          }}
+                          size="icon"
+                          type="button"
+                          variant="outline"
+                        >
+                          <ArrowUp className="size-4" />
+                        </Button>
+                        <Button
+                          aria-label={`Move ${item.name} down`}
+                          className="rounded-md px-3"
+                          disabled={isLastItem || isReorderPending}
+                          onClick={() => {
+                            handleMoveEquipment(item.id, "down");
+                          }}
+                          size="icon"
+                          type="button"
+                          variant="outline"
+                        >
+                          <ArrowDown className="size-4" />
+                        </Button>
+                      </div>
+
                       <label className="flex-1">
                         <span className="sr-only">Equipment name</span>
                         <input
@@ -195,14 +233,14 @@ export function EquipmentPage(): JSX.Element {
                       <div className="flex items-center gap-2">
                         <Button
                           className="rounded-md px-4"
-                          disabled={!isDirty || isUpdatePending}
+                          disabled={!isDirty || isReorderPending || isUpdatePending}
                           type="submit"
                         >
                           {isUpdatePending ? "Saving..." : "Save"}
                         </Button>
                         <Button
                           className="rounded-md px-4 text-destructive hover:text-destructive"
-                          disabled={isDeletePending}
+                          disabled={isDeletePending || isReorderPending}
                           onClick={() => {
                             handleDeleteEquipment(item);
                           }}
@@ -324,6 +362,34 @@ export function EquipmentPage(): JSX.Element {
             description: "The equipment item was removed from your inventory.",
             title: "Equipment removed",
             tone: "success",
+          });
+        },
+      },
+    );
+  }
+
+  function handleMoveEquipment(
+    equipmentId: string,
+    direction: "down" | "up",
+  ): void {
+    const nextEquipmentIds = moveEquipmentItemIds(
+      equipment,
+      equipmentId,
+      direction,
+    );
+
+    if (nextEquipmentIds === null) {
+      return;
+    }
+
+    reorderMutation.mutate(
+      { equipmentIds: nextEquipmentIds },
+      {
+        onError: (error) => {
+          toast({
+            description: getEquipmentMutationErrorMessage(error),
+            title: "Equipment order could not be updated",
+            tone: "error",
           });
         },
       },

--- a/src/features/equipment/index.ts
+++ b/src/features/equipment/index.ts
@@ -5,6 +5,7 @@ export {
   EquipmentDataAccessError,
   listEquipmentByIdsForOwner,
   listEquipmentForOwner,
+  reorderEquipment,
   updateEquipment,
   type EquipmentDataAccessErrorCode,
 } from "./queries/equipmentApi";
@@ -15,6 +16,7 @@ export {
 export {
   createEquipmentMutationOptions,
   deleteEquipmentMutationOptions,
+  reorderEquipmentMutationOptions,
   updateEquipmentMutationOptions,
 } from "./queries/equipmentMutationOptions";
 export {
@@ -32,5 +34,6 @@ export type {
   DeleteEquipmentInput,
   DeleteEquipmentResult,
   EquipmentItem,
+  ReorderEquipmentInput,
   UpdateEquipmentInput,
 } from "./types/equipment";

--- a/src/features/equipment/queries/equipmentApi.ts
+++ b/src/features/equipment/queries/equipmentApi.ts
@@ -5,12 +5,14 @@ import type {
   DeleteEquipmentInput,
   DeleteEquipmentResult,
   EquipmentItem,
+  ReorderEquipmentInput,
   UpdateEquipmentInput,
 } from "../types/equipment";
 
 type EquipmentApiClient = NonNullable<typeof supabase>;
 type EquipmentRecord = {
   created_at: string;
+  display_order: number;
   id: string;
   name: string;
   owner_id: string;
@@ -22,6 +24,7 @@ type DeletedEquipmentRecord = {
 
 export type EquipmentDataAccessErrorCode =
   | "authentication-required"
+  | "invalid-reorder"
   | "not-found"
   | "supabase-unconfigured";
 
@@ -43,6 +46,7 @@ const equipmentSelect = `
   id,
   owner_id,
   name,
+  display_order,
   created_at,
   updated_at
 `;
@@ -56,6 +60,7 @@ export async function listEquipmentForOwner(
     .from("user_equipment")
     .select(equipmentSelect)
     .eq("owner_id", ownerId.trim())
+    .order("display_order", { ascending: true })
     .order("name", { ascending: true })
     .overrideTypes<EquipmentRecord[], { merge: false }>();
 
@@ -81,6 +86,8 @@ export async function listEquipmentByIdsForOwner(
     .select(equipmentSelect)
     .eq("owner_id", ownerId.trim())
     .in("id", [...equipmentIds])
+    .order("display_order", { ascending: true })
+    .order("name", { ascending: true })
     .overrideTypes<EquipmentRecord[], { merge: false }>();
 
   if (error !== null) {
@@ -181,6 +188,58 @@ export async function deleteEquipment(
   };
 }
 
+export async function reorderEquipment(
+  input: ReorderEquipmentInput,
+  client: EquipmentApiClient | null = supabase,
+): Promise<EquipmentItem[]> {
+  const equipmentClient = getEquipmentApiClient(client);
+  const ownerId = await getAuthenticatedEquipmentUserId(equipmentClient);
+  const currentEquipment = await listEquipmentForOwner(ownerId, equipmentClient);
+  const nextEquipmentIds = input.equipmentIds.map((equipmentId) =>
+    equipmentId.trim(),
+  );
+
+  if (!isValidEquipmentReorder(currentEquipment, nextEquipmentIds)) {
+    throw new EquipmentDataAccessError(
+      "invalid-reorder",
+      "The equipment order could not be updated with the provided items.",
+    );
+  }
+
+  const currentEquipmentById = new Map(
+    currentEquipment.map((equipmentItem) => [equipmentItem.id, equipmentItem]),
+  );
+
+  const { error } = await equipmentClient.from("user_equipment").upsert(
+    nextEquipmentIds.map((equipmentId, index) => {
+      const equipmentItem = currentEquipmentById.get(equipmentId);
+
+      if (equipmentItem === undefined) {
+        throw new EquipmentDataAccessError(
+          "invalid-reorder",
+          `Equipment item ${equipmentId} is not available for reordering.`,
+        );
+      }
+
+      return {
+        display_order: index + 1,
+        id: equipmentId,
+        name: equipmentItem.name,
+        owner_id: ownerId,
+      };
+    }),
+    {
+      onConflict: "id",
+    },
+  );
+
+  if (error !== null) {
+    throw error;
+  }
+
+  return listEquipmentForOwner(ownerId, equipmentClient);
+}
+
 function getEquipmentApiClient(
   client: EquipmentApiClient | null,
 ): EquipmentApiClient {
@@ -213,9 +272,35 @@ async function getAuthenticatedEquipmentUserId(
 function mapEquipmentRecord(record: EquipmentRecord): EquipmentItem {
   return {
     createdAt: record.created_at,
+    displayOrder: record.display_order,
     id: record.id,
     name: record.name,
     ownerId: record.owner_id,
     updatedAt: record.updated_at,
   };
+}
+
+function isValidEquipmentReorder(
+  currentEquipment: EquipmentItem[],
+  nextEquipmentIds: readonly string[],
+): boolean {
+  if (currentEquipment.length !== nextEquipmentIds.length) {
+    return false;
+  }
+
+  const currentEquipmentIds = new Set(
+    currentEquipment.map((equipmentItem) => equipmentItem.id),
+  );
+
+  if (currentEquipmentIds.size !== nextEquipmentIds.length) {
+    return false;
+  }
+
+  for (const equipmentId of nextEquipmentIds) {
+    if (!currentEquipmentIds.has(equipmentId)) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/features/equipment/queries/equipmentKeys.ts
+++ b/src/features/equipment/queries/equipmentKeys.ts
@@ -7,5 +7,6 @@ export const equipmentQueryKeys = {
 export const equipmentMutationKeys = {
   create: () => [...equipmentQueryKeys.all, "create"] as const,
   delete: () => [...equipmentQueryKeys.all, "delete"] as const,
+  reorder: () => [...equipmentQueryKeys.all, "reorder"] as const,
   update: () => [...equipmentQueryKeys.all, "update"] as const,
 };

--- a/src/features/equipment/queries/equipmentMutationOptions.ts
+++ b/src/features/equipment/queries/equipmentMutationOptions.ts
@@ -3,6 +3,7 @@ import { mutationOptions } from "@tanstack/react-query";
 import {
   createEquipment,
   deleteEquipment,
+  reorderEquipment,
   updateEquipment,
 } from "./equipmentApi";
 import { equipmentMutationKeys, equipmentQueryKeys } from "./equipmentKeys";
@@ -12,6 +13,7 @@ import type {
   DeleteEquipmentInput,
   DeleteEquipmentResult,
   EquipmentItem,
+  ReorderEquipmentInput,
   UpdateEquipmentInput,
 } from "../types/equipment";
 import type { QueryClient } from "@tanstack/react-query";
@@ -21,6 +23,9 @@ type CreateEquipmentMutationOptions = ReturnType<
 >;
 type UpdateEquipmentMutationOptions = ReturnType<
   typeof mutationOptions<EquipmentItem, Error, UpdateEquipmentInput>
+>;
+type ReorderEquipmentMutationOptions = ReturnType<
+  typeof mutationOptions<EquipmentItem[], Error, ReorderEquipmentInput>
 >;
 type DeleteEquipmentMutationOptions = ReturnType<
   typeof mutationOptions<DeleteEquipmentResult, Error, DeleteEquipmentInput>
@@ -44,6 +49,18 @@ export function updateEquipmentMutationOptions(
   return mutationOptions({
     mutationFn: (input): Promise<EquipmentItem> => updateEquipment(input),
     mutationKey: equipmentMutationKeys.update(),
+    onSuccess: async (): Promise<void> => {
+      await invalidateEquipmentRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function reorderEquipmentMutationOptions(
+  queryClient: QueryClient,
+): ReorderEquipmentMutationOptions {
+  return mutationOptions({
+    mutationFn: (input): Promise<EquipmentItem[]> => reorderEquipment(input),
+    mutationKey: equipmentMutationKeys.reorder(),
     onSuccess: async (): Promise<void> => {
       await invalidateEquipmentRelatedQueries(queryClient);
     },

--- a/src/features/equipment/types/equipment.ts
+++ b/src/features/equipment/types/equipment.ts
@@ -1,5 +1,6 @@
 export type EquipmentItem = {
   createdAt: string;
+  displayOrder: number;
   id: string;
   name: string;
   ownerId: string;
@@ -21,4 +22,8 @@ export type DeleteEquipmentInput = {
 
 export type DeleteEquipmentResult = {
   equipmentId: string;
+};
+
+export type ReorderEquipmentInput = {
+  equipmentIds: string[];
 };

--- a/src/features/equipment/utils/equipmentOrdering.test.ts
+++ b/src/features/equipment/utils/equipmentOrdering.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { moveEquipmentItemIds } from "./equipmentOrdering";
+
+import type { EquipmentItem } from "../types/equipment";
+
+const equipment: EquipmentItem[] = [
+  {
+    createdAt: "2026-04-10T00:00:00Z",
+    displayOrder: 1,
+    id: "skillet",
+    name: "Skillet",
+    ownerId: "owner-1",
+    updatedAt: "2026-04-10T00:00:00Z",
+  },
+  {
+    createdAt: "2026-04-10T00:00:00Z",
+    displayOrder: 2,
+    id: "pot",
+    name: "Pot",
+    ownerId: "owner-1",
+    updatedAt: "2026-04-10T00:00:00Z",
+  },
+  {
+    createdAt: "2026-04-10T00:00:00Z",
+    displayOrder: 3,
+    id: "whisk",
+    name: "Whisk",
+    ownerId: "owner-1",
+    updatedAt: "2026-04-10T00:00:00Z",
+  },
+];
+
+describe("moveEquipmentItemIds", () => {
+  it("moves an item up by one slot", () => {
+    expect(moveEquipmentItemIds(equipment, "pot", "up")).toEqual([
+      "pot",
+      "skillet",
+      "whisk",
+    ]);
+  });
+
+  it("moves an item down by one slot", () => {
+    expect(moveEquipmentItemIds(equipment, "pot", "down")).toEqual([
+      "skillet",
+      "whisk",
+      "pot",
+    ]);
+  });
+
+  it("returns null when the target item is missing", () => {
+    expect(moveEquipmentItemIds(equipment, "ladle", "up")).toBeNull();
+  });
+
+  it("returns null when the move would go out of bounds", () => {
+    expect(moveEquipmentItemIds(equipment, "skillet", "up")).toBeNull();
+    expect(moveEquipmentItemIds(equipment, "whisk", "down")).toBeNull();
+  });
+});

--- a/src/features/equipment/utils/equipmentOrdering.ts
+++ b/src/features/equipment/utils/equipmentOrdering.ts
@@ -1,0 +1,26 @@
+import type { EquipmentItem } from "../types/equipment";
+
+export function moveEquipmentItemIds(
+  equipment: readonly EquipmentItem[],
+  equipmentId: string,
+  direction: "down" | "up",
+): string[] | null {
+  const currentIndex = equipment.findIndex((item) => item.id === equipmentId);
+
+  if (currentIndex === -1) {
+    return null;
+  }
+
+  const nextIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+
+  if (nextIndex < 0 || nextIndex >= equipment.length) {
+    return null;
+  }
+
+  const nextEquipment = [...equipment];
+  const [movedEquipment] = nextEquipment.splice(currentIndex, 1);
+
+  nextEquipment.splice(nextIndex, 0, movedEquipment);
+
+  return nextEquipment.map((item) => item.id);
+}

--- a/src/features/recipes/components/EditRecipePage.tsx
+++ b/src/features/recipes/components/EditRecipePage.tsx
@@ -449,6 +449,7 @@ function mergeEquipmentOptions(
 
     equipmentMap.set(item.equipmentId, {
       createdAt: "",
+      displayOrder: Number.MAX_SAFE_INTEGER,
       id: item.equipmentId,
       name: item.name,
       ownerId: "",

--- a/src/features/recipes/queries/recipeData.test.ts
+++ b/src/features/recipes/queries/recipeData.test.ts
@@ -209,6 +209,7 @@ describe("recipe insert builders", () => {
           "inventory-1",
           {
             createdAt: "",
+            displayOrder: 1,
             id: "inventory-1",
             name: " Dutch oven ",
             ownerId: "owner-1",

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -351,6 +351,7 @@ export type Database = {
       user_equipment: {
         Row: {
           created_at: string;
+          display_order: number;
           id: string;
           name: string;
           owner_id: string;
@@ -358,6 +359,7 @@ export type Database = {
         };
         Insert: {
           created_at?: string;
+          display_order?: number;
           id?: string;
           name: string;
           owner_id?: string;
@@ -365,6 +367,7 @@ export type Database = {
         };
         Update: {
           created_at?: string;
+          display_order?: number;
           id?: string;
           name?: string;
           owner_id?: string;

--- a/supabase/migrations/20260415233000_add_user_equipment_display_order.sql
+++ b/supabase/migrations/20260415233000_add_user_equipment_display_order.sql
@@ -1,0 +1,56 @@
+alter table public.user_equipment
+add column display_order integer;
+
+with
+  ordered_equipment as (
+    select
+      id,
+      row_number() over (
+        partition by
+          owner_id
+        order by
+          lower(btrim(name)),
+          created_at,
+          id
+      ) as next_display_order
+    from
+      public.user_equipment
+  )
+update public.user_equipment
+set
+  display_order = ordered_equipment.next_display_order
+from
+  ordered_equipment
+where
+  ordered_equipment.id = user_equipment.id;
+
+alter table public.user_equipment
+alter column display_order
+set not null;
+
+alter table public.user_equipment
+add constraint user_equipment_display_order_positive check (display_order >= 1);
+
+create index user_equipment_owner_display_order_idx on public.user_equipment (owner_id, display_order, name);
+
+create or replace function public.set_user_equipment_display_order () returns trigger language plpgsql
+set
+  search_path = public as $$
+begin
+  if new.display_order is null then
+    select
+      coalesce(max(display_order), 0) + 1
+    into
+      new.display_order
+    from
+      public.user_equipment
+    where
+      owner_id = new.owner_id;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger set_user_equipment_display_order before insert on public.user_equipment for each row
+execute function public.set_user_equipment_display_order ();


### PR DESCRIPTION
## Summary
- add persisted display ordering for user equipment inventory items
- add explicit move up/down controls to the equipment page
- keep recipe authoring aligned with the saved inventory order

## Validation
- npm run test
- npm run lint
- npm run build

Closes #150