### PR TITLE
fix(recipes): improve recipe shelf card density on desktop

### DIFF
--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -56,18 +56,28 @@ export function RecipePreviewCard({
         </Link>
       ) : null}
 
-      <div className="flex h-full flex-col gap-4 p-5">
-        <div className="space-y-2">
-          <h2 className="text-xl font-semibold tracking-tight text-foreground">
-            <Link
-              className="transition hover:text-primary"
-              params={{ recipeId: recipe.id }}
-              to="/recipes/$recipeId"
-            >
-              {recipe.title}
-            </Link>
-          </h2>
-          <p className="truncate text-sm text-muted-foreground">{summary}</p>
+      <div className="flex h-full flex-col gap-3 p-6">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-2">
+            <h2 className="text-xl font-semibold tracking-tight text-foreground">
+              <Link
+                className="transition hover:text-primary"
+                params={{ recipeId: recipe.id }}
+                to="/recipes/$recipeId"
+              >
+                {recipe.title}
+              </Link>
+            </h2>
+            <p className="truncate text-sm text-muted-foreground">{summary}</p>
+          </div>
+          <Link
+            className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-primary transition hover:underline"
+            params={{ recipeId: recipe.id }}
+            to="/recipes/$recipeId"
+          >
+            Open
+            <ArrowRight className="size-4" />
+          </Link>
         </div>
 
         {recipe.categories.length > 0 ? (
@@ -105,17 +115,6 @@ export function RecipePreviewCard({
               {item}
             </span>
           ))}
-        </div>
-
-        <div className="mt-auto flex justify-end">
-          <Link
-            className="inline-flex items-center gap-1 text-sm font-medium text-primary transition hover:underline"
-            params={{ recipeId: recipe.id }}
-            to="/recipes/$recipeId"
-          >
-            Open
-            <ArrowRight className="size-4" />
-          </Link>
         </div>
       </div>
     </article>

--- a/src/features/recipes/components/RecipesPageContent.tsx
+++ b/src/features/recipes/components/RecipesPageContent.tsx
@@ -21,12 +21,13 @@ export function RecipesPageContent({
     return <RecipesEmptyState isFiltered={isFiltered} />;
   }
 
-  const sparseGridClassName =
-    recipes.length === 1
-      ? "mx-auto w-full max-w-3xl grid-cols-1"
-      : recipes.length === 2
-        ? "mx-auto w-full max-w-6xl sm:grid-cols-2 2xl:grid-cols-2"
-        : "sm:grid-cols-2 2xl:grid-cols-3";
+  let sparseGridClassName = "sm:grid-cols-2 2xl:grid-cols-3";
+
+  if (recipes.length === 1) {
+    sparseGridClassName = "mx-auto w-full max-w-3xl grid-cols-1";
+  } else if (recipes.length === 2) {
+    sparseGridClassName = "mx-auto w-full max-w-6xl sm:grid-cols-2";
+  }
 
   return (
     <section className={cn("grid gap-5", sparseGridClassName)}>

--- a/src/features/recipes/components/RecipesPageContent.tsx
+++ b/src/features/recipes/components/RecipesPageContent.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 import { RecipePreviewCard } from "./RecipePreviewCard";
 import { RecipesEmptyState } from "./RecipesEmptyState";
 
@@ -19,8 +21,15 @@ export function RecipesPageContent({
     return <RecipesEmptyState isFiltered={isFiltered} />;
   }
 
+  const sparseGridClassName =
+    recipes.length === 1
+      ? "mx-auto w-full max-w-3xl grid-cols-1"
+      : recipes.length === 2
+        ? "mx-auto w-full max-w-6xl sm:grid-cols-2 2xl:grid-cols-2"
+        : "sm:grid-cols-2 2xl:grid-cols-3";
+
   return (
-    <section className="grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
+    <section className={cn("grid gap-5", sparseGridClassName)}>
       {recipes.map((recipe) => (
         <RecipePreviewCard
           key={recipe.id}


### PR DESCRIPTION
# Pull Request

## Summary

Improve recipe shelf density on desktop so low-count states use page width more intentionally and cards feel less sparse.

## Changes

- Made `RecipesPageContent` grid count-aware:
- 1 recipe: centered single column with `max-w-3xl`
- 2 recipes: centered 2-column layout with `max-w-6xl` and no forced 3-column expansion at `2xl`
- 3+ recipes: existing responsive behavior (`sm:grid-cols-2`, `2xl:grid-cols-3`)
- Increased recipe card interior spacing and moved the `Open` action into the title row in `RecipePreviewCard` to improve scanability and reduce visual dead space

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [ ] Relevant tests were run when available
- [x] Manual verification was performed when needed

Validation notes:

- Verified local lint and build pass after changes.

## Data and Security Impact

- [x] No schema change
- [ ] Schema/migration change included
- [x] No auth or permission impact
- [ ] Auth, permission, or data exposure impact reviewed

Notes:

- Frontend-only layout and UI composition update; no Supabase schema/auth or secret handling changes.

## Documentation

- [x] No doc updates needed
- [ ] README updated
- [ ] AGENTS updated
- [ ] Other docs updated

## Reviewer Notes

- Desktop card density was adjusted specifically for sparse result sets.
- This PR closes #153.
