### PR TITLE
fix(recipes): tighten page header layout

### DIFF
--- a/src/features/recipes/components/RecipesPageHeader.tsx
+++ b/src/features/recipes/components/RecipesPageHeader.tsx
@@ -34,14 +34,14 @@ export function RecipesPageHeader({
 }: RecipesPageHeaderProps): JSX.Element {
   return (
     <section className="space-y-4 border-b border-border pb-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center">
         <div className="min-w-0">
           <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
             Recipes
           </h1>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 sm:shrink-0">
           <Button asChild className="rounded-md px-4" size="lg">
             <Link to="/recipes/new">New recipe</Link>
           </Button>


### PR DESCRIPTION
# Pull Request

## Summary

Tightens the Recipes page header so the heading and the "New recipe" action stay visually grouped on wide screens instead of drifting to opposite edges.

## Changes

- Remove wide-screen `justify-between` spacing from `RecipesPageHeader` so the title and CTA remain adjacent
- Allow the header row to wrap when needed while keeping the button from shrinking awkwardly
- Closes #177

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] Relevant tests were run when available
- [x] Manual verification was performed when needed

Validation notes:

- Ran `npm run lint`
- Ran `npm run build`
- Ran `npm test`
- Reviewed the header layout change in `src/features/recipes/components/RecipesPageHeader.tsx` for wide-screen behavior and confirmed no auth, routing, or data-access behavior changed

## Data and Security Impact

- [x] No schema change
- [ ] Schema/migration change included
- [x] No auth or permission impact
- [x] Auth, permission, or data exposure impact reviewed

Notes:

- UI-only layout adjustment; no Supabase, auth, env var, or secret handling changes

## Documentation

- [x] No doc updates needed
- [ ] README updated
- [ ] AGENTS updated
- [ ] Other docs updated

## Reviewer Notes

- The fix is intentionally narrow and limited to header flex behavior on the recipes list page
