### PR TITLE
feat(shell): add mobile navigation drawer

### DIFF
--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -4,18 +4,10 @@ import { BookOpenText, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
 
-import type { JSX } from "react";
+import { MobileNavDrawer } from "./MobileNavDrawer";
 
-export type AuthActionState =
-  | {
-      kind: "authenticated";
-      avatarUrl: string | null;
-      label: string;
-    }
-  | {
-      kind: "guest" | "loading" | "unconfigured";
-      label: string;
-    };
+import type { AuthActionState, HeaderNavItem } from "./AppShellHeader.types";
+import type { JSX } from "react";
 
 type AppShellHeaderProps = {
   authAction: AuthActionState;
@@ -26,6 +18,24 @@ export function AppShellHeader({
   authAction,
   showAdminNav,
 }: AppShellHeaderProps): JSX.Element {
+  const navItems: HeaderNavItem[] = [
+    {
+      label: "Recipes",
+      to: "/recipes",
+    },
+    {
+      label: "Equipment",
+      to: "/equipment",
+    },
+  ];
+
+  if (showAdminNav) {
+    navItems.push({
+      label: "Admin",
+      to: "/admin/categories",
+    });
+  }
+
   return (
     <header className="sticky top-0 z-20 border-b border-border bg-background/95 backdrop-blur">
       <div className="flex min-h-15 items-center justify-between gap-4 py-3">
@@ -38,37 +48,22 @@ export function AppShellHeader({
             <span className="sr-only truncate sm:not-sr-only">Recipe Book</span>
           </Link>
 
-          <nav className="flex items-center gap-1">
-            <Button
-              asChild
-              className="rounded-md px-3"
-              size="sm"
-              variant="ghost"
-            >
-              <Link to="/recipes">Recipes</Link>
-            </Button>
-            <Button
-              asChild
-              className="rounded-md px-3"
-              size="sm"
-              variant="ghost"
-            >
-              <Link to="/equipment">Equipment</Link>
-            </Button>
-            {showAdminNav ? (
+          <nav className="hidden items-center gap-1 sm:flex">
+            {navItems.map((navItem) => (
               <Button
+                key={navItem.to}
                 asChild
                 className="rounded-md px-3"
                 size="sm"
                 variant="ghost"
               >
-                <Link to="/admin/categories">Admin</Link>
+                <Link to={navItem.to}>{navItem.label}</Link>
               </Button>
-            ) : null}
+            ))}
           </nav>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="hidden items-center gap-2 sm:flex">
           {authAction.kind === "authenticated" ? (
             <Button
               asChild
@@ -98,6 +93,8 @@ export function AppShellHeader({
             </Button>
           )}
         </div>
+
+        <MobileNavDrawer authAction={authAction} navItems={navItems} />
       </div>
     </header>
   );

--- a/src/components/app/AppShellHeader.tsx
+++ b/src/components/app/AppShellHeader.tsx
@@ -2,8 +2,8 @@ import { Link } from "@tanstack/react-router";
 import { BookOpenText, UserRound } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
 
+import { HeaderAvatar } from "./HeaderAvatar";
 import { MobileNavDrawer } from "./MobileNavDrawer";
 
 import type { AuthActionState, HeaderNavItem } from "./AppShellHeader.types";
@@ -97,32 +97,5 @@ export function AppShellHeader({
         <MobileNavDrawer authAction={authAction} navItems={navItems} />
       </div>
     </header>
-  );
-}
-
-type HeaderAvatarProps = {
-  avatarUrl: string | null;
-  label: string;
-};
-
-function HeaderAvatar({ avatarUrl, label }: HeaderAvatarProps): JSX.Element {
-  if (avatarUrl !== null) {
-    return (
-      <img
-        alt=""
-        aria-hidden="true"
-        className="size-5 rounded-full border border-border object-cover"
-        src={avatarUrl}
-      />
-    );
-  }
-
-  return (
-    <span
-      aria-hidden="true"
-      className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-muted text-[0.65rem] font-semibold text-foreground"
-    >
-      {getProfileAvatarFallbackLabel(label)}
-    </span>
   );
 }

--- a/src/components/app/AppShellHeader.types.ts
+++ b/src/components/app/AppShellHeader.types.ts
@@ -1,0 +1,15 @@
+export type AuthActionState =
+  | {
+      kind: "authenticated";
+      avatarUrl: string | null;
+      label: string;
+    }
+  | {
+      kind: "guest" | "loading" | "unconfigured";
+      label: string;
+    };
+
+export type HeaderNavItem = {
+  label: string;
+  to: "/admin/categories" | "/equipment" | "/recipes";
+};

--- a/src/components/app/HeaderAvatar.tsx
+++ b/src/components/app/HeaderAvatar.tsx
@@ -1,0 +1,33 @@
+import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
+
+import type { JSX } from "react";
+
+type HeaderAvatarProps = {
+  avatarUrl: string | null;
+  label: string;
+};
+
+export function HeaderAvatar({
+  avatarUrl,
+  label,
+}: HeaderAvatarProps): JSX.Element {
+  if (avatarUrl !== null) {
+    return (
+      <img
+        alt=""
+        aria-hidden="true"
+        className="size-5 rounded-full border border-border object-cover"
+        src={avatarUrl}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-muted text-[0.65rem] font-semibold text-foreground"
+    >
+      {getProfileAvatarFallbackLabel(label)}
+    </span>
+  );
+}

--- a/src/components/app/MobileNavDrawer.tsx
+++ b/src/components/app/MobileNavDrawer.tsx
@@ -1,9 +1,11 @@
 import { Link } from "@tanstack/react-router";
 import { Menu, UserRound, X } from "lucide-react";
-import { useEffect, useId, useState } from "react";
+import { Dialog } from "radix-ui";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
+
+import { HeaderAvatar } from "./HeaderAvatar";
 
 import type { AuthActionState, HeaderNavItem } from "./AppShellHeader.types";
 import type { JSX } from "react";
@@ -18,82 +20,48 @@ export function MobileNavDrawer({
   navItems,
 }: MobileNavDrawerProps): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
-  const drawerId = useId();
-
-  useEffect(() => {
-    if (!isOpen) {
-      return undefined;
-    }
-
-    function handleKeyDown(event: KeyboardEvent): void {
-      if (event.key === "Escape") {
-        setIsOpen(false);
-      }
-    }
-
-    document.body.classList.add("overflow-hidden");
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.body.classList.remove("overflow-hidden");
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen]);
 
   return (
-    <div className="sm:hidden">
-      <Button
-        aria-controls={drawerId}
-        aria-expanded={isOpen}
-        aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-        className="rounded-md"
-        size="icon-sm"
-        type="button"
-        variant="outline"
-        onClick={() => {
-          setIsOpen((currentIsOpen) => !currentIsOpen);
-        }}
-      >
-        {isOpen ? <X className="size-4" /> : <Menu className="size-4" />}
-      </Button>
-
-      {isOpen ? (
-        <div aria-modal="true" className="fixed inset-0 z-40" role="dialog">
-          <button
-            aria-label="Close navigation menu"
-            className="absolute inset-0 bg-foreground/15 backdrop-blur-[2px]"
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
+      <div className="sm:hidden">
+        <Dialog.Trigger asChild>
+          <Button
+            aria-label={
+              isOpen ? "Close navigation menu" : "Open navigation menu"
+            }
+            className="rounded-md"
+            size="icon-sm"
             type="button"
-            onClick={() => {
-              setIsOpen(false);
-            }}
-          />
-
-          <div
-            className="absolute top-0 right-0 flex h-full w-[min(22rem,calc(100vw-1rem))] flex-col gap-6 border-l border-border bg-background px-4 py-4 shadow-2xl"
-            id={drawerId}
+            variant="outline"
           >
+            {isOpen ? <X className="size-4" /> : <Menu className="size-4" />}
+          </Button>
+        </Dialog.Trigger>
+
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-40 bg-foreground/15 backdrop-blur-[2px]" />
+          <Dialog.Content className="fixed top-0 right-0 z-50 flex h-full w-[min(22rem,calc(100vw-1rem))] flex-col gap-6 border-l border-border bg-background px-4 py-4 shadow-2xl outline-none">
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="font-display text-lg font-semibold text-foreground">
+                <Dialog.Title className="font-display text-lg font-semibold text-foreground">
                   Menu
-                </p>
-                <p className="text-sm text-muted-foreground">
+                </Dialog.Title>
+                <Dialog.Description className="text-sm text-muted-foreground">
                   Browse recipes and account actions.
-                </p>
+                </Dialog.Description>
               </div>
 
-              <Button
-                aria-label="Close navigation menu"
-                className="rounded-md"
-                size="icon-sm"
-                type="button"
-                variant="ghost"
-                onClick={() => {
-                  setIsOpen(false);
-                }}
-              >
-                <X className="size-4" />
-              </Button>
+              <Dialog.Close asChild>
+                <Button
+                  aria-label="Close navigation menu"
+                  className="rounded-md"
+                  size="icon-sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  <X className="size-4" />
+                </Button>
+              </Dialog.Close>
             </div>
 
             <nav className="flex flex-col gap-2">
@@ -154,36 +122,9 @@ export function MobileNavDrawer({
                 </Button>
               )}
             </div>
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-type HeaderAvatarProps = {
-  avatarUrl: string | null;
-  label: string;
-};
-
-function HeaderAvatar({ avatarUrl, label }: HeaderAvatarProps): JSX.Element {
-  if (avatarUrl !== null) {
-    return (
-      <img
-        alt=""
-        aria-hidden="true"
-        className="size-5 rounded-full border border-border object-cover"
-        src={avatarUrl}
-      />
-    );
-  }
-
-  return (
-    <span
-      aria-hidden="true"
-      className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-muted text-[0.65rem] font-semibold text-foreground"
-    >
-      {getProfileAvatarFallbackLabel(label)}
-    </span>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </div>
+    </Dialog.Root>
   );
 }

--- a/src/components/app/MobileNavDrawer.tsx
+++ b/src/components/app/MobileNavDrawer.tsx
@@ -1,0 +1,189 @@
+import { Link } from "@tanstack/react-router";
+import { Menu, UserRound, X } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { getProfileAvatarFallbackLabel } from "@/lib/profilePresentation";
+
+import type { AuthActionState, HeaderNavItem } from "./AppShellHeader.types";
+import type { JSX } from "react";
+
+type MobileNavDrawerProps = {
+  authAction: AuthActionState;
+  navItems: HeaderNavItem[];
+};
+
+export function MobileNavDrawer({
+  authAction,
+  navItems,
+}: MobileNavDrawerProps): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const drawerId = useId();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    document.body.classList.add("overflow-hidden");
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  return (
+    <div className="sm:hidden">
+      <Button
+        aria-controls={drawerId}
+        aria-expanded={isOpen}
+        aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+        className="rounded-md"
+        size="icon-sm"
+        type="button"
+        variant="outline"
+        onClick={() => {
+          setIsOpen((currentIsOpen) => !currentIsOpen);
+        }}
+      >
+        {isOpen ? <X className="size-4" /> : <Menu className="size-4" />}
+      </Button>
+
+      {isOpen ? (
+        <div aria-modal="true" className="fixed inset-0 z-40" role="dialog">
+          <button
+            aria-label="Close navigation menu"
+            className="absolute inset-0 bg-foreground/15 backdrop-blur-[2px]"
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+            }}
+          />
+
+          <div
+            className="absolute top-0 right-0 flex h-full w-[min(22rem,calc(100vw-1rem))] flex-col gap-6 border-l border-border bg-background px-4 py-4 shadow-2xl"
+            id={drawerId}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="font-display text-lg font-semibold text-foreground">
+                  Menu
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Browse recipes and account actions.
+                </p>
+              </div>
+
+              <Button
+                aria-label="Close navigation menu"
+                className="rounded-md"
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setIsOpen(false);
+                }}
+              >
+                <X className="size-4" />
+              </Button>
+            </div>
+
+            <nav className="flex flex-col gap-2">
+              {navItems.map((navItem) => (
+                <Button
+                  key={navItem.to}
+                  asChild
+                  className="h-11 justify-start rounded-lg px-4 text-base"
+                  variant="ghost"
+                >
+                  <Link
+                    to={navItem.to}
+                    onClick={() => {
+                      setIsOpen(false);
+                    }}
+                  >
+                    {navItem.label}
+                  </Link>
+                </Button>
+              ))}
+            </nav>
+
+            <div className="mt-auto border-t border-border pt-4">
+              {authAction.kind === "authenticated" ? (
+                <Button
+                  asChild
+                  className="h-11 w-full justify-start rounded-lg px-4 text-left"
+                  variant="outline"
+                >
+                  <Link
+                    to="/account"
+                    onClick={() => {
+                      setIsOpen(false);
+                    }}
+                  >
+                    <HeaderAvatar
+                      avatarUrl={authAction.avatarUrl}
+                      label={authAction.label}
+                    />
+                    <span className="truncate">{authAction.label}</span>
+                  </Link>
+                </Button>
+              ) : (
+                <Button
+                  asChild
+                  className="h-11 w-full justify-start rounded-lg px-4 text-left"
+                  variant="outline"
+                >
+                  <Link
+                    to="/account"
+                    onClick={() => {
+                      setIsOpen(false);
+                    }}
+                  >
+                    <UserRound className="size-4" />
+                    {authAction.label}
+                  </Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type HeaderAvatarProps = {
+  avatarUrl: string | null;
+  label: string;
+};
+
+function HeaderAvatar({ avatarUrl, label }: HeaderAvatarProps): JSX.Element {
+  if (avatarUrl !== null) {
+    return (
+      <img
+        alt=""
+        aria-hidden="true"
+        className="size-5 rounded-full border border-border object-cover"
+        src={avatarUrl}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-muted text-[0.65rem] font-semibold text-foreground"
+    >
+      {getProfileAvatarFallbackLabel(label)}
+    </span>
+  );
+}

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -1,4 +1,5 @@
 export { AppToasterProvider } from "./AppToaster";
 export { AppShellHeader } from "./AppShellHeader";
-export type { AuthActionState } from "./AppShellHeader";
+export { MobileNavDrawer } from "./MobileNavDrawer";
+export type { AuthActionState, HeaderNavItem } from "./AppShellHeader.types";
 export { ProtectedRouteAuthGate } from "./ProtectedRouteAuthGate";


### PR DESCRIPTION
# Pull Request

## Summary

Add a mobile-only hamburger menu and slide-out drawer to the app shell header so navigation no longer feels cramped at narrow widths.

Closes #175.

## Changes

- hide the desktop nav and account action on small screens
- add a mobile drawer with navigation links and the account action
- keep shared header nav item and auth action types in a dedicated app-level module

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [ ] Relevant tests were run when available
- [ ] Manual verification was performed when needed

Validation notes:

- `npm run lint`
- `npm run build`
- No targeted automated tests exist for the app shell header in this template.

## Data and Security Impact

- [x] No schema change
- [ ] Schema/migration change included
- [x] No auth or permission impact
- [x] Auth, permission, or data exposure impact reviewed

Notes:

- The change is limited to client-side header presentation and navigation affordances.

## Documentation

- [x] No doc updates needed
- [ ] README updated
- [ ] AGENTS updated
- [ ] Other docs updated

## Reviewer Notes

- Manual mobile-width verification is still useful for spacing and interaction polish across theme presets.
