### PR TITLE
fix(recipes): surface active shelf filters visibility

### DIFF
--- a/src/features/recipes/components/RecipeShelfFilters.tsx
+++ b/src/features/recipes/components/RecipeShelfFilters.tsx
@@ -40,13 +40,14 @@ export function RecipeShelfFilters({
     maxSliderValue,
   );
   const rangeValue: [number, number] = [minRangeValue, maxRangeValue];
-  const selectedCategoryNames = selectedCategorySlugs.map((slug) => {
-    const matchingCategory = availableCategories.find(
-      (category) => category.slug === slug,
-    );
+  const categoryNameBySlug = new Map(
+    availableCategories.map((category) => [category.slug, category.name]),
+  );
+  const selectedCategories = selectedCategorySlugs.map((slug) => {
+    const matchingCategoryName = categoryNameBySlug.get(slug);
 
     return {
-      name: matchingCategory?.name ?? slug,
+      name: matchingCategoryName ?? slug,
       slug,
     };
   });
@@ -98,13 +99,14 @@ export function RecipeShelfFilters({
             )}
           </div>
         </details>
-        {selectedCategoryNames.length > 0 ? (
+        {selectedCategories.length > 0 ? (
           <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-2">
             <p className="px-1 text-xs font-medium text-muted-foreground">
               Active
             </p>
-            {selectedCategoryNames.map((category) => (
+            {selectedCategories.map((category) => (
               <button
+                aria-label={`Remove ${category.name} filter`}
                 className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-1 text-xs font-medium text-foreground transition hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 key={category.slug}
                 onClick={() => {
@@ -116,7 +118,6 @@ export function RecipeShelfFilters({
                 <span aria-hidden className="text-muted-foreground">
                   ×
                 </span>
-                <span className="sr-only">Remove {category.name} filter</span>
               </button>
             ))}
           </div>

--- a/src/features/recipes/components/RecipeShelfFilters.tsx
+++ b/src/features/recipes/components/RecipeShelfFilters.tsx
@@ -40,51 +40,88 @@ export function RecipeShelfFilters({
     maxSliderValue,
   );
   const rangeValue: [number, number] = [minRangeValue, maxRangeValue];
+  const selectedCategoryNames = selectedCategorySlugs.map((slug) => {
+    const matchingCategory = availableCategories.find(
+      (category) => category.slug === slug,
+    );
+
+    return {
+      name: matchingCategory?.name ?? slug,
+      slug,
+    };
+  });
 
   return (
     <section className="flex flex-col gap-4 border-t border-border pt-4 xl:flex-row xl:items-start xl:justify-between">
-      <details className="max-w-xl">
-        <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border px-3 py-2 text-sm text-foreground transition hover:bg-muted/40">
-          <span className="font-medium">Categories</span>
-          <span className="text-muted-foreground">
-            {selectedCategorySlugs.length === 0
-              ? "All categories"
-              : `${selectedCategorySlugs.length} selected`}
-          </span>
-        </summary>
-        <div className="mt-2 flex flex-wrap gap-2 rounded-md border border-border bg-background p-3">
-          {availableCategories.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No categories are available yet.
-            </p>
-          ) : (
-            availableCategories.map((category) => {
-              const isSelected = selectedCategorySlugs.includes(category.slug);
+      <div className="w-full max-w-xl space-y-2">
+        <details>
+          <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border px-3 py-2 text-sm text-foreground transition hover:bg-muted/40">
+            <span className="font-medium">Categories</span>
+            <span className="text-muted-foreground">
+              {selectedCategorySlugs.length === 0
+                ? "All categories"
+                : `${selectedCategorySlugs.length} selected`}
+            </span>
+          </summary>
+          <div className="mt-2 flex flex-wrap gap-2 rounded-md border border-border bg-background p-3">
+            {availableCategories.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No categories are available yet.
+              </p>
+            ) : (
+              availableCategories.map((category) => {
+                const isSelected = selectedCategorySlugs.includes(
+                  category.slug,
+                );
 
-              return (
-                <label
-                  key={category.id}
-                  className={
-                    isSelected
-                      ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-primary bg-primary/10 px-3 py-2 text-sm text-foreground"
-                      : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-2 text-sm text-foreground"
-                  }
-                >
-                  <input
-                    checked={isSelected}
-                    className="size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20"
-                    onChange={() => {
-                      onCategoryToggle(category.slug);
-                    }}
-                    type="checkbox"
-                  />
-                  {category.name}
-                </label>
-              );
-            })
-          )}
-        </div>
-      </details>
+                return (
+                  <label
+                    key={category.id}
+                    className={
+                      isSelected
+                        ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-primary bg-primary/10 px-3 py-2 text-sm text-foreground"
+                        : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-2 text-sm text-foreground"
+                    }
+                  >
+                    <input
+                      checked={isSelected}
+                      className="size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20"
+                      onChange={() => {
+                        onCategoryToggle(category.slug);
+                      }}
+                      type="checkbox"
+                    />
+                    {category.name}
+                  </label>
+                );
+              })
+            )}
+          </div>
+        </details>
+        {selectedCategoryNames.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-2">
+            <p className="px-1 text-xs font-medium text-muted-foreground">
+              Active
+            </p>
+            {selectedCategoryNames.map((category) => (
+              <button
+                className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-1 text-xs font-medium text-foreground transition hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                key={category.slug}
+                onClick={() => {
+                  onCategoryToggle(category.slug);
+                }}
+                type="button"
+              >
+                <span>{category.name}</span>
+                <span aria-hidden className="text-muted-foreground">
+                  ×
+                </span>
+                <span className="sr-only">Remove {category.name} filter</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
 
       <div className="w-full max-w-xl space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Summary
- surface selected shelf categories in a persistent compact active-filter row outside the collapsed category control
- keep category remove actions one-click by toggling each active chip
- preserve existing category picker and total-time filtering behavior

Closes #154