### PR TITLE
fix(recipes): unify recipe filter bar layout

### DIFF
--- a/src/features/recipes/components/RecipeShelfFilters.tsx
+++ b/src/features/recipes/components/RecipeShelfFilters.tsx
@@ -53,114 +53,116 @@ export function RecipeShelfFilters({
   });
 
   return (
-    <section className="flex flex-col gap-4 border-t border-border pt-4 xl:flex-row xl:items-start xl:justify-between">
-      <div className="w-full max-w-xl space-y-2">
-        <details>
-          <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border px-3 py-2 text-sm text-foreground transition hover:bg-muted/40">
-            <span className="font-medium">Categories</span>
-            <span className="text-muted-foreground">
-              {selectedCategorySlugs.length === 0
-                ? "All categories"
-                : `${selectedCategorySlugs.length} selected`}
-            </span>
-          </summary>
-          <div className="mt-2 flex flex-wrap gap-2 rounded-md border border-border bg-background p-3">
-            {availableCategories.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No categories are available yet.
+    <section className="border-t border-border pt-4">
+      <div className="grid gap-4 rounded-xl border border-border/70 bg-card/70 p-4 shadow-sm xl:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] xl:items-start">
+        <div className="min-w-0 space-y-2">
+          <details>
+            <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border bg-background/80 px-3 py-2 text-sm text-foreground transition hover:bg-muted/40">
+              <span className="font-medium">Categories</span>
+              <span className="text-muted-foreground">
+                {selectedCategorySlugs.length === 0
+                  ? "All categories"
+                  : `${selectedCategorySlugs.length} selected`}
+              </span>
+            </summary>
+            <div className="mt-2 flex flex-wrap gap-2 rounded-md border border-border bg-background p-3">
+              {availableCategories.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No categories are available yet.
+                </p>
+              ) : (
+                availableCategories.map((category) => {
+                  const isSelected = selectedCategorySlugs.includes(
+                    category.slug,
+                  );
+
+                  return (
+                    <label
+                      key={category.id}
+                      className={
+                        isSelected
+                          ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-primary bg-primary/10 px-3 py-2 text-sm text-foreground"
+                          : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-2 text-sm text-foreground"
+                      }
+                    >
+                      <input
+                        checked={isSelected}
+                        className="size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20"
+                        onChange={() => {
+                          onCategoryToggle(category.slug);
+                        }}
+                        type="checkbox"
+                      />
+                      {category.name}
+                    </label>
+                  );
+                })
+              )}
+            </div>
+          </details>
+          {selectedCategories.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-2">
+              <p className="px-1 text-xs font-medium text-muted-foreground">
+                Active
               </p>
-            ) : (
-              availableCategories.map((category) => {
-                const isSelected = selectedCategorySlugs.includes(
-                  category.slug,
-                );
-
-                return (
-                  <label
-                    key={category.id}
-                    className={
-                      isSelected
-                        ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-primary bg-primary/10 px-3 py-2 text-sm text-foreground"
-                        : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-2 text-sm text-foreground"
-                    }
-                  >
-                    <input
-                      checked={isSelected}
-                      className="size-4 rounded border border-input text-primary shadow-sm focus:ring-2 focus:ring-primary/20"
-                      onChange={() => {
-                        onCategoryToggle(category.slug);
-                      }}
-                      type="checkbox"
-                    />
-                    {category.name}
-                  </label>
-                );
-              })
-            )}
-          </div>
-        </details>
-        {selectedCategories.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-2">
-            <p className="px-1 text-xs font-medium text-muted-foreground">
-              Active
-            </p>
-            {selectedCategories.map((category) => (
-              <button
-                aria-label={`Remove ${category.name} filter`}
-                className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-1 text-xs font-medium text-foreground transition hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                key={category.slug}
-                onClick={() => {
-                  onCategoryToggle(category.slug);
-                }}
-                type="button"
-              >
-                <span>{category.name}</span>
-                <span aria-hidden className="text-muted-foreground">
-                  ×
-                </span>
-              </button>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      <div className="w-full max-w-xl space-y-3">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-sm font-medium text-foreground">Total time</p>
-          </div>
-          {hasActiveFilters ? (
-            <button
-              className="text-sm font-medium text-primary transition hover:underline"
-              onClick={onClearFilters}
-              type="button"
-            >
-              Clear filters
-            </button>
+              {selectedCategories.map((category) => (
+                <button
+                  aria-label={`Remove ${category.name} filter`}
+                  className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-1 text-xs font-medium text-foreground transition hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  key={category.slug}
+                  onClick={() => {
+                    onCategoryToggle(category.slug);
+                  }}
+                  type="button"
+                >
+                  <span>{category.name}</span>
+                  <span aria-hidden className="text-muted-foreground">
+                    ×
+                  </span>
+                </button>
+              ))}
+            </div>
           ) : null}
         </div>
 
-        <div className="flex flex-col gap-3 rounded-md border border-border px-3 py-3 sm:flex-row sm:items-center sm:gap-4">
-          <div className="shrink-0 text-sm text-muted-foreground">
-            {formatTotalTimeRangeLabel(rangeValue, maxSliderValue)}
+        <div className="min-w-0 space-y-3 rounded-lg border border-border bg-background/80 px-3 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium text-foreground">Total time</p>
+            </div>
+            {hasActiveFilters ? (
+              <button
+                className="text-sm font-medium text-primary transition hover:underline"
+                onClick={onClearFilters}
+                type="button"
+              >
+                Clear filters
+              </button>
+            ) : null}
           </div>
-          <div className="min-w-0 flex-1">
-            <RangeSlider
-              max={maxSliderValue}
-              min={0}
-              onValueChange={(nextRange) => {
-                const [nextMin, nextMax] = normalizeSliderRange(
-                  nextRange,
-                  maxSliderValue,
-                );
-                onMinTotalMinutesChange(nextMin <= 0 ? null : nextMin);
-                onMaxTotalMinutesChange(
-                  nextMax >= maxSliderValue ? null : nextMax,
-                );
-              }}
-              step={5}
-              value={rangeValue}
-            />
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <div className="shrink-0 text-sm text-muted-foreground">
+              {formatTotalTimeRangeLabel(rangeValue, maxSliderValue)}
+            </div>
+            <div className="min-w-0 flex-1">
+              <RangeSlider
+                max={maxSliderValue}
+                min={0}
+                onValueChange={(nextRange) => {
+                  const [nextMin, nextMax] = normalizeSliderRange(
+                    nextRange,
+                    maxSliderValue,
+                  );
+                  onMinTotalMinutesChange(nextMin <= 0 ? null : nextMin);
+                  onMaxTotalMinutesChange(
+                    nextMax >= maxSliderValue ? null : nextMax,
+                  );
+                }}
+                step={5}
+                value={rangeValue}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/recipes/components/RecipeShelfFilters.tsx
+++ b/src/features/recipes/components/RecipeShelfFilters.tsx
@@ -57,7 +57,7 @@ export function RecipeShelfFilters({
       <div className="grid gap-4 rounded-xl border border-border/70 bg-card/70 p-4 shadow-sm xl:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] xl:items-start">
         <div className="min-w-0 space-y-2">
           <details>
-            <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border bg-background/80 px-3 py-2 text-sm text-foreground transition hover:bg-muted/40">
+            <summary className="flex cursor-pointer list-none items-center gap-3 rounded-md border border-border bg-background/80 px-3 py-2 text-sm text-foreground transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
               <span className="font-medium">Categories</span>
               <span className="text-muted-foreground">
                 {selectedCategorySlugs.length === 0


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #176 by turning the recipe shelf filters into a single cohesive filter bar and removing the narrow width caps that made the category picker and total-time slider feel detached.

## Changes

- wrap the category and total-time controls in one shared filter container
- remove the per-control `max-w-xl` constraints that caused narrow stacked layouts
- keep existing filter behavior while tightening the desktop and mid-width presentation

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] Relevant tests were run when available
- [x] Manual verification was performed when needed

Validation notes:

- Ran `npm run lint`
- Ran `npm run build`
- Manually reviewed the filter layout change in `src/features/recipes/components/RecipeShelfFilters.tsx` to confirm the controls now read as one filter surface and the slider remains full-width within its section

## Data and Security Impact

- [x] No schema change
- [ ] Schema/migration change included
- [x] No auth or permission impact
- [x] Auth, permission, or data exposure impact reviewed

Notes:

- Frontend-only layout adjustment. No schema, RLS, secret, or privileged behavior changes.

## Documentation

- [x] No doc updates needed
- [ ] README updated
- [ ] AGENTS updated
- [ ] Other docs updated

## Reviewer Notes

- UI-only change focused on the recipes shelf filter bar. The main tradeoff is slightly stronger container styling so the two controls read as a unified filter area.
