### PR TITLE
fix(auth): emphasize primary sign-in on account page

### DIFF
--- a/src/features/auth/components/AccountPage.tsx
+++ b/src/features/auth/components/AccountPage.tsx
@@ -160,7 +160,7 @@ export function AccountPage(): JSX.Element {
                 </p>
                 <AuthFormCard
                   className="mt-4 border-0 bg-transparent p-0"
-                  description="Create a new account."
+                  description="Create an account if you do not have one yet."
                   email={signUpValues.email}
                   isPending={signUpMutation.isPending}
                   onEmailChange={(event) => {
@@ -186,6 +186,7 @@ export function AccountPage(): JSX.Element {
                   passwordAutoComplete="new-password"
                   password={signUpValues.password}
                   submitLabel="Create account"
+                  submitVariant="secondary"
                   title="Sign up"
                 />
               </section>

--- a/src/features/auth/components/AuthFormCard.tsx
+++ b/src/features/auth/components/AuthFormCard.tsx
@@ -13,6 +13,7 @@ type AuthFormCardProps = {
   passwordAutoComplete: "current-password" | "new-password";
   password: string;
   submitLabel: string;
+  submitVariant?: "primary" | "secondary";
   title: string;
 };
 
@@ -30,8 +31,14 @@ export function AuthFormCard({
   passwordAutoComplete,
   password,
   submitLabel,
+  submitVariant = "primary",
   title,
 }: AuthFormCardProps): JSX.Element {
+  const submitButtonClassName =
+    submitVariant === "secondary"
+      ? "border border-border bg-background text-foreground hover:bg-muted/50"
+      : "bg-primary text-primary-foreground hover:bg-primary/90";
+
   return (
     <article
       className={cn(
@@ -80,7 +87,10 @@ export function AuthFormCard({
         </div>
 
         <button
-          className="inline-flex h-11 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          className={cn(
+            "inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-60",
+            submitButtonClassName,
+          )}
           disabled={isPending}
           type="submit"
         >


### PR DESCRIPTION
## Summary
- add a secondary submit button variant to `AuthFormCard`
- use the secondary variant for sign-up on the signed-out account page
- keep sign-in as the clear primary action in the layout

## Validation
- npm run lint
- npm run build

Closes #156
