### PR TITLE
fix(recipes): refine recipe detail header information hierarchy

### DIFF
--- a/src/features/recipes/components/RecipeAllergenSummary.tsx
+++ b/src/features/recipes/components/RecipeAllergenSummary.tsx
@@ -19,7 +19,7 @@ export function RecipeAllergenSummary({
   return (
     <section className="space-y-3">
       <div>
-        <h2 className="text-sm font-semibold text-foreground">Allergens</h2>
+        <h3 className="text-sm font-semibold text-foreground">Allergens</h3>
         <p className="mt-1 text-sm text-muted-foreground">
           {sortedAllergens.length === 0
             ? recipeAllergenEmptyStateLabel

--- a/src/features/recipes/components/RecipeDetailHero.tsx
+++ b/src/features/recipes/components/RecipeDetailHero.tsx
@@ -14,18 +14,23 @@ import {
 
 import { RecipeAllergenSummary } from "./RecipeAllergenSummary";
 import { RecipeCoverImage } from "./RecipeCoverImage";
+import { RecipeScalingPanel } from "./RecipeScalingPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
 
 type RecipeDetailHeroProps = {
   displaySystem: "imperial" | "metric";
+  onDisplaySystemChange: (displaySystem: "imperial" | "metric") => void;
+  onScaleChange: (scaleFactor: number) => void;
   recipe: RecipeDetail;
   scaleFactor: number;
 };
 
 export function RecipeDetailHero({
   displaySystem,
+  onDisplaySystemChange,
+  onScaleChange,
   recipe,
   scaleFactor,
 }: RecipeDetailHeroProps): JSX.Element {
@@ -63,10 +68,10 @@ export function RecipeDetailHero({
         className={
           hasCoverImage
             ? "grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)] lg:items-start"
-            : "space-y-5"
+            : "space-y-6"
         }
       >
-        <div className="min-w-0 space-y-5">
+        <div className="min-w-0 space-y-6">
           <div className="min-w-0">
             <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
               {recipe.title}
@@ -92,18 +97,30 @@ export function RecipeDetailHero({
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
-            {metadata.map((item) => (
-              <span
-                key={item}
-                className="rounded-full border border-border bg-background px-3 py-1.5"
-              >
-                {item}
-              </span>
-            ))}
+          <div className="space-y-4 rounded-xl border border-border bg-muted/20 p-4">
+            <h2 className="text-sm font-semibold text-foreground">
+              Recipe facts
+            </h2>
+            <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+              {metadata.map((item) => (
+                <span
+                  key={item}
+                  className="rounded-full border border-border bg-background px-3 py-1.5"
+                >
+                  {item}
+                </span>
+              ))}
+            </div>
+            <RecipeAllergenSummary allergens={recipe.allergens} />
           </div>
 
-          <RecipeAllergenSummary allergens={recipe.allergens} />
+          <RecipeScalingPanel
+            displaySystem={displaySystem}
+            onDisplaySystemChange={onDisplaySystemChange}
+            onScaleChange={onScaleChange}
+            recipe={recipe}
+            scaleFactor={scaleFactor}
+          />
         </div>
 
         {recipe.coverImagePath !== null ? (

--- a/src/features/recipes/components/RecipeDetailPage.tsx
+++ b/src/features/recipes/components/RecipeDetailPage.tsx
@@ -42,14 +42,14 @@ export function RecipeDetailPage({
     <main className="flex w-full flex-col gap-8 py-3 sm:py-4">
       <RecipeDetailHero
         displaySystem={displaySystem}
+        onDisplaySystemChange={setDisplaySystem}
+        onScaleChange={setScaleFactor}
         recipe={recipe}
         scaleFactor={scaleFactor}
       />
       <RecipeDetailPageSections
         displaySystem={displaySystem}
         isSessionLoading={sessionQuery.isLoading}
-        onDisplaySystemChange={setDisplaySystem}
-        onScaleChange={setScaleFactor}
         recipe={recipe}
         scaleFactor={scaleFactor}
         sessionState={sessionQuery.data}

--- a/src/features/recipes/components/RecipeDetailPageSections.tsx
+++ b/src/features/recipes/components/RecipeDetailPageSections.tsx
@@ -3,7 +3,6 @@ import type { AuthSessionState } from "@/features/auth";
 import { RecipeCookLogSection } from "./RecipeCookLogSection";
 import { RecipeDetailCollectionSection } from "./RecipeDetailCollectionSection";
 import { RecipeOwnerActionsPanel } from "./RecipeOwnerActionsPanel";
-import { RecipeScalingPanel } from "./RecipeScalingPanel";
 
 import type { RecipeDetail } from "../types/recipes";
 import type { JSX } from "react";
@@ -11,8 +10,6 @@ import type { JSX } from "react";
 type RecipeDetailPageSectionsProps = {
   displaySystem: "imperial" | "metric";
   isSessionLoading: boolean;
-  onDisplaySystemChange: (displaySystem: "imperial" | "metric") => void;
-  onScaleChange: (scaleFactor: number) => void;
   recipe: RecipeDetail;
   scaleFactor: number;
   sessionState: AuthSessionState | undefined;
@@ -21,22 +18,12 @@ type RecipeDetailPageSectionsProps = {
 export function RecipeDetailPageSections({
   displaySystem,
   isSessionLoading,
-  onDisplaySystemChange,
-  onScaleChange,
   recipe,
   scaleFactor,
   sessionState,
 }: RecipeDetailPageSectionsProps): JSX.Element {
   return (
     <div className="space-y-8">
-      <RecipeScalingPanel
-        displaySystem={displaySystem}
-        onDisplaySystemChange={onDisplaySystemChange}
-        onScaleChange={onScaleChange}
-        recipe={recipe}
-        scaleFactor={scaleFactor}
-      />
-
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
         <RecipeDetailCollectionSection
           defaultExpanded

--- a/src/features/recipes/components/RecipeScalingPanel.tsx
+++ b/src/features/recipes/components/RecipeScalingPanel.tsx
@@ -69,11 +69,11 @@ export function RecipeScalingPanel({
   }
 
   return (
-    <section className="border-t border-border pt-6">
+    <section className="space-y-4 rounded-xl border border-border bg-background/80 p-4">
       {!isScalable ? (
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-3">
-            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            <h2 className="text-base font-semibold tracking-tight text-foreground">
               Batch size
             </h2>
             <MeasurementSystemToggle
@@ -90,7 +90,7 @@ export function RecipeScalingPanel({
       {isScalable ? (
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div className="flex flex-wrap items-center gap-3">
-            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            <h2 className="text-base font-semibold tracking-tight text-foreground">
               Batch size
             </h2>
             <MeasurementSystemToggle
@@ -177,7 +177,7 @@ export function RecipeScalingPanel({
           className={
             customBatchSizeError === null
               ? "sr-only"
-              : "mt-2 text-sm text-destructive xl:text-right"
+              : "text-sm text-destructive xl:text-right"
           }
           id={`${customBatchSizeInputId}-message`}
         >


### PR DESCRIPTION
## Summary
- move batch-size controls into the recipe detail hero so title/byline, facts, allergens, and scaling controls read as one cohesive header block
- group top-level recipe facts and allergen summary in a single metadata surface for clearer scanning
- remove the duplicate standalone scaling band from the page sections stack

## Testing
- `npm run lint`
- `npm run build`

Closes #157
