### PR TITLE
feat(ux): redesign signed-out protected route gates

### DIFF
--- a/src/components/app/ProtectedRouteAuthGate.tsx
+++ b/src/components/app/ProtectedRouteAuthGate.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+
+import type { JSX } from "react";
+
+type ProtectedRouteAuthGateAction = {
+  label: string;
+  to: "/account" | "/equipment" | "/recipes" | "/recipes/new";
+};
+
+type ProtectedRouteAuthGateProps = {
+  description: string;
+  primaryAction: ProtectedRouteAuthGateAction;
+  secondaryAction: ProtectedRouteAuthGateAction;
+  title: string;
+};
+
+export function ProtectedRouteAuthGate({
+  description,
+  primaryAction,
+  secondaryAction,
+  title,
+}: ProtectedRouteAuthGateProps): JSX.Element {
+  return (
+    <main className="flex w-full flex-1 items-center justify-center py-6 sm:py-10">
+      <section className="w-full max-w-3xl rounded-2xl border border-border bg-card/60 px-6 py-10 text-center shadow-sm sm:px-10 sm:py-12">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Protected page
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          {title}
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-sm text-muted-foreground sm:text-base">
+          {description}
+        </p>
+        <div className="mt-8 flex flex-col-reverse justify-center gap-3 sm:flex-row">
+          <Button
+            asChild
+            className="rounded-md px-5"
+            size="lg"
+            variant="outline"
+          >
+            <Link to={secondaryAction.to}>{secondaryAction.label}</Link>
+          </Button>
+          <Button asChild className="rounded-md px-5" size="lg">
+            <Link to={primaryAction.to}>{primaryAction.label}</Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/app/ProtectedRouteAuthGate.tsx
+++ b/src/components/app/ProtectedRouteAuthGate.tsx
@@ -2,14 +2,15 @@ import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
 
-import type { JSX } from "react";
+import type { ComponentProps, JSX } from "react";
 
 type ProtectedRouteAuthGateAction = {
   label: string;
-  to: "/account" | "/equipment" | "/recipes" | "/recipes/new";
+  to: ComponentProps<typeof Link>["to"];
 };
 
 type ProtectedRouteAuthGateProps = {
+  eyebrow?: string;
   description: string;
   primaryAction: ProtectedRouteAuthGateAction;
   secondaryAction: ProtectedRouteAuthGateAction;
@@ -17,16 +18,17 @@ type ProtectedRouteAuthGateProps = {
 };
 
 export function ProtectedRouteAuthGate({
+  eyebrow = "Protected page",
   description,
   primaryAction,
   secondaryAction,
   title,
 }: ProtectedRouteAuthGateProps): JSX.Element {
   return (
-    <main className="flex w-full flex-1 items-center justify-center py-6 sm:py-10">
+    <main className="flex min-h-dvh w-full items-center justify-center py-6 sm:py-10">
       <section className="w-full max-w-3xl rounded-2xl border border-border bg-card/60 px-6 py-10 text-center shadow-sm sm:px-10 sm:py-12">
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-          Protected page
+          {eyebrow}
         </p>
         <h1 className="mt-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           {title}

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -1,3 +1,4 @@
 export { AppToasterProvider } from "./AppToaster";
 export { AppShellHeader } from "./AppShellHeader";
 export type { AuthActionState } from "./AppShellHeader";
+export { ProtectedRouteAuthGate } from "./ProtectedRouteAuthGate";

--- a/src/features/equipment/components/EquipmentPage.tsx
+++ b/src/features/equipment/components/EquipmentPage.tsx
@@ -71,9 +71,12 @@ export function EquipmentPage(): JSX.Element {
 
   if (sessionQuery.data.kind === "unconfigured") {
     return (
-      <EquipmentPageState
+      <ProtectedRouteAuthGate
+        eyebrow="Configuration required"
         description="Supabase is not configured for equipment management in this environment."
-        title="Equipment management is unavailable"
+        primaryAction={{ label: "Review account setup", to: "/account" }}
+        secondaryAction={{ label: "Browse recipes", to: "/recipes" }}
+        title="Equipment management unavailable"
       />
     );
   }

--- a/src/features/equipment/components/EquipmentPage.tsx
+++ b/src/features/equipment/components/EquipmentPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowDown, ArrowUp } from "lucide-react";
 import { useState, type ChangeEvent, type JSX } from "react";
 
+import { ProtectedRouteAuthGate } from "@/components/app";
 import { Button } from "@/components/ui/button";
 import { sessionQueryOptions } from "@/features/auth";
 import { useAppToast } from "@/hooks/useAppToast";
@@ -59,8 +60,10 @@ export function EquipmentPage(): JSX.Element {
 
   if (sessionQuery.data === undefined || sessionQuery.data.kind === "guest") {
     return (
-      <EquipmentPageState
-        description="Sign in to manage the equipment you use across recipes."
+      <ProtectedRouteAuthGate
+        description="Sign in to build your equipment inventory and keep recipe forms fast."
+        primaryAction={{ label: "Sign in to continue", to: "/account" }}
+        secondaryAction={{ label: "Browse recipes", to: "/recipes" }}
         title="Sign in to manage equipment"
       />
     );
@@ -233,7 +236,9 @@ export function EquipmentPage(): JSX.Element {
                       <div className="flex items-center gap-2">
                         <Button
                           className="rounded-md px-4"
-                          disabled={!isDirty || isReorderPending || isUpdatePending}
+                          disabled={
+                            !isDirty || isReorderPending || isUpdatePending
+                          }
                           type="submit"
                         >
                           {isUpdatePending ? "Saving..." : "Save"}

--- a/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
+++ b/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
@@ -1,6 +1,4 @@
-import { Link } from "@tanstack/react-router";
-
-import { Button } from "@/components/ui/button";
+import { ProtectedRouteAuthGate } from "@/components/app";
 import type { AuthSessionState } from "@/features/auth";
 
 import type { JSX } from "react";
@@ -15,30 +13,16 @@ export function RecipeCreateAuthPrompt({
   const copy = getAuthPromptCopy(sessionState);
 
   return (
-    <main className="w-full max-w-6xl py-3 sm:py-4">
-      <section className="border-b border-border pb-4">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-          {copy.title}
-        </h1>
-        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-          {copy.description}
-        </p>
-        <div className="mt-6 flex flex-wrap gap-3">
-          <Button asChild className="rounded-md px-5" size="lg">
-            <Link to="/account">{copy.ctaLabel}</Link>
-          </Button>
-          <Button asChild className="rounded-md px-5" size="lg" variant="outline">
-            <Link to="/recipes">Back to recipes</Link>
-          </Button>
-        </div>
-      </section>
-    </main>
+    <ProtectedRouteAuthGate
+      description={copy.description}
+      primaryAction={{ label: copy.ctaLabel, to: "/account" }}
+      secondaryAction={{ label: "Back to recipes", to: "/recipes" }}
+      title={copy.title}
+    />
   );
 }
 
-function getAuthPromptCopy(
-  sessionState: AuthSessionState | undefined,
-): {
+function getAuthPromptCopy(sessionState: AuthSessionState | undefined): {
   ctaLabel: string;
   description: string;
   title: string;
@@ -47,15 +31,14 @@ function getAuthPromptCopy(
     return {
       ctaLabel: "Sign in to continue",
       description:
-        "You need to sign in before creating a recipe.",
+        "Sign in to create, save, and organize recipes in your collection.",
       title: "Sign in before creating a recipe",
     };
   }
 
   return {
     ctaLabel: "Review account setup",
-    description:
-      "Auth is not configured in this environment.",
+    description: "Authentication is not configured in this environment yet.",
     title: "Auth setup required",
   };
 }

--- a/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
+++ b/src/features/recipes/components/RecipeCreateAuthPrompt.tsx
@@ -14,6 +14,7 @@ export function RecipeCreateAuthPrompt({
 
   return (
     <ProtectedRouteAuthGate
+      eyebrow={copy.eyebrow}
       description={copy.description}
       primaryAction={{ label: copy.ctaLabel, to: "/account" }}
       secondaryAction={{ label: "Back to recipes", to: "/recipes" }}
@@ -25,6 +26,7 @@ export function RecipeCreateAuthPrompt({
 function getAuthPromptCopy(sessionState: AuthSessionState | undefined): {
   ctaLabel: string;
   description: string;
+  eyebrow: string;
   title: string;
 } {
   if (sessionState === undefined || sessionState.kind === "guest") {
@@ -32,6 +34,7 @@ function getAuthPromptCopy(sessionState: AuthSessionState | undefined): {
       ctaLabel: "Sign in to continue",
       description:
         "Sign in to create, save, and organize recipes in your collection.",
+      eyebrow: "Protected page",
       title: "Sign in before creating a recipe",
     };
   }
@@ -39,6 +42,7 @@ function getAuthPromptCopy(sessionState: AuthSessionState | undefined): {
   return {
     ctaLabel: "Review account setup",
     description: "Authentication is not configured in this environment yet.",
+    eyebrow: "Configuration required",
     title: "Auth setup required",
   };
 }


### PR DESCRIPTION
## Summary
- add a shared protected-route auth gate component with centered layout and clear CTAs
- use the shared gate for signed-out `/recipes/new` and `/equipment` states
- tighten copy so next actions are explicit while keeping messaging concise

## Validation
- npm run lint
- npm run build

Fixes #152