### PR TITLE
fix(auth): rework signed-out account page hierarchy

### DIFF
--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -44,7 +44,7 @@ function getHeadlineDescription(
     case "authenticated":
       return "Manage your sign-in and app settings.";
     case "guest":
-      return "Sign in to create and delete recipes.";
+      return "Sign in to continue managing recipes.";
     case "loading":
       return "Checking session status.";
     case "unconfigured":
@@ -69,8 +69,6 @@ export function AccountPage(): JSX.Element {
     ? "loading"
     : (sessionQuery.data?.kind ?? "guest");
   const headlineDescription = getHeadlineDescription(kind);
-  const isGuest =
-    sessionQuery.data?.kind === "guest" || sessionQuery.data === undefined;
   const isConfigured = sessionQuery.data?.kind !== "unconfigured";
 
   return (
@@ -113,63 +111,82 @@ export function AccountPage(): JSX.Element {
               <ProfileSettingsSection userId={sessionQuery.data.userId} />
             </>
           ) : (
-            <section className="grid gap-4 md:grid-cols-2">
-              <AuthFormCard
-                description="Use your existing account."
-                email={signInValues.email}
-                isPending={signInMutation.isPending}
-                onEmailChange={(event) => {
-                  setSignInValues((current) => ({
-                    ...current,
-                    email: event.target.value,
-                  }));
-                }}
-                onPasswordChange={(event) => {
-                  setSignInValues((current) => ({
-                    ...current,
-                    password: event.target.value,
-                  }));
-                }}
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  submitCredentials(signInValues, signInMutation, {
-                    setValues: setSignInValues,
-                    toast,
-                    successTitle: "Signed in",
-                  });
-                }}
-                password={signInValues.password}
-                submitLabel="Sign in"
-                title="Sign in"
-              />
-              <AuthFormCard
-                description="Create a new account."
-                email={signUpValues.email}
-                isPending={signUpMutation.isPending}
-                onEmailChange={(event) => {
-                  setSignUpValues((current) => ({
-                    ...current,
-                    email: event.target.value,
-                  }));
-                }}
-                onPasswordChange={(event) => {
-                  setSignUpValues((current) => ({
-                    ...current,
-                    password: event.target.value,
-                  }));
-                }}
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  submitCredentials(signUpValues, signUpMutation, {
-                    setValues: setSignUpValues,
-                    toast,
-                    successTitle: "Account ready",
-                  });
-                }}
-                password={signUpValues.password}
-                submitLabel="Create account"
-                title="Sign up"
-              />
+            <section className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+              <div className="space-y-4">
+                <section className="rounded-lg border border-primary/35 bg-primary/5 px-5 py-4">
+                  <h2 className="text-sm font-semibold text-foreground">
+                    Sign in to continue
+                  </h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Create and delete recipes after signing in.
+                  </p>
+                </section>
+                <AuthFormCard
+                  description="Use your existing account."
+                  email={signInValues.email}
+                  isPending={signInMutation.isPending}
+                  onEmailChange={(event) => {
+                    setSignInValues((current) => ({
+                      ...current,
+                      email: event.target.value,
+                    }));
+                  }}
+                  onPasswordChange={(event) => {
+                    setSignInValues((current) => ({
+                      ...current,
+                      password: event.target.value,
+                    }));
+                  }}
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    submitCredentials(signInValues, signInMutation, {
+                      setValues: setSignInValues,
+                      toast,
+                      successTitle: "Signed in",
+                    });
+                  }}
+                  password={signInValues.password}
+                  submitLabel="Sign in"
+                  title="Sign in"
+                />
+              </div>
+              <section className="rounded-lg border border-border bg-muted/20 p-5">
+                <h3 className="text-sm font-semibold text-foreground">
+                  New to Recipe Book?
+                </h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Create an account to save your recipes and preferences.
+                </p>
+                <AuthFormCard
+                  className="mt-4 border-0 bg-transparent p-0"
+                  description="Create a new account."
+                  email={signUpValues.email}
+                  isPending={signUpMutation.isPending}
+                  onEmailChange={(event) => {
+                    setSignUpValues((current) => ({
+                      ...current,
+                      email: event.target.value,
+                    }));
+                  }}
+                  onPasswordChange={(event) => {
+                    setSignUpValues((current) => ({
+                      ...current,
+                      password: event.target.value,
+                    }));
+                  }}
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    submitCredentials(signUpValues, signUpMutation, {
+                      setValues: setSignUpValues,
+                      toast,
+                      successTitle: "Account ready",
+                    });
+                  }}
+                  password={signUpValues.password}
+                  submitLabel="Create account"
+                  title="Sign up"
+                />
+              </section>
             </section>
           )}
 
