### PR TITLE
fix(profiles): strengthen public profile page hierarchy

### DIFF
--- a/src/features/profiles/components/PublicProfilePage.tsx
+++ b/src/features/profiles/components/PublicProfilePage.tsx
@@ -23,6 +23,10 @@ export function PublicProfilePage({
   const recipesQuery = useQuery(recipeListByOwnerQueryOptions(userId));
   const profile = profileQuery.data;
   const recipes = recipesQuery.data ?? [];
+  const recipeCountLabel =
+    recipes.length === 1
+      ? "1 public recipe"
+      : `${recipes.length} public recipes`;
 
   useDocumentTitle(profile?.displayName ?? "Profile");
 
@@ -43,39 +47,49 @@ export function PublicProfilePage({
 
   return (
     <main className="w-full max-w-5xl py-3 sm:py-4">
-      <section className="border-b border-border pb-6">
-        <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
-          <ProfileAvatar
-            avatarPath={profile.avatarPath}
-            displayName={profile.displayName}
-            size="lg"
-          />
-          <div className="min-w-0 space-y-3">
-            <div>
-              <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+      <section className="rounded-2xl border border-border/80 bg-card/80 px-5 py-6 shadow-sm sm:px-7 sm:py-7">
+        <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-start">
+          <div className="flex min-w-0 flex-col gap-5 sm:flex-row sm:items-start">
+            <ProfileAvatar
+              avatarPath={profile.avatarPath}
+              displayName={profile.displayName}
+              size="lg"
+            />
+            <div className="min-w-0 space-y-3">
+              <p className="inline-flex rounded-full bg-muted px-3 py-1 text-xs font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+                Public profile
+              </p>
+              <h1 className="font-display text-3xl leading-tight font-semibold tracking-tight text-foreground sm:text-4xl">
                 {profile.displayName}
               </h1>
-              <p className="mt-2 text-sm text-muted-foreground">
-                {recipes.length === 1
-                  ? "1 public recipe"
-                  : `${recipes.length} public recipes`}
-              </p>
-            </div>
 
-            {profile.bio !== null ? (
-              <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-                {profile.bio}
-              </p>
-            ) : (
-              <p className="max-w-3xl text-sm text-muted-foreground">
-                No bio has been added to this profile yet.
-              </p>
-            )}
+              {profile.bio !== null ? (
+                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                  {profile.bio}
+                </p>
+              ) : (
+                <p className="max-w-3xl text-sm text-muted-foreground">
+                  No bio has been added to this profile yet.
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-background/70 px-4 py-3 lg:min-w-[12rem]">
+            <p className="text-xs font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+              Recipes shared
+            </p>
+            <p className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+              {recipes.length}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {recipeCountLabel}
+            </p>
           </div>
         </div>
       </section>
 
-      <section className="mt-6 space-y-4">
+      <section className="mt-7 space-y-4">
         <div>
           <h2 className="text-xl font-semibold tracking-tight text-foreground">
             Recipes


### PR DESCRIPTION
## Summary
- strengthen the public profile header with a more intentional card layout
- improve identity hierarchy with a profile label, display font heading, and clearer bio placement
- add a dedicated recipe summary panel so recipe count context is immediately visible

## Validation
- `npx eslint src/features/profiles/components/PublicProfilePage.tsx`
- `npm run build`
- `npm run lint` *(fails due to existing unrelated import-order issues in `eslint.config.ts`)*

Closes #155
