### PR TITLE
fix(recipes): improve mobile metadata pills

### DIFF
--- a/src/features/recipes/components/RecipePreviewCard.tsx
+++ b/src/features/recipes/components/RecipePreviewCard.tsx
@@ -106,11 +106,11 @@ export function RecipePreviewCard({
           </div>
         ) : null}
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2.5">
           {metadata.map((item) => (
             <span
               key={item}
-              className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground"
+              className="inline-flex min-h-8 items-center rounded-full border border-border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground sm:min-h-0 sm:px-2.5 sm:py-1 sm:text-xs"
             >
               {item}
             </span>


### PR DESCRIPTION
# Pull Request

## Summary

Improve the recipe preview card metadata pills on mobile so they are easier to scan and feel less cramped.
Closes #178.

## Changes

- increase mobile metadata pill padding, height, and type size in `RecipePreviewCard`
- add slightly more gap between metadata pills while preserving the existing desktop sizing

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] Relevant tests were run when available
- [ ] Manual verification was performed when needed

Validation notes:

- `npm run lint`
- `npm run build`
- `npm test`

## Data and Security Impact

- [x] No schema change
- [ ] Schema/migration change included
- [x] No auth or permission impact
- [x] Auth, permission, or data exposure impact reviewed

Notes:

- UI-only styling change in the browser app. No data access, auth, or Supabase behavior changed.

## Documentation

- [x] No doc updates needed
- [ ] README updated
- [ ] AGENTS updated
- [ ] Other docs updated

## Reviewer Notes

- Manual visual verification on a 375px viewport would be the most direct confirmation of spacing and readability.
