### PR TITLE
fix(recipes): improve detail accordions

### DIFF
--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -61,11 +61,21 @@ export function RecipeCookLogSection({
     ? "space-y-4 border-t border-border/70 pt-6"
     : "space-y-4";
   const contentId = `recipe-cook-log-content-${recipe.id}`;
+  const buttonId = `${contentId}-trigger`;
 
   return (
     <section className="space-y-6 border-t border-border pt-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
+      <button
+        aria-controls={contentId}
+        aria-expanded={isExpanded}
+        className="flex w-full items-center justify-between gap-4 rounded-lg border border-border bg-background px-4 py-3 text-left shadow-sm outline-none transition hover:border-primary/40 hover:bg-muted/40 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20"
+        id={buttonId}
+        onClick={() => {
+          setIsExpanded((current) => !current);
+        }}
+        type="button"
+      >
+        <div className="flex min-w-0 items-center gap-3">
           <h2 className="text-2xl font-semibold tracking-tight text-foreground">
             Kitchen memories
           </h2>
@@ -73,26 +83,18 @@ export function RecipeCookLogSection({
             {recipe.cookLogs.length}
           </span>
         </div>
-        <Button
-          aria-controls={contentId}
-          aria-expanded={isExpanded}
-          className="rounded-md px-3"
-          onClick={() => {
-            setIsExpanded((current) => !current);
-          }}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          {isExpanded ? <ChevronUp /> : <ChevronDown />}
+        <span className="flex items-center gap-2 text-sm text-muted-foreground">
+          {isExpanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
           {isExpanded ? "Hide" : "Show"}
-        </Button>
-      </div>
+        </span>
+      </button>
 
       <div
         className={isExpanded ? "space-y-6" : "hidden"}
         hidden={!isExpanded}
         id={contentId}
+        role="region"
+        aria-labelledby={buttonId}
       >
         {isOwner ? (
           <section

--- a/src/features/recipes/components/RecipeCookLogSection.tsx
+++ b/src/features/recipes/components/RecipeCookLogSection.tsx
@@ -16,6 +16,7 @@ import {
 } from "../queries/recipeCookLogPhotoApi";
 import { RecipeDataAccessError } from "../queries/recipeDataErrors";
 import { recipeQueryKeys } from "../queries/recipeKeys";
+import { recipeSectionTriggerButtonClassName } from "../utils/recipeSectionStyles";
 
 import type {
   CreateRecipeCookLogInput,
@@ -61,22 +62,24 @@ export function RecipeCookLogSection({
     ? "space-y-4 border-t border-border/70 pt-6"
     : "space-y-4";
   const contentId = `recipe-cook-log-content-${recipe.id}`;
-  const buttonId = `${contentId}-trigger`;
+  const headingId = `${contentId}-heading`;
 
   return (
     <section className="space-y-6 border-t border-border pt-6">
       <button
         aria-controls={contentId}
         aria-expanded={isExpanded}
-        className="flex w-full items-center justify-between gap-4 rounded-lg border border-border bg-background px-4 py-3 text-left shadow-sm outline-none transition hover:border-primary/40 hover:bg-muted/40 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20"
-        id={buttonId}
+        className={recipeSectionTriggerButtonClassName}
         onClick={() => {
           setIsExpanded((current) => !current);
         }}
         type="button"
       >
         <div className="flex min-w-0 items-center gap-3">
-          <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          <h2
+            className="text-2xl font-semibold tracking-tight text-foreground"
+            id={headingId}
+          >
             Kitchen memories
           </h2>
           <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
@@ -85,7 +88,7 @@ export function RecipeCookLogSection({
         </div>
         <span className="flex items-center gap-2 text-sm text-muted-foreground">
           {isExpanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
-          {isExpanded ? "Hide" : "Show"}
+          <span aria-hidden>{isExpanded ? "Hide" : "Show"}</span>
         </span>
       </button>
 
@@ -94,7 +97,7 @@ export function RecipeCookLogSection({
         hidden={!isExpanded}
         id={contentId}
         role="region"
-        aria-labelledby={buttonId}
+        aria-labelledby={headingId}
       >
         {isOwner ? (
           <section

--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -7,6 +7,7 @@ import {
   formatIngredientText,
   formatStepTimer,
 } from "../utils/recipePresentation";
+import { recipeSectionTriggerButtonClassName } from "../utils/recipeSectionStyles";
 
 import { RecipeStepTimerControl } from "./RecipeStepTimerControl";
 
@@ -45,22 +46,24 @@ export function RecipeDetailCollectionSection(
   const [isExpanded, setIsExpanded] = useState(props.defaultExpanded ?? false);
   const stepTimer = useStepTimer();
   const contentId = `recipe-detail-section-${props.kind}`;
-  const buttonId = `${contentId}-trigger`;
+  const headingId = `${contentId}-heading`;
 
   return (
     <section className="space-y-4 border-t border-border pt-6">
       <button
         aria-controls={contentId}
         aria-expanded={isExpanded}
-        className="flex w-full items-center justify-between gap-4 rounded-lg border border-border bg-background px-4 py-3 text-left shadow-sm outline-none transition hover:border-primary/40 hover:bg-muted/40 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20"
-        id={buttonId}
+        className={recipeSectionTriggerButtonClassName}
         onClick={() => {
           setIsExpanded((current) => !current);
         }}
         type="button"
       >
         <div className="flex min-w-0 items-center gap-3">
-          <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          <h2
+            className="text-2xl font-semibold tracking-tight text-foreground"
+            id={headingId}
+          >
             {props.title}
           </h2>
           <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground">
@@ -69,7 +72,7 @@ export function RecipeDetailCollectionSection(
         </div>
         <span className="flex items-center gap-2 text-sm text-muted-foreground">
           {isExpanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
-          {isExpanded ? "Hide" : "Show"}
+          <span aria-hidden>{isExpanded ? "Hide" : "Show"}</span>
         </span>
       </button>
 
@@ -78,7 +81,7 @@ export function RecipeDetailCollectionSection(
         hidden={!isExpanded}
         id={contentId}
         role="region"
-        aria-labelledby={buttonId}
+        aria-labelledby={headingId}
       >
         {props.items.length === 0 ? (
           <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">

--- a/src/features/recipes/components/RecipeDetailCollectionSection.tsx
+++ b/src/features/recipes/components/RecipeDetailCollectionSection.tsx
@@ -1,8 +1,6 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 
-import { Button } from "@/components/ui/button";
-
 import { useStepTimer } from "../hooks/useStepTimer";
 import {
   formatCountdownClock,
@@ -21,6 +19,7 @@ import type { JSX } from "react";
 
 type RecipeDetailCollectionSectionProps =
   | {
+      defaultExpanded?: boolean;
       displaySystem: "imperial" | "metric";
       items: RecipeIngredient[];
       kind: "ingredients";
@@ -28,11 +27,13 @@ type RecipeDetailCollectionSectionProps =
       title: string;
     }
   | {
+      defaultExpanded?: boolean;
       items: RecipeEquipment[];
       kind: "equipment";
       title: string;
     }
   | {
+      defaultExpanded?: boolean;
       items: RecipeStep[];
       kind: "steps";
       title: string;
@@ -41,14 +42,24 @@ type RecipeDetailCollectionSectionProps =
 export function RecipeDetailCollectionSection(
   props: RecipeDetailCollectionSectionProps,
 ): JSX.Element {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(props.defaultExpanded ?? false);
   const stepTimer = useStepTimer();
   const contentId = `recipe-detail-section-${props.kind}`;
+  const buttonId = `${contentId}-trigger`;
 
   return (
     <section className="space-y-4 border-t border-border pt-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
+      <button
+        aria-controls={contentId}
+        aria-expanded={isExpanded}
+        className="flex w-full items-center justify-between gap-4 rounded-lg border border-border bg-background px-4 py-3 text-left shadow-sm outline-none transition hover:border-primary/40 hover:bg-muted/40 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20"
+        id={buttonId}
+        onClick={() => {
+          setIsExpanded((current) => !current);
+        }}
+        type="button"
+      >
+        <div className="flex min-w-0 items-center gap-3">
           <h2 className="text-2xl font-semibold tracking-tight text-foreground">
             {props.title}
           </h2>
@@ -56,26 +67,18 @@ export function RecipeDetailCollectionSection(
             {props.items.length}
           </span>
         </div>
-        <Button
-          aria-controls={contentId}
-          aria-expanded={isExpanded}
-          className="rounded-md px-3"
-          onClick={() => {
-            setIsExpanded((current) => !current);
-          }}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          {isExpanded ? <ChevronUp /> : <ChevronDown />}
+        <span className="flex items-center gap-2 text-sm text-muted-foreground">
+          {isExpanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
           {isExpanded ? "Hide" : "Show"}
-        </Button>
-      </div>
+        </span>
+      </button>
 
       <div
         className={isExpanded ? "space-y-4" : "hidden"}
         hidden={!isExpanded}
         id={contentId}
+        role="region"
+        aria-labelledby={buttonId}
       >
         {props.items.length === 0 ? (
           <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-muted-foreground">

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -39,6 +39,7 @@ export function RecipeDetailPageSections({
 
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
         <RecipeDetailCollectionSection
+          defaultExpanded
           displaySystem={displaySystem}
           items={recipe.ingredients}
           kind="ingredients"
@@ -46,6 +47,7 @@ export function RecipeDetailPageSections({
           title="Ingredients"
         />
         <RecipeDetailCollectionSection
+          defaultExpanded={recipe.equipment.length > 0}
           items={recipe.equipment}
           kind="equipment"
           title="Equipment"
@@ -53,6 +55,7 @@ export function RecipeDetailPageSections({
       </div>
 
       <RecipeDetailCollectionSection
+        defaultExpanded
         items={recipe.steps}
         kind="steps"
         title="Method"

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -42,6 +42,7 @@ export function RecipeDetailPageSections({
           defaultExpanded
           displaySystem={displaySystem}
           items={recipe.ingredients}
+          key={`${recipe.id}-ingredients`}
           kind="ingredients"
           scaleFactor={scaleFactor}
           title="Ingredients"
@@ -49,6 +50,7 @@ export function RecipeDetailPageSections({
         <RecipeDetailCollectionSection
           defaultExpanded={recipe.equipment.length > 0}
           items={recipe.equipment}
+          key={`${recipe.id}-equipment`}
           kind="equipment"
           title="Equipment"
         />
@@ -57,6 +59,7 @@ export function RecipeDetailPageSections({
       <RecipeDetailCollectionSection
         defaultExpanded
         items={recipe.steps}
+        key={`${recipe.id}-steps`}
         kind="steps"
         title="Method"
       />

--- a/src/features/recipes/utils/recipeSectionStyles.ts
+++ b/src/features/recipes/utils/recipeSectionStyles.ts
@@ -1,0 +1,2 @@
+export const recipeSectionTriggerButtonClassName =
+  "flex w-full items-center justify-between gap-4 rounded-lg border border-border bg-background px-4 py-3 text-left shadow-sm outline-none transition hover:border-primary/40 hover:bg-muted/40 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20";


### PR DESCRIPTION
## Summary
- make recipe detail section headers full-width accordion triggers
- expose primary content on first load by opening ingredients and method by default
- keep kitchen memories on the stronger accordion pattern without changing its collapsed default

## Validation
- npm run test
- npm run lint
- npm run build

Closes #151