@@ -183,18 +200,6 @@ export function AccountPage(): JSX.Element {
               </p>
             </section>
           ) : null}
-
-          {isGuest ? (
-            <section className="rounded-lg border border-amber-300/70 bg-amber-50/80 px-5 py-4">
-              <h2 className="text-sm font-semibold text-amber-950">
-                Sign in required
-              </h2>
-              <p className="mt-1 text-sm text-amber-950/85">
-                Sign in before creating or deleting recipes.
-              </p>
-            </section>
-          ) : null}
-
         </div>
 
         <section className="space-y-4 border-t border-border pt-6">

--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -145,15 +145,16 @@ export function AccountPage(): JSX.Element {
                       successTitle: "Signed in",
                     });
                   }}
+                  passwordAutoComplete="current-password"
                   password={signInValues.password}
                   submitLabel="Sign in"
                   title="Sign in"
                 />
               </div>
               <section className="rounded-lg border border-border bg-muted/20 p-5">
-                <h3 className="text-sm font-semibold text-foreground">
+                <h2 className="text-sm font-semibold text-foreground">
                   New to Recipe Book?
-                </h3>
+                </h2>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Create an account to save your recipes and preferences.
                 </p>
@@ -182,6 +183,7 @@ export function AccountPage(): JSX.Element {
                       successTitle: "Account ready",
                     });
                   }}
+                  passwordAutoComplete="new-password"
                   password={signUpValues.password}
                   submitLabel="Create account"
                   title="Sign up"

--- a/src/features/auth/components/AuthFormCard.tsx
+++ b/src/features/auth/components/AuthFormCard.tsx
@@ -1,6 +1,9 @@
+import { cn } from "@/lib/utils";
+
 import type { ChangeEvent, FormEvent, JSX } from "react";
 
 type AuthFormCardProps = {
+  className?: string;
   description: string;
   email: string;
   isPending: boolean;
@@ -16,6 +19,7 @@ const inputClassName =
   "h-11 w-full rounded-md border border-border bg-background px-4 text-sm text-foreground outline-none transition focus:border-primary/50 focus:ring-3 focus:ring-primary/15";
 
 export function AuthFormCard({
+  className,
   description,
   email,
   isPending,
@@ -27,17 +31,21 @@ export function AuthFormCard({
   title,
 }: AuthFormCardProps): JSX.Element {
   return (
-    <article className="rounded-lg border border-border bg-background p-5">
-      <h2 className="text-sm font-semibold text-foreground">
-        {title}
-      </h2>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {description}
-      </p>
+    <article
+      className={cn(
+        "rounded-lg border border-border bg-background p-5",
+        className,
+      )}
+    >
+      <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
 
       <form className="mt-5 space-y-4" onSubmit={onSubmit}>
         <div className="space-y-2">
-          <label className="text-sm font-medium text-foreground" htmlFor={`${title}-email`}>
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor={`${title}-email`}
+          >
             Email
           </label>
           <input
@@ -59,7 +67,11 @@ export function AuthFormCard({
             Password
           </label>
           <input
-            autoComplete={submitLabel === "Create account" ? "new-password" : "current-password"}
+            autoComplete={
+              submitLabel === "Create account"
+                ? "new-password"
+                : "current-password"
+            }
             className={inputClassName}
             id={`${title}-password`}
             name="password"

--- a/src/features/auth/components/AuthFormCard.tsx
+++ b/src/features/auth/components/AuthFormCard.tsx
@@ -10,6 +10,7 @@ type AuthFormCardProps = {
   onEmailChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  passwordAutoComplete: "current-password" | "new-password";
   password: string;
   submitLabel: string;
   title: string;
@@ -26,6 +27,7 @@ export function AuthFormCard({
   onEmailChange,
   onPasswordChange,
   onSubmit,
+  passwordAutoComplete,
   password,
   submitLabel,
   title,
@@ -67,11 +69,7 @@ export function AuthFormCard({
             Password
           </label>
           <input
-            autoComplete={
-              submitLabel === "Create account"
-                ? "new-password"
-                : "current-password"
-            }
+            autoComplete={passwordAutoComplete}
             className={inputClassName}
             id={`${title}-password`}
             name="password"


### PR DESCRIPTION
## Summary\n- rework signed-out account page hierarchy to clearly prioritize sign-in\n- keep sign-up in a secondary panel while preserving full auth functionality\n- remove duplicated guest warning copy for a more intentional, compact layout\n- address review feedback by fixing heading order and making password autocomplete explicit\n\n## Validation\n- npm run lint\n- npm run build\n\nCloses #